### PR TITLE
Fix enforcement of execution duration

### DIFF
--- a/crates/base/src/js_worker.rs
+++ b/crates/base/src/js_worker.rs
@@ -387,7 +387,8 @@ impl UserWorker {
             let future = async move {
                 tokio::select! {
                     _ = tokio::time::sleep(Duration::from_millis(worker_timeout_ms)) => {
-                        debug!("max duration reached for the worker. terminating the worker. (duration {})", human_elapsed(worker_timeout_ms))
+                        error!("max duration reached for the worker. terminating the worker. (duration {})", human_elapsed(worker_timeout_ms));
+                        thread_safe_handle.terminate_execution();
                     }
                     Some(val) = memory_limit_rx.recv() => {
                         error!("memory limit reached for the worker. terminating the worker. (used: {})", bytes_to_display(val));


### PR DESCRIPTION
I noticed that requests might hang forever despite the timeout feature being in place.

This problem (and the fix) can be reproduced with a main worker with a `workerTimeoutMs` of e.g. 3000 and the following user worker:

```ts
import { serve } from "https://deno.land/std@0.131.0/http/server.ts";

serve((_req) => {
  while (true) {}

  return new Response("Hello");
});
```
