### PR TITLE
doc: Fix README script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ curl --request POST 'http://localhost:9000/hello-world' \
 
 To run with a different entry point, you can pass a different main service like below
 ```sh
-./run.sh start --main-service /path/to/main-service-directory -p 9000
+./scripts/run.sh start --main-service /path/to/main-service-directory -p 9000
 ```
 
 using Docker:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc Update.

The README command was pointing to a non-existent file.
Considering the above command uses the full path, this one should too.

## What is the current behavior?

The command cannot be copied and pasted and run.

## What is the new behavior?

The command points to the correct file.

## Additional context

This command still doesn't work, actually. The parameters cannot
be expressed multiple times, and they don't override correctly. The
`run.sh` script is a little too basic to capture the nuance of what should
happen.

I (well, ChatGPT) wrote a more advanced version if you want, but it might be a little
too much:

```bash
#!/usr/bin/env bash

set -e

# Default values
MAIN_SERVICE="./examples/main"
PORT=9000

cargo build

# Parse command line arguments
while [[ $# -gt 0 ]]
do
    key="$1"

    case $key in
        --main-service)
        MAIN_SERVICE="$2"
        shift # past argument
        shift # past value
        ;;
        -p|--port)
        PORT="$2"
        shift # past argument
        shift # past value
        ;;
        *)
        shift # unknown option
        ;;
    esac
done

# Call the executable with the specified or default flags
RUST_LOG=debug RUST_BACKTRACE=full ./target/debug/edge-runtime start --main-service "${MAIN_SERVICE}" -p "${PORT}"
```