### PR TITLE
fix: enable performance API

### DIFF
--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -26,7 +26,7 @@ import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
 import { SUPABASE_ENV } from "ext:sb_env/env.js";
 import { loadUserRuntime } from "ext:sb_core_main_js/js/user_runtime_loader.js"
 import * as permissions from "ext:sb_core_main_js/js/permissions.js";
-
+import * as performance from "ext:deno_web/15_performance.js";
 
 const core = globalThis.Deno.core;
 const ops = core.ops;
@@ -191,6 +191,13 @@ const globalScope = {
 
   // web sockets
   WebSocket: nonEnumerable(webSocket.WebSocket),
+
+  // performance
+  Performance: nonEnumerable(performance.Performance),
+  PerformanceEntry: nonEnumerable(performance.PerformanceEntry),
+  PerformanceMark: nonEnumerable(performance.PerformanceMark),
+  PerformanceMeasure: nonEnumerable(performance.PerformanceMeasure),
+  performance: writable(performance.performance),
 }
 
 const pendingRejections = [];

--- a/crates/sb_core/permissions.rs
+++ b/crates/sb_core/permissions.rs
@@ -42,7 +42,7 @@ deno_core::extension!(
 
 impl deno_web::TimersPermission for Permissions {
     fn allow_hrtime(&mut self) -> bool {
-        true
+        false
     }
 
     fn check_unstable(&self, _state: &deno_core::OpState, _api_name: &'static str) {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR enables the use of Performance API (https://developer.mozilla.org/en-US/docs/Web/API/Performance). We disable the use high-res time to protect against timing attacks and fingerprinting (https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#security_requirements).
