### PR TITLE
Add integration tests for workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "deno_web",
  "deno_webidl",
  "deno_websocket",
+ "futures-util",
  "http",
  "httparse",
  "hyper",

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -38,6 +38,9 @@ sb_env = { version = "0.1.0", path = "../sb_env" }
 sb_core = { version = "0.1.0", path = "../sb_core" }
 uuid.workspace = true
 
+[dev-dependencies]
+futures-util = { version = "0.3.28" }
+
 [build-dependencies]
 anyhow = { workspace = true }
 bytes = { version = "1.2.1" }

--- a/crates/base/src/edge_runtime.rs
+++ b/crates/base/src/edge_runtime.rs
@@ -363,7 +363,6 @@ impl EdgeRuntime {
 
 #[cfg(test)]
 mod test {
-    use crate::commands::start_server;
     use crate::edge_runtime::{EdgeCallResult, EdgeRuntime};
     use sb_worker_context::essentials::{
         EdgeContextInitOpts, EdgeContextOpts, EdgeMainRuntimeOpts, EdgeUserRuntimeOpts,
@@ -568,39 +567,5 @@ mod test {
         let (_tx, unix_stream_rx) = create_user_rt_params_to_run();
         let data = user_rt.run(unix_stream_rx).await.unwrap();
         assert_eq!(data, EdgeCallResult::HeapLimitReached);
-    }
-
-    #[tokio::test]
-    async fn test_oak_60_issue() {
-        let main_rt_simulation = async {
-            let _server = start_server(
-                "0.0.0.0",
-                9000,
-                String::from("./test_cases/main"),
-                None,
-                false,
-            )
-            .await;
-        };
-
-        let oak_req = async {
-            tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await; // Warm up time
-            let resp: String = reqwest::get("http://localhost:9000/oak")
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap();
-            resp
-        };
-
-        tokio::select! {
-            _ = main_rt_simulation => {
-                panic!("This shouldn't end first");
-            }
-            res = oak_req => {
-                assert_eq!(res, "This is an example Oak server running on Edge Functions!");
-            }
-        };
     }
 }

--- a/crates/base/test_cases/oak/index.ts
+++ b/crates/base/test_cases/oak/index.ts
@@ -1,9 +1,16 @@
-import { Application, Router } from 'https://deno.land/x/oak@v12.2.0/mod.ts'
-const router = new Router()
+import { Application, Router } from 'https://deno.land/x/oak@v12.3.0/mod.ts'
+
+const MB = 1024 * 1024;
+const controller = new AbortController();
+
+const router = new Router();
 router
     // Note: path will be prefixed with function name
     .get('/oak', (context) => {
         context.response.body = 'This is an example Oak server running on Edge Functions!'
+
+        // tests panic unless we close the server after a request
+        controller.abort();
     })
     .post('/oak/greet', async (context) => {
         // Note: request body will be streamed to the function as chunks, set limit to 0 to fully read it.
@@ -16,9 +23,33 @@ router
     .get('/oak/redirect', (context) => {
         context.response.redirect('https://www.example.com')
     })
+    .post('/file-upload', async (ctx) => {
+      try {
+        const body = ctx.request.body({ type: 'form-data' });
+        const formData = await body.value.read({
+          // Need to set the maxSize so files will be stored in memory.
+          // This is necessary as Edge Functions don't have disk write access.
+          // We are setting the max size as 10MB (an Edge Function has a max memory limit of 150MB)
+          // For more config options, check: https://deno.land/x/oak@v11.1.0/mod.ts?s=FormDataReadOptions
+          maxSize: 1 * MB,
+        });
+        const file = formData.files[0];
+
+        ctx.response.status = 201
+        ctx.response.body = `file-type: ${file.contentType}`
+      } catch (e) {
+        console.log("error occurred");
+        console.log(e)
+        ctx.response.status = 500
+        ctx.response.body = 'Error!'
+      }
+      // tests panic unless we close the server after a request
+      controller.abort();
+    })
 
 const app = new Application()
 app.use(router.routes())
 app.use(router.allowedMethods())
 
-await app.listen({ port: 8000 })
+const { signal } = controller;
+await app.listen({ port: 8000, signal })

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -1,0 +1,77 @@
+use base::worker_ctx::{create_worker, WorkerRequestMsg};
+use hyper::{Body, Request, Response};
+use sb_worker_context::essentials::{EdgeContextInitOpts, EdgeContextOpts, EdgeUserRuntimeOpts};
+use std::collections::HashMap;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+async fn test_oak_server() {
+    let user_rt_opts = EdgeUserRuntimeOpts::default();
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/oak".into(),
+        no_module_cache: false,
+        import_map_path: None,
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::UserWorker(user_rt_opts),
+    };
+    let worker_req_tx = create_worker(opts).await.unwrap();
+    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
+
+    let req = Request::builder()
+        .uri("/oak")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let msg = WorkerRequestMsg { req, res_tx };
+    let _ = worker_req_tx.send(msg);
+
+    let res = res_rx.await.unwrap().unwrap();
+    assert!(res.status().as_u16() == 200);
+
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+    assert_eq!(
+        body_bytes,
+        "This is an example Oak server running on Edge Functions!"
+    );
+}
+
+#[tokio::test]
+async fn test_file_upload() {
+    let user_rt_opts = EdgeUserRuntimeOpts::default();
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/oak".into(),
+        no_module_cache: false,
+        import_map_path: None,
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::UserWorker(user_rt_opts),
+    };
+    let worker_req_tx = create_worker(opts).await.unwrap();
+    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
+
+    let body_chunk = "--TEST\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\ntestuser\r\n--TEST--\r\n";
+
+    let content_length = &body_chunk.len();
+    let chunks: Vec<Result<_, std::io::Error>> = vec![Ok(body_chunk)];
+    let stream = futures_util::stream::iter(chunks);
+    let body = Body::wrap_stream(stream);
+
+    let req = Request::builder()
+        .uri("/file-upload")
+        .method("POST")
+        .header("Content-Type", "multipart/form-data; boundary=TEST")
+        .header("Content-Length", content_length.to_string())
+        .body(body)
+        .unwrap();
+
+    let msg = WorkerRequestMsg { req, res_tx };
+    let _ = worker_req_tx.send(msg);
+
+    let res = res_rx.await.unwrap().unwrap();
+    assert!(res.status().as_u16() == 201);
+
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+    assert_eq!(body_bytes, "file-type: text/plain");
+}

--- a/examples/file-upload/index.ts
+++ b/examples/file-upload/index.ts
@@ -1,4 +1,4 @@
-import { Application, Router } from 'https://deno.land/x/oak/mod.ts'
+import { Application, Router } from 'https://deno.land/x/oak@v12.3.0/mod.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const MB = 1024 * 1024

--- a/examples/oak/index.ts
+++ b/examples/oak/index.ts
@@ -1,4 +1,4 @@
-import { Application, Router } from 'https://deno.land/x/oak@v12.2.0/mod.ts'
+import { Application, Router } from 'https://deno.land/x/oak@v12.3.0/mod.ts'
 const router = new Router()
 router
   // Note: path will be prefixed with function name

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
- cargo build && RUST_LOG=debug RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start --main-service ./examples/main
+ cargo build && RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start --main-service ./examples/main


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds integration tests for user workers (oak server and file uploads). 

Along with the integration tests, I fixed couple of missing properties from the global scope - `DOMException` and `Deno.errors`.