### PR TITLE
Handle worker boot errors

### DIFF
--- a/crates/base/src/edge_runtime.rs
+++ b/crates/base/src/edge_runtime.rs
@@ -39,9 +39,9 @@ use sb_workers::sb_user_workers;
 fn load_import_map(maybe_path: Option<String>) -> Result<Option<ImportMap>, Error> {
     if let Some(path_str) = maybe_path {
         let path = Path::new(&path_str);
-        let json_str = fs::read_to_string(path)?;
-
         let abs_path = std::env::current_dir().map(|p| p.join(path))?;
+
+        let json_str = fs::read_to_string(abs_path.clone())?;
         let base_url = Url::from_directory_path(abs_path.parent().unwrap()).unwrap();
         let result = parse_from_json(&base_url, json_str.as_str())?;
         print_import_map_diagnostics(&result.diagnostics);

--- a/crates/base/src/edge_runtime.rs
+++ b/crates/base/src/edge_runtime.rs
@@ -340,7 +340,7 @@ impl EdgeRuntime {
             if let Some(k) = key {
                 if let Some(tx) = pool_msg_tx {
                     if tx.send(UserWorkerMsgs::Shutdown(k)).is_err() {
-                        error!("failed to send the halt execution signal");
+                        error!("failed to send the shutdown signal to user worker pool");
                     }
                 }
             };

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -84,6 +84,25 @@ async fn test_main_worker_post_request() {
     assert_eq!(body_bytes, "{\"message\":\"Hello bar from foo!\"}");
 }
 
+#[tokio::test]
+async fn test_main_worker_boot_error() {
+    // create a user worker pool
+    let user_worker_msgs_tx = create_user_worker_pool().await.unwrap();
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/main".into(),
+        no_module_cache: false,
+        import_map_path: Some("./non-existing-import-map.json".to_string()),
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::MainWorker(EdgeMainRuntimeOpts {
+            worker_pool_tx: user_worker_msgs_tx,
+        }),
+    };
+    let result = create_worker(opts).await;
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "worker boot error");
+}
+
 //#[tokio::test]
 //async fn test_main_worker_post_request_with_transfer_encoding() {
 //    // create a user worker pool


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR handles user worker boot errors (eg: import map provided for worker is invalid). 

Handles part of scenarios that can cause #44 (there are some other scenarios not handled by this PR) 
