### PR TITLE
fix: install LLVM deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 FROM rust:1.68.2-bullseye as builder
 ARG TARGETPLATFORM
+RUN apt-get update && apt-get install -y llvm-dev libclang-dev clang
 WORKDIR /usr/src/edge-runtime
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETPLATFORM} \
     cargo install cargo-strip


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently the docker builds fails because of missing rust bindgen dependencies. This PR addresses it.