### PR TITLE
get version from cargo using clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim 0.10.0",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 base = { path = "../base" }
-clap = "4.0.29"
+clap = { version = "4.0.29", features = ["cargo"] }
 env_logger = "0.10.0"
 log = { workspace = true }
 tokio.workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,11 +3,11 @@ mod logger;
 use anyhow::Error;
 use base::commands::start_server;
 use clap::builder::FalseyValueParser;
-use clap::{arg, value_parser, ArgAction, Command};
+use clap::{arg, crate_version, value_parser, ArgAction, Command};
 fn cli() -> Command {
     Command::new("edge-runtime")
         .about("A server based on Deno runtime, capable of running JavaScript, TypeScript, and WASM services")
-        .version("0.0.1") // TODO: set version on compile time
+        .version(crate_version!())
         .arg_required_else_help(true)
         .arg(
             arg!(-v --verbose "Use verbose output")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a todo.

## What is the current behavior?

`edge-runtime --version` returns a hard-coded value.

## What is the new behavior?

`edge-runtime --version` returns the crate version that was set at compile time.

## Additional context

Note was `// TODO: set version on compile time`.
