### PR TITLE
feat: add support for providing import map as a data URI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "serde",
  "tokio",
  "url",
+ "urlencoding",
  "v8 0.60.1",
 ]
 
@@ -4707,6 +4708,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "urlpattern"

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -39,6 +39,7 @@ sb_worker_context = { version = "0.1.0", path = "../sb_worker_context" }
 sb_workers = { version = "0.1.0", path = "../sb_workers" }
 sb_env = { version = "0.1.0", path = "../sb_env" }
 sb_core = { version = "0.1.0", path = "../sb_core" }
+urlencoding = { version = "2.1.2" }
 
 [dev-dependencies]
 futures-util = { version = "0.3.28" }

--- a/crates/base/test_cases/with_import_map/bar/index.ts
+++ b/crates/base/test_cases/with_import_map/bar/index.ts
@@ -1,0 +1,3 @@
+const bar = "bar";
+
+export default bar;

--- a/crates/base/test_cases/with_import_map/import_map.json
+++ b/crates/base/test_cases/with_import_map/import_map.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "std/": "https://deno.land/std@0.131.0/",
+    "foo/": "./bar/"
+  }
+}

--- a/crates/base/test_cases/with_import_map/index.ts
+++ b/crates/base/test_cases/with_import_map/index.ts
@@ -1,0 +1,11 @@
+import { serve } from "std/http/server.ts";
+import foo from "foo/index.ts";
+
+console.log(foo);
+
+serve(async (req: Request) => {
+  return new Response(
+    JSON.stringify({ message: "ok" }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+});

--- a/crates/base/tests/import_map_tests.rs
+++ b/crates/base/tests/import_map_tests.rs
@@ -1,0 +1,85 @@
+use hyper::{Body, Request, Response};
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::sync::oneshot;
+use urlencoding::encode;
+
+use base::worker_ctx::{create_worker, WorkerRequestMsg};
+use sb_worker_context::essentials::{EdgeContextInitOpts, EdgeContextOpts, EdgeUserRuntimeOpts};
+
+#[tokio::test]
+async fn test_import_map_file_path() {
+    let user_rt_opts = EdgeUserRuntimeOpts::default();
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/with_import_map".into(),
+        no_module_cache: false,
+        import_map_path: Some("./test_cases/with_import_map/import_map.json".to_string()),
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::UserWorker(user_rt_opts),
+    };
+    let worker_req_tx = create_worker(opts).await.unwrap();
+    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
+
+    let req = Request::builder()
+        .uri("/")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let msg = WorkerRequestMsg { req, res_tx };
+    let _ = worker_req_tx.send(msg);
+
+    let res = res_rx.await.unwrap().unwrap();
+    assert!(res.status().as_u16() == 200);
+
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+    assert_eq!(body_bytes, r#"{"message":"ok"}"#);
+}
+
+#[tokio::test]
+async fn test_import_map_inline() {
+    let user_rt_opts = EdgeUserRuntimeOpts::default();
+    let inline_import_map = format!(
+        "data:{}?{}",
+        encode(
+            r#"{
+        "imports": {
+            "std/": "https://deno.land/std@0.131.0/",
+            "foo/": "./bar/"
+        }
+    }"#
+        ),
+        encode(
+            Path::new(&std::env::current_dir().unwrap())
+                .join("./test_cases/with_import_map")
+                .to_str()
+                .unwrap()
+        )
+    );
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/with_import_map".into(),
+        no_module_cache: false,
+        import_map_path: Some(inline_import_map),
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::UserWorker(user_rt_opts),
+    };
+    let worker_req_tx = create_worker(opts).await.unwrap();
+    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
+
+    let req = Request::builder()
+        .uri("/")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let msg = WorkerRequestMsg { req, res_tx };
+    let _ = worker_req_tx.send(msg);
+
+    let res = res_rx.await.unwrap().unwrap();
+    assert!(res.status().as_u16() == 200);
+
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+    assert_eq!(body_bytes, r#"{"message":"ok"}"#);
+}

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -23,6 +23,14 @@ serve(async (req: Request) => {
     const memoryLimitMb = 150;
     const workerTimeoutMs = 1 * 60 * 1000;
     const noModuleCache = false;
+    // you can provide an import map inline
+    // const inlineImportMap = {
+    //   imports: {
+    //     "std/": "https://deno.land/std@0.131.0/",
+    //     "cors": "./examples/_shared/cors.ts"
+    //   }
+    // }
+    // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
     const importMapPath = null;
     const envVarsObj = Deno.env.toObject();
     const envVars = Object.keys(envVarsObj).map(k => [k, envVarsObj[k]]);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the option to provide an import_map_path to a user worker as a data URI.
