### PR TITLE
fix: move main module load to worker boot phase

### DIFF
--- a/crates/base/test_cases/invalid_imports/index.ts
+++ b/crates/base/test_cases/invalid_imports/index.ts
@@ -1,0 +1,20 @@
+import * from "https://deno.land/std@0.131.0/http/server.ts"
+
+interface reqPayload {
+  name: string;
+}
+
+console.log('server started modified');
+
+serve(async (req: Request) => {
+  const { name } : reqPayload = await req.json();
+  const data = {
+    message: `Hello ${name} from foo!`,
+    test: 'foo'
+  }
+
+  return new Response(
+    JSON.stringify(data),
+    { headers: { "Content-Type": "application/json", "Connection": "keep-alive" } },
+  )
+}, { port: 9005 })

--- a/crates/base/tests/worker_boot_tests.rs
+++ b/crates/base/tests/worker_boot_tests.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use base::worker_ctx::create_worker;
+use sb_worker_context::essentials::{EdgeContextInitOpts, EdgeContextOpts, EdgeUserRuntimeOpts};
+
+#[tokio::test]
+async fn test_worker_boot_invalid_imports() {
+    let user_rt_opts = EdgeUserRuntimeOpts::default();
+    let opts = EdgeContextInitOpts {
+        service_path: "./test_cases/invalid_imports".into(),
+        no_module_cache: false,
+        import_map_path: None,
+        env_vars: HashMap::new(),
+        conf: EdgeContextOpts::UserWorker(user_rt_opts),
+    };
+    let result = create_worker(opts).await;
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "worker boot error");
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Catch any module loading issues in boot phase by moving `load_main_module` to `worker::new`.