### PR TITLE
fix: show more descriptive error when module not found

### DIFF
--- a/crates/base/src/js_worker/module_loader.rs
+++ b/crates/base/src/js_worker/module_loader.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Error};
+use anyhow::{anyhow, bail, Error};
 use deno_ast::EmitOptions;
 use deno_ast::MediaType;
 use deno_core::error::AnyError;
@@ -139,7 +139,16 @@ impl ModuleLoader for DefaultModuleLoader {
             .finish();
 
         async move {
-            let fetched_file = file_fetcher.fetch(&module_specifier, permissions).await?;
+            let fetched_file = file_fetcher
+                .fetch(&module_specifier, permissions)
+                .await
+                .map_err(|err| {
+                    anyhow!(
+                        "Failed to load module: {:?} - {:?}",
+                        module_specifier.as_str(),
+                        err
+                    )
+                })?;
             let module_type = get_module_type(fetched_file.media_type)?;
 
             let code = fetched_file.source;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #126 - Show a descriptive error message including the name of failed import.