### PR TITLE
Add metadata to events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "tokio",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -41,6 +41,7 @@ sb_env = { version = "0.1.0", path = "../sb_env" }
 sb_core = { version = "0.1.0", path = "../sb_core" }
 sb_os = { version = "0.1.0", path = "../sb_os" }
 urlencoding = { version = "2.1.2" }
+uuid = { workspace = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3.28" }

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -94,7 +94,7 @@ impl Server {
     ) -> Result<Self, Error> {
         let mut worker_event_sender: Option<mpsc::UnboundedSender<WorkerEvents>> = None;
 
-        // Creates Event Worker
+        // Create Event Worker
         if let Some(events_service_path) = maybe_events_service_path {
             let events_path = Path::new(&events_service_path);
             let events_path_buf = events_path.to_path_buf();
@@ -107,7 +107,7 @@ impl Server {
             worker_event_sender = Some(event_worker);
         }
 
-        // create a user worker pool
+        // Create a user worker pool
         let user_worker_msgs_tx = create_user_worker_pool(worker_event_sender).await?;
 
         // create main worker

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -1,5 +1,5 @@
 use crate::worker_ctx::{
-    create_event_worker, create_user_worker_pool, create_worker, WorkerRequestMsg,
+    create_events_worker, create_user_worker_pool, create_worker, WorkerRequestMsg,
 };
 use anyhow::Error;
 use hyper::{server::conn::Http, service::Service, Body, Request, Response};
@@ -7,7 +7,7 @@ use log::{debug, error, info};
 use sb_worker_context::essentials::{
     MainWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
 };
-use sb_worker_context::events::WorkerEvents;
+use sb_worker_context::events::WorkerEventWithMetadata;
 use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
@@ -92,38 +92,36 @@ impl Server {
         no_module_cache: bool,
         callback_tx: Option<Sender<ServerCodes>>,
     ) -> Result<Self, Error> {
-        let mut worker_event_sender: Option<mpsc::UnboundedSender<WorkerEvents>> = None;
+        let mut worker_events_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>> = None;
 
         // Create Event Worker
         if let Some(events_service_path) = maybe_events_service_path {
             let events_path = Path::new(&events_service_path);
             let events_path_buf = events_path.to_path_buf();
 
-            let event_worker =
-                create_event_worker(events_path_buf, import_map_path.clone(), no_module_cache)
+            let events_worker =
+                create_events_worker(events_path_buf, import_map_path.clone(), no_module_cache)
                     .await
                     .expect("Event worker could not be created");
 
-            worker_event_sender = Some(event_worker);
+            worker_events_sender = Some(events_worker);
         }
 
         // Create a user worker pool
-        let user_worker_msgs_tx = create_user_worker_pool(worker_event_sender).await?;
+        let user_worker_msgs_tx = create_user_worker_pool(worker_events_sender).await?;
 
         // create main worker
         let main_path = Path::new(&main_service_path);
-        let main_worker_req_tx = create_worker(
-            WorkerContextInitOpts {
-                service_path: main_path.to_path_buf(),
-                import_map_path,
-                no_module_cache,
-                conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                    worker_pool_tx: user_worker_msgs_tx,
-                }),
-                env_vars: std::env::vars().collect(),
-            },
-            None,
-        )
+        let main_worker_req_tx = create_worker(WorkerContextInitOpts {
+            service_path: main_path.to_path_buf(),
+            import_map_path,
+            no_module_cache,
+            events_rx: None,
+            conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                worker_pool_tx: user_worker_msgs_tx,
+            }),
+            env_vars: std::env::vars().collect(),
+        })
         .await?;
 
         // register alarm signal handler

--- a/crates/base/src/utils.rs
+++ b/crates/base/src/utils.rs
@@ -1,13 +1,14 @@
-use sb_worker_context::events::WorkerEvents;
+use sb_worker_context::events::{EventMetadata, WorkerEventWithMetadata, WorkerEvents};
 use tokio::sync::mpsc;
 
 pub mod units;
 
 pub fn send_event_if_event_manager_available(
-    maybe_event_manager: Option<mpsc::UnboundedSender<WorkerEvents>>,
+    maybe_event_manager: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
     event: WorkerEvents,
+    metadata: EventMetadata,
 ) {
     if let Some(event_manager) = maybe_event_manager {
-        let _ = event_manager.send(event);
+        let _ = event_manager.send(WorkerEventWithMetadata { event, metadata });
     }
 }

--- a/crates/base/tests/import_map_tests.rs
+++ b/crates/base/tests/import_map_tests.rs
@@ -17,9 +17,10 @@ async fn test_import_map_file_path() {
         no_module_cache: false,
         import_map_path: Some("./test_cases/with_import_map/import_map.json".to_string()),
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()
@@ -64,9 +65,10 @@ async fn test_import_map_inline() {
         no_module_cache: false,
         import_map_path: Some(inline_import_map),
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -15,11 +15,12 @@ async fn test_main_worker_options_request() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()
@@ -53,11 +54,12 @@ async fn test_main_worker_post_request() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let body_chunk = "{ \"name\": \"bar\"}";
@@ -95,11 +97,12 @@ async fn test_main_worker_boot_error() {
         no_module_cache: false,
         import_map_path: Some("./non-existing-import-map.json".to_string()),
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
     };
-    let result = create_worker(opts, None).await;
+    let result = create_worker(opts).await;
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "worker boot error");

--- a/crates/base/tests/null_body_status_null_body_tests.rs
+++ b/crates/base/tests/null_body_status_null_body_tests.rs
@@ -14,9 +14,10 @@ async fn test_null_body_with_204_status() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()
@@ -47,9 +48,10 @@ async fn test_null_body_with_204_status_post() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()

--- a/crates/base/tests/oak_user_worker_tests.rs
+++ b/crates/base/tests/oak_user_worker_tests.rs
@@ -17,9 +17,10 @@ async fn test_oak_server() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()
@@ -50,9 +51,10 @@ async fn test_file_upload() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let body_chunk = "--TEST\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\ntestuser\r\n--TEST--\r\n";

--- a/crates/base/tests/tls_invalid_data_tests.rs
+++ b/crates/base/tests/tls_invalid_data_tests.rs
@@ -14,9 +14,10 @@ async fn test_tls_throw_invalid_data() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()

--- a/crates/base/tests/user_worker_tests.rs
+++ b/crates/base/tests/user_worker_tests.rs
@@ -14,9 +14,10 @@ async fn test_user_worker_json_imports() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let worker_req_tx = create_worker(opts, None).await.unwrap();
+    let worker_req_tx = create_worker(opts).await.unwrap();
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 
     let req = Request::builder()

--- a/crates/base/tests/worker_boot_tests.rs
+++ b/crates/base/tests/worker_boot_tests.rs
@@ -13,9 +13,10 @@ async fn test_worker_boot_invalid_imports() {
         no_module_cache: false,
         import_map_path: None,
         env_vars: HashMap::new(),
+        events_rx: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
-    let result = create_worker(opts, None).await;
+    let result = create_worker(opts).await;
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "worker boot error");

--- a/crates/sb_worker_context/Cargo.toml
+++ b/crates/sb_worker_context/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT"
 path = "lib.rs"
 
 [dependencies]
-hyper.workspace = true
-tokio.workspace = true
-uuid.workspace = true
-serde.workspace = true
 anyhow = { workspace = true }
 enum-as-inner = "0.6.0"
+hyper.workspace = true
+serde.workspace = true
+tokio.workspace = true
+uuid.workspace = true

--- a/crates/sb_worker_context/events.rs
+++ b/crates/sb_worker_context/events.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PseudoEvent {}
@@ -19,17 +20,17 @@ pub struct UncaughtException {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct LogEvent {
+    pub msg: String,
+    pub level: LogLevel,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub enum LogLevel {
     Debug,
     Info,
     Warning,
     Error,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct LogEvent {
-    pub msg: String,
-    pub level: LogLevel,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -42,4 +43,16 @@ pub enum WorkerEvents {
     MemoryLimit(PseudoEvent),
     EventLoopCompleted(PseudoEvent),
     Log(LogEvent),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EventMetadata {
+    pub service_path: Option<String>,
+    pub execution_id: Option<Uuid>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WorkerEventWithMetadata {
+    pub event: WorkerEvents,
+    pub metadata: EventMetadata,
 }

--- a/crates/sb_workers/event_worker.js
+++ b/crates/sb_workers/event_worker.js
@@ -3,37 +3,38 @@ const { SymbolAsyncIterator } = primordials;
 const core = globalThis.Deno.core;
 
 class SupabaseEventListener {
-    [SymbolAsyncIterator]() {
-        return {
-            async next() {
-                try {
-                  const reqEvt = await core.opAsync("op_event_accept");
-                  const done = reqEvt === "Done";
+	async nextEvent() {
+		try {
+			const reqEvt = await core.opAsync('op_event_accept');
+			const done = reqEvt === 'Done';
 
-                  let value = undefined;
-                  if (!done) {
-                    const rawEvent = reqEvt['Event'];
-                    const eventType = Object.keys(rawEvent)[0];
-                    value = {
-                        deployment_id: "",
-                        timestamp: new Date().toISOString(),
-                        event_type: eventType,
-                        event: rawEvent[eventType],
-                        execution_id: "",
-                        region: "",
-                        context: undefined
-                    }
-                  }
+			let value = undefined;
+			if (!done) {
+				const rawEvent = reqEvt['Event'];
+				const eventType = Object.keys(rawEvent)[0];
+				value = {
+					timestamp: new Date().toISOString(),
+					event_type: eventType,
+					event: rawEvent[eventType],
+				};
+			}
 
-                  return { value, done }
-                } catch (e) {
-                  // TODO: handle errors
-                  throw e;
-                }
-            },
-        };
-    }
+			return { value, done };
+		} catch (e) {
+			// TODO: handle errors
+			throw e;
+		}
+	}
 
+	[SymbolAsyncIterator]() {
+		const scopedClass = this;
+
+		return {
+			async next() {
+				return await scopedClass.nextEvent();
+			},
+		};
+	}
 }
 
 export { SupabaseEventListener };

--- a/crates/sb_workers/event_worker.js
+++ b/crates/sb_workers/event_worker.js
@@ -11,11 +11,12 @@ class SupabaseEventListener {
 			let value = undefined;
 			if (!done) {
 				const rawEvent = reqEvt['Event'];
-				const eventType = Object.keys(rawEvent)[0];
+				const eventType = Object.keys(rawEvent.event)[0];
 				value = {
 					timestamp: new Date().toISOString(),
 					event_type: eventType,
-					event: rawEvent[eventType],
+					event: rawEvent.event[eventType],
+					metadata: rawEvent.metadata,
 				};
 			}
 

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -94,6 +94,7 @@ pub async fn op_user_worker_create(
             no_module_cache,
             import_map_path,
             env_vars: env_vars_map,
+            events_rx: None,
             conf: WorkerRuntimeOpts::UserWorker(UserWorkerRuntimeOpts {
                 memory_limit_mb,
                 low_memory_multiplier,
@@ -107,6 +108,8 @@ pub async fn op_user_worker_create(
                 key: None,
                 pool_msg_tx: None,
                 events_msg_tx: None,
+                service_path: None,
+                execution_id: None,
             }),
         };
 

--- a/examples/event-manager/index.ts
+++ b/examples/event-manager/index.ts
@@ -1,5 +1,7 @@
 const eventManager = new globalThis.EventManager();
 
+console.log('event manager running');
+
 for await (const data of eventManager) {
 	if (data) {
 		switch (data.event_type) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This adds a `metadata` field to the event object. Currently it's populated with `service_path` and `execution_id`.