### PR TITLE
Log source file

### DIFF
--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -159,7 +159,9 @@ impl Server {
                                 .serve_connection(conn, service);
 
                              if let Err(e) = conn_fut.await {
-                                 error!("{:?}", e);
+                                 // Most common cause for these errors are when the client closes the connection before
+                                 // we could send a response
+                                 error!("client connection error: {:?}", e);
                              }
                            });
                        }

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -161,7 +161,7 @@ impl Server {
                              if let Err(e) = conn_fut.await {
                                  // Most common cause for these errors are when the client closes the connection before
                                  // we could send a response
-                                 error!("client connection error: {:?}", e);
+                                 error!("client connection error ({:?})", e);
                              }
                            });
                        }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,6 +21,11 @@ fn cli() -> Command {
                 .global(true)
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            arg!(--"log-source" "Include source file and line in log messages")
+                .global(true)
+                .action(ArgAction::SetTrue),
+        )
         .subcommand(
             Command::new("start")
                 .about("Start the server")
@@ -60,7 +65,8 @@ fn main() -> Result<(), anyhow::Error> {
 
         if !matches.get_flag("quiet") {
             let verbose = matches.get_flag("verbose");
-            logger::init(verbose);
+            let include_source = matches.get_flag("log-source");
+            logger::init(verbose, include_source);
         }
 
         #[allow(clippy::single_match)]

--- a/crates/module_fetcher/src/file_fetcher.rs
+++ b/crates/module_fetcher/src/file_fetcher.rs
@@ -30,7 +30,6 @@ use deno_fetch::reqwest::header::IF_NONE_MATCH;
 use deno_fetch::reqwest::StatusCode;
 use deno_web::BlobStore;
 use log::debug;
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -324,14 +323,12 @@ impl FileFetcher {
             ));
         }
 
-        let blob = {
-            let blob_store = self.blob_store.borrow();
-            blob_store
-                .get_object_url(specifier.clone())
-                .ok_or_else(|| {
-                    custom_error("NotFound", format!("Blob URL not found: \"{specifier}\"."))
-                })?
-        };
+        let blob = self
+            .blob_store
+            .get_object_url(specifier.clone())
+            .ok_or_else(|| {
+                custom_error("NotFound", format!("Blob URL not found: \"{specifier}\"."))
+            })?;
 
         let content_type = blob.media_type.clone();
         let bytes = blob.read_all().await?;

--- a/crates/module_fetcher/src/npm/resolution/graph.rs
+++ b/crates/module_fetcher/src/npm/resolution/graph.rs
@@ -853,7 +853,7 @@ impl<'a> GraphDependencyResolver<'a> {
 
         if !has_deps {
             // ensure this is set if not, as it's an optimization
-            let mut node = self.graph.borrow_node_mut(node_id);
+            let node = self.graph.borrow_node_mut(node_id);
             node.no_peers = true;
         }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

If you run edge-runtime with `--log-source` option, it will emit log messages with the corresponding source file and line number.

eg:
```
crates/base/src/server.rs-164: client connection error (hyper::Error(IncompleteMessage))
```

This is quite useful for figuring out the source of some of the non-descriptive error messages.
