### PR TITLE
feat: upgrade docker image to use bookworm base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM rust:1.68.2-bullseye as builder
+FROM rust:1.71.0-bookworm as builder
 ARG TARGETPLATFORM
 RUN apt-get update && apt-get install -y llvm-dev libclang-dev clang
 WORKDIR /usr/src/edge-runtime
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETPLATFORM} --m
     mv /usr/src/edge-runtime/target/release/edge-runtime /root
 
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /root/edge-runtime /usr/local/bin/edge-runtime
 ENTRYPOINT ["edge-runtime"]

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To run with a different entry point, you can pass a different main service like 
 using Docker:
 
 ```
-docker build -t edge-runtime .
-docker run -it --rm -p 9000:9000 -v /path/to/supabase/functions:/functions supabase/edge-runtime start --main-service /functions/main
+docker build -t supabase/edge-runtime .
+docker run -it --rm -p 9000:9000 -v ./examples/:/examples supabase/edge-runtime start --main-service /examples/main
 ```
 
 ## How to run tests


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade to bookworm base image to fix security vulnerabilities identified via ECR container scans.