### PR TITLE
fix: remove perl from runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETPLATFORM} --m
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get remove -y perl && apt-get autoremove -y
 COPY --from=builder /root/edge-runtime /usr/local/bin/edge-runtime
 ENTRYPOINT ["edge-runtime"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

There's a container vulnerability marked as high severity for the Perl module and edge-runtime doesn't rely on it. 