### PR TITLE
fix: parse unknown media type as JS

### DIFF
--- a/crates/base/src/js_worker/module_loader.rs
+++ b/crates/base/src/js_worker/module_loader.rs
@@ -22,7 +22,9 @@ use url::Url;
 
 fn get_module_type(media_type: MediaType) -> Result<ModuleType, Error> {
     let module_type = match media_type {
-        MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs => ModuleType::JavaScript,
+        MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs | MediaType::Unknown => {
+            ModuleType::JavaScript
+        }
         MediaType::Jsx => ModuleType::JavaScript,
         MediaType::TypeScript
         | MediaType::Mts


### PR DESCRIPTION
## What kind of change does this PR introduce?

Treat unknown media types as JS