### PR TITLE
Node create server

### DIFF
--- a/crates/base/test_cases/node-server/index.ts
+++ b/crates/base/test_cases/node-server/index.ts
@@ -1,0 +1,18 @@
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import process from "node:process";
+
+const generateRandomString = (length) => {
+    const buffer = randomBytes(length);
+    return buffer.toString('hex');
+};
+
+const randomString = generateRandomString(10);
+console.log(randomString);
+
+const server = createServer((req, res) => {
+    const message = `Look again at that dot. That's here. That's home. That's us. On it everyone you love, everyone you know, everyone you ever heard of, every human being who ever was, lived out their lives. The aggregate of our joy and suffering, thousands of confident religions, ideologies, and economic doctrines, every hunter and forager, every hero and coward, every creator and destroyer of civilization, every king and peasant, every young couple in love, every mother and father, hopeful child, inventor and explorer, every teacher of morals, every corrupt politician, every 'superstar,' every 'supreme leader,' every saint and sinner in the history of our species lived there-on a mote of dust suspended in a sunbeam.`;
+    res.end(message);
+});
+
+server.listen(9999);

--- a/crates/base/tests/test_node_server.rs
+++ b/crates/base/tests/test_node_server.rs
@@ -1,0 +1,43 @@
+use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use hyper::{Body, Request, Response};
+use sb_worker_context::essentials::{
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+};
+use std::collections::HashMap;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+async fn test_node_server() {
+    let user_rt_opts = UserWorkerRuntimeOpts::default();
+    let opts = WorkerContextInitOpts {
+        service_path: "./test_cases/node-server".into(),
+        no_module_cache: false,
+        import_map_path: None,
+        env_vars: HashMap::new(),
+        events_rx: None,
+        maybe_eszip: None,
+        maybe_entrypoint: None,
+        conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
+    };
+    let worker_req_tx = create_worker(opts).await.unwrap();
+    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
+
+    let req = Request::builder()
+        .uri("/")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let msg = WorkerRequestMsg { req, res_tx };
+    let _ = worker_req_tx.send(msg);
+
+    let res = res_rx.await.unwrap().unwrap();
+    assert_eq!(res.status().as_u16(), 200);
+
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+
+    assert_eq!(
+        body_bytes,
+        "Look again at that dot. That's here. That's home. That's us. On it everyone you love, everyone you know, everyone you ever heard of, every human being who ever was, lived out their lives. The aggregate of our joy and suffering, thousands of confident religions, ideologies, and economic doctrines, every hunter and forager, every hero and coward, every creator and destroyer of civilization, every king and peasant, every young couple in love, every mother and father, hopeful child, inventor and explorer, every teacher of morals, every corrupt politician, every 'superstar,' every 'supreme leader,' every saint and sinner in the history of our species lived there-on a mote of dust suspended in a sunbeam."
+    );
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR introduces the ability to use `createServer` imported from `node:http` in EdgeRuntime.

This functionality is currently not fully backwards compatible, things such as `AbortController` are missing support or listening events.

We probably want to create tickets for the things above.
