### PR TITLE
feat: support loading inline module code

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -119,10 +119,11 @@ impl DenoRuntime {
             conf,
             maybe_eszip,
             maybe_entrypoint,
+            maybe_module_code,
         } = opts;
 
         // check if the service_path exists
-        if maybe_eszip.is_none() && !service_path.exists() {
+        if maybe_entrypoint.is_none() && !service_path.exists() {
             bail!("service does not exist {:?}", &service_path)
         }
 
@@ -134,7 +135,7 @@ impl DenoRuntime {
 
         // TODO: check for other potential main paths (eg: index.js, index.tsx)
         let mut main_module_url = base_url.join("index.ts")?;
-        if maybe_eszip.is_some() && maybe_entrypoint.is_some() {
+        if maybe_entrypoint.is_some() {
             main_module_url = Url::parse(&maybe_entrypoint.unwrap())?;
         }
 
@@ -277,7 +278,9 @@ impl DenoRuntime {
             }
         }
 
-        let main_module_id = js_runtime.load_main_module(&main_module_url, None).await?;
+        let main_module_id = js_runtime
+            .load_main_module(&main_module_url, maybe_module_code)
+            .await?;
 
         Ok(Self {
             js_runtime,
@@ -380,6 +383,7 @@ mod test {
             events_rx: None,
             maybe_eszip: None,
             maybe_entrypoint: None,
+            maybe_module_code: None,
             conf: {
                 if let Some(uc) = user_conf {
                     uc

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -239,6 +239,7 @@ pub async fn create_events_worker(
         events_rx: Some(events_rx),
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::EventsWorker(EventWorkerRuntimeOpts {}),
     })
     .await?;

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -119,6 +119,7 @@ impl Server {
             events_rx: None,
             maybe_eszip: None,
             maybe_entrypoint: None,
+            maybe_module_code: None,
             conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                 worker_pool_tx: user_worker_msgs_tx,
             }),

--- a/crates/base/tests/import_map_tests.rs
+++ b/crates/base/tests/import_map_tests.rs
@@ -20,6 +20,7 @@ async fn test_import_map_file_path() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -70,6 +71,7 @@ async fn test_import_map_inline() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -18,6 +18,7 @@ async fn test_main_worker_options_request() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
@@ -59,6 +60,7 @@ async fn test_main_worker_post_request() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
@@ -104,6 +106,7 @@ async fn test_main_worker_boot_error() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),

--- a/crates/base/tests/null_body_status_null_body_tests.rs
+++ b/crates/base/tests/null_body_status_null_body_tests.rs
@@ -17,6 +17,7 @@ async fn test_null_body_with_204_status() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -53,6 +54,7 @@ async fn test_null_body_with_204_status_post() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/oak_user_worker_tests.rs
+++ b/crates/base/tests/oak_user_worker_tests.rs
@@ -20,6 +20,7 @@ async fn test_oak_server() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -56,6 +57,7 @@ async fn test_file_upload() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/test_node_server.rs
+++ b/crates/base/tests/test_node_server.rs
@@ -17,6 +17,7 @@ async fn test_node_server() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/tls_invalid_data_tests.rs
+++ b/crates/base/tests/tls_invalid_data_tests.rs
@@ -17,6 +17,7 @@ async fn test_tls_throw_invalid_data() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/user_worker_tests.rs
+++ b/crates/base/tests/user_worker_tests.rs
@@ -17,6 +17,7 @@ async fn test_user_worker_json_imports() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/worker_boot_tests.rs
+++ b/crates/base/tests/worker_boot_tests.rs
@@ -16,6 +16,7 @@ async fn test_worker_boot_invalid_imports() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let result = create_worker(opts).await;

--- a/crates/sb_worker_context/essentials.rs
+++ b/crates/sb_worker_context/essentials.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use deno_core::JsBuffer;
+use deno_core::{FastString, JsBuffer};
 use enum_as_inner::EnumAsInner;
 use event_worker::events::WorkerEventWithMetadata;
 use hyper::{Body, Request, Response};
@@ -77,6 +77,7 @@ pub struct WorkerContextInitOpts {
     pub events_rx: Option<mpsc::UnboundedReceiver<WorkerEventWithMetadata>>,
     pub conf: WorkerRuntimeOpts,
     pub maybe_eszip: Option<JsBuffer>,
+    pub maybe_module_code: Option<FastString>,
     pub maybe_entrypoint: Option<String>,
 }
 

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -47,6 +47,7 @@ pub struct UserWorkerCreateOptions {
     custom_module_root: Option<String>,
     maybe_eszip: Option<JsBuffer>,
     maybe_entrypoint: Option<String>,
+    maybe_module_code: Option<String>,
 
     memory_limit_mb: u64,
     low_memory_multiplier: u64,
@@ -76,6 +77,7 @@ pub async fn op_user_worker_create(
             custom_module_root,
             maybe_eszip,
             maybe_entrypoint,
+            maybe_module_code,
 
             memory_limit_mb,
             low_memory_multiplier,
@@ -98,6 +100,7 @@ pub async fn op_user_worker_create(
             events_rx: None,
             maybe_eszip,
             maybe_entrypoint,
+            maybe_module_code: maybe_module_code.map(|v| v.into()),
             conf: WorkerRuntimeOpts::UserWorker(UserWorkerRuntimeOpts {
                 memory_limit_mb,
                 low_memory_multiplier,

--- a/crates/sb_workers/user_workers.js
+++ b/crates/sb_workers/user_workers.js
@@ -74,6 +74,7 @@ class UserWorker {
 			customModuleRoot: '',
 			maybeEszip: null,
 			maybeEntrypoint: null,
+			maybeModuleCode: null,
 			...opts,
 		};
 

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -49,6 +49,8 @@ serve(async (req: Request) => {
 		// load source from an eszip
 		// const maybeEszip = await Deno.readFile('./sample.eszip');
 		// const maybeEntrypoint = 'file:///src/index.ts';
+		// or load module source from an inline module
+		// const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
 
 		return await EdgeRuntime.userWorkers.create({
 			servicePath,
@@ -59,8 +61,9 @@ serve(async (req: Request) => {
 			envVars,
 			forceCreate,
 			netAccessDisabled,
-			//maybeEszip,
-			//maybeEntrypoint,
+			// maybeEszip,
+			// maybeEntrypoint,
+			// maybeModuleCode,
 		});
 	};
 


### PR DESCRIPTION
Can provide module code as a string when creating a worker.

example,

```
const worker = createWorker({
....
maybeEntrypoint: "file:///src/index.ts",
maybeModuleCode: 'Deno.serve((req) => new Response("Hello from Module Code"));',
})
```