### PR TITLE
Bug fix: Revert "Merge pull request #169 from supabase/support-inline-module-c…

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -119,11 +119,10 @@ impl DenoRuntime {
             conf,
             maybe_eszip,
             maybe_entrypoint,
-            maybe_module_code,
         } = opts;
 
         // check if the service_path exists
-        if maybe_entrypoint.is_none() && !service_path.exists() {
+        if maybe_eszip.is_none() && !service_path.exists() {
             bail!("service does not exist {:?}", &service_path)
         }
 
@@ -135,7 +134,7 @@ impl DenoRuntime {
 
         // TODO: check for other potential main paths (eg: index.js, index.tsx)
         let mut main_module_url = base_url.join("index.ts")?;
-        if maybe_entrypoint.is_some() {
+        if maybe_eszip.is_some() && maybe_entrypoint.is_some() {
             main_module_url = Url::parse(&maybe_entrypoint.unwrap())?;
         }
 
@@ -286,9 +285,7 @@ impl DenoRuntime {
             }
         }
 
-        let main_module_id = js_runtime
-            .load_main_module(&main_module_url, maybe_module_code)
-            .await?;
+        let main_module_id = js_runtime.load_main_module(&main_module_url, None).await?;
 
         Ok(Self {
             js_runtime,
@@ -391,7 +388,6 @@ mod test {
             events_rx: None,
             maybe_eszip: None,
             maybe_entrypoint: None,
-            maybe_module_code: None,
             conf: {
                 if let Some(uc) = user_conf {
                     uc

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -239,7 +239,6 @@ pub async fn create_events_worker(
         events_rx: Some(events_rx),
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::EventsWorker(EventWorkerRuntimeOpts {}),
     })
     .await?;

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -119,7 +119,6 @@ impl Server {
             events_rx: None,
             maybe_eszip: None,
             maybe_entrypoint: None,
-            maybe_module_code: None,
             conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                 worker_pool_tx: user_worker_msgs_tx,
             }),

--- a/crates/base/tests/import_map_tests.rs
+++ b/crates/base/tests/import_map_tests.rs
@@ -20,7 +20,6 @@ async fn test_import_map_file_path() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -71,7 +70,6 @@ async fn test_import_map_inline() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -18,7 +18,6 @@ async fn test_main_worker_options_request() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
@@ -60,7 +59,6 @@ async fn test_main_worker_post_request() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),
@@ -106,7 +104,6 @@ async fn test_main_worker_boot_error() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx: user_worker_msgs_tx,
         }),

--- a/crates/base/tests/null_body_status_null_body_tests.rs
+++ b/crates/base/tests/null_body_status_null_body_tests.rs
@@ -17,7 +17,6 @@ async fn test_null_body_with_204_status() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -54,7 +53,6 @@ async fn test_null_body_with_204_status_post() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/oak_user_worker_tests.rs
+++ b/crates/base/tests/oak_user_worker_tests.rs
@@ -20,7 +20,6 @@ async fn test_oak_server() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();
@@ -57,7 +56,6 @@ async fn test_file_upload() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/test_node_server.rs
+++ b/crates/base/tests/test_node_server.rs
@@ -17,7 +17,6 @@ async fn test_node_server() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/tls_invalid_data_tests.rs
+++ b/crates/base/tests/tls_invalid_data_tests.rs
@@ -17,7 +17,6 @@ async fn test_tls_throw_invalid_data() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/user_worker_tests.rs
+++ b/crates/base/tests/user_worker_tests.rs
@@ -17,7 +17,6 @@ async fn test_user_worker_json_imports() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let worker_req_tx = create_worker(opts).await.unwrap();

--- a/crates/base/tests/worker_boot_tests.rs
+++ b/crates/base/tests/worker_boot_tests.rs
@@ -16,7 +16,6 @@ async fn test_worker_boot_invalid_imports() {
         events_rx: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
-        maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(user_rt_opts),
     };
     let result = create_worker(opts).await;

--- a/crates/sb_worker_context/essentials.rs
+++ b/crates/sb_worker_context/essentials.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use deno_core::{FastString, JsBuffer};
+use deno_core::JsBuffer;
 use enum_as_inner::EnumAsInner;
 use event_worker::events::WorkerEventWithMetadata;
 use hyper::{Body, Request, Response};
@@ -77,7 +77,6 @@ pub struct WorkerContextInitOpts {
     pub events_rx: Option<mpsc::UnboundedReceiver<WorkerEventWithMetadata>>,
     pub conf: WorkerRuntimeOpts,
     pub maybe_eszip: Option<JsBuffer>,
-    pub maybe_module_code: Option<FastString>,
     pub maybe_entrypoint: Option<String>,
 }
 

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -47,7 +47,6 @@ pub struct UserWorkerCreateOptions {
     custom_module_root: Option<String>,
     maybe_eszip: Option<JsBuffer>,
     maybe_entrypoint: Option<String>,
-    maybe_module_code: Option<String>,
 
     memory_limit_mb: u64,
     low_memory_multiplier: u64,
@@ -77,7 +76,6 @@ pub async fn op_user_worker_create(
             custom_module_root,
             maybe_eszip,
             maybe_entrypoint,
-            maybe_module_code,
 
             memory_limit_mb,
             low_memory_multiplier,
@@ -100,7 +98,6 @@ pub async fn op_user_worker_create(
             events_rx: None,
             maybe_eszip,
             maybe_entrypoint,
-            maybe_module_code: maybe_module_code.map(|v| v.into()),
             conf: WorkerRuntimeOpts::UserWorker(UserWorkerRuntimeOpts {
                 memory_limit_mb,
                 low_memory_multiplier,

--- a/crates/sb_workers/user_workers.js
+++ b/crates/sb_workers/user_workers.js
@@ -110,7 +110,6 @@ class UserWorker {
 			customModuleRoot: '',
 			maybeEszip: null,
 			maybeEntrypoint: null,
-			maybeModuleCode: null,
 			...opts,
 		};
 

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -49,8 +49,6 @@ serve(async (req: Request) => {
 		// load source from an eszip
 		// const maybeEszip = await Deno.readFile('./sample.eszip');
 		// const maybeEntrypoint = 'file:///src/index.ts';
-		// or load module source from an inline module
-		// const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
 
 		return await EdgeRuntime.userWorkers.create({
 			servicePath,
@@ -61,9 +59,8 @@ serve(async (req: Request) => {
 			envVars,
 			forceCreate,
 			netAccessDisabled,
-			// maybeEszip,
-			// maybeEntrypoint,
-			// maybeModuleCode,
+			//maybeEszip,
+			//maybeEntrypoint,
 		});
 	};
 


### PR DESCRIPTION
This reverts commit 55d21818491c54755845e88d1a40c98446f5a06c, reversing changes made to 9ce25ff4d72568b51fc9ec913eec52d2386093d2.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There is support for inline module code.

## What is the new behavior?

support for inline module code is reverted

## Additional context

This PR reverts PR #169 , as it seems to cause an issue where Deno loads modules as a browser environment.

I am sorry to revert this @laktek  but we are losing a lot of money every day, as we can't update our production functions, and this PR seems to be the cause of the issue. I tried to debug and find a different way to fix it, I tried to work with you guys on it - but can't seems to move forward much. Hopefully you accept this revert, and find a way to merge it back without the issue
