### PR TITLE
fix: Made user worker create non-blocking

### DIFF
--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -1,12 +1,13 @@
 use crate::rt_worker::worker_ctx::{create_worker, send_user_worker_request, UserWorkerProfile};
-use anyhow::{anyhow, bail, Error};
+use anyhow::{anyhow, Error};
 use cityhash::cityhash_1::city_hash_64;
 use event_worker::events::WorkerEventWithMetadata;
 use http::{Request, Response};
 use hyper::Body;
 use log::error;
 use sb_worker_context::essentials::{
-    CreateUserWorkerResult, UserWorkerMsgs, WorkerContextInitOpts, WorkerRuntimeOpts,
+    CreateUserWorkerResult, UserWorkerMsgs, WorkerContextInitOpts, WorkerRequestMsg,
+    WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -23,11 +24,6 @@ pub struct WorkerPool {
     pub worker_event_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
 }
 
-pub enum CreationCodes {
-    AlreadyExist,
-    Unknown,
-}
-
 impl WorkerPool {
     pub(crate) fn new(
         worker_event_sender: Option<UnboundedSender<WorkerEventWithMetadata>>,
@@ -40,11 +36,11 @@ impl WorkerPool {
         }
     }
 
-    pub async fn create_user_worker(
-        &mut self,
+    pub fn create_user_worker(
+        &self,
         mut worker_options: WorkerContextInitOpts,
         tx: Sender<Result<CreateUserWorkerResult, Error>>,
-    ) -> Result<CreationCodes, Error> {
+    ) {
         let mut user_worker_rt_opts = match worker_options.conf {
             WorkerRuntimeOpts::UserWorker(opts) => opts,
             _ => unreachable!(),
@@ -57,9 +53,9 @@ impl WorkerPool {
 
         if self.worker_already_exists(key, user_worker_rt_opts.force_create) {
             if tx.send(Ok(CreateUserWorkerResult { key })).is_err() {
-                bail!("main worker receiver dropped")
+                error!("main worker receiver dropped")
             }
-            return Ok(CreationCodes::AlreadyExist);
+            return;
         }
 
         user_worker_rt_opts.service_path = Some(service_path);
@@ -69,31 +65,44 @@ impl WorkerPool {
         user_worker_rt_opts.events_msg_tx = self.worker_event_sender.clone();
 
         worker_options.conf = WorkerRuntimeOpts::UserWorker(user_worker_rt_opts);
+        let worker_pool_msgs_tx = self.worker_pool_msgs_tx.clone();
 
-        let result = create_worker(worker_options).await;
-
-        match result {
-            Ok(user_worker_req_tx) => {
-                self.user_workers.insert(
-                    key,
-                    UserWorkerProfile {
-                        worker_event_tx: user_worker_req_tx,
-                    },
-                );
-                if tx.send(Ok(CreateUserWorkerResult { key })).is_err() {
-                    bail!("main worker receiver dropped")
-                };
-
-                Ok(CreationCodes::Unknown)
-            }
-            Err(e) => {
-                if tx.send(Err(e)).is_err() {
-                    bail!("main worker receiver dropped")
-                } else {
-                    bail!("An error has occured")
+        tokio::task::spawn(async move {
+            let result = create_worker(worker_options).await;
+            match result {
+                Ok(worker_request_msg_tx) => {
+                    if worker_pool_msgs_tx
+                        .send(UserWorkerMsgs::Created(key, worker_request_msg_tx))
+                        .is_err()
+                    {
+                        error!("user worker msgs receiver dropped")
+                    }
+                    if tx.send(Ok(CreateUserWorkerResult { key })).is_err() {
+                        error!("main worker receiver dropped")
+                    };
+                }
+                Err(e) => {
+                    if tx.send(Err(e)).is_err() {
+                        error!("main worker receiver dropped")
+                    } else {
+                        error!("An error has occured")
+                    }
                 }
             }
-        }
+        });
+    }
+
+    pub fn add_user_worker(
+        &mut self,
+        key: u64,
+        worker_request_msg_tx: mpsc::UnboundedSender<WorkerRequestMsg>,
+    ) {
+        self.user_workers.insert(
+            key,
+            UserWorkerProfile {
+                worker_request_msg_tx,
+            },
+        );
     }
 
     pub fn send_request(
@@ -108,7 +117,7 @@ impl WorkerPool {
 
                 // Create a closure to handle the request and send the response
                 let request_handler = async move {
-                    let result = send_user_worker_request(profile.worker_event_tx, req).await;
+                    let result = send_user_worker_request(profile.worker_request_msg_tx, req).await;
                     match result {
                         Ok(rep) => Ok(rep),
                         Err(err) => {

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -1,10 +1,11 @@
 use crate::rt_worker::worker_ctx::{
-    create_events_worker, create_main_worker, create_user_worker_pool, WorkerRequestMsg,
+    create_events_worker, create_main_worker, create_user_worker_pool,
 };
 use anyhow::Error;
 use event_worker::events::WorkerEventWithMetadata;
 use hyper::{server::conn::Http, service::Service, Body, Request, Response};
 use log::{debug, error, info};
+use sb_worker_context::essentials::WorkerRequestMsg;
 use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;

--- a/crates/base/tests/import_map_tests.rs
+++ b/crates/base/tests/import_map_tests.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use tokio::sync::oneshot;
 use urlencoding::encode;
 
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 
 #[tokio::test]

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_user_worker_pool, create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::{create_user_worker_pool, create_worker};
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    MainWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    MainWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/base/tests/null_body_status_null_body_tests.rs
+++ b/crates/base/tests/null_body_status_null_body_tests.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/base/tests/oak_user_worker_tests.rs
+++ b/crates/base/tests/oak_user_worker_tests.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/base/tests/test_node_server.rs
+++ b/crates/base/tests/test_node_server.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/base/tests/tls_invalid_data_tests.rs
+++ b/crates/base/tests/tls_invalid_data_tests.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/base/tests/user_worker_tests.rs
+++ b/crates/base/tests/user_worker_tests.rs
@@ -1,7 +1,7 @@
-use base::rt_worker::worker_ctx::{create_worker, WorkerRequestMsg};
+use base::rt_worker::worker_ctx::create_worker;
 use hyper::{Body, Request, Response};
 use sb_worker_context::essentials::{
-    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRuntimeOpts,
+    UserWorkerRuntimeOpts, WorkerContextInitOpts, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
 use tokio::sync::oneshot;

--- a/crates/sb_worker_context/essentials.rs
+++ b/crates/sb_worker_context/essentials.rs
@@ -91,6 +91,7 @@ pub enum UserWorkerMsgs {
         WorkerContextInitOpts,
         oneshot::Sender<Result<CreateUserWorkerResult, Error>>,
     ),
+    Created(u64, mpsc::UnboundedSender<WorkerRequestMsg>),
     SendRequest(
         u64,
         Request<Body>,
@@ -102,4 +103,10 @@ pub enum UserWorkerMsgs {
 #[derive(Debug)]
 pub struct CreateUserWorkerResult {
     pub key: u64,
+}
+
+#[derive(Debug)]
+pub struct WorkerRequestMsg {
+    pub req: Request<Body>,
+    pub res_tx: oneshot::Sender<Result<Response<Body>, hyper::Error>>,
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the user worker creation blocks the worker pool events loops. This can cause deadlocks and make edge-runtime unresponsive. 

This PR modifies the user worker creation to be non-blocking.