### PR TITLE
fix: exclude default v8 heap stats from user worker logs

### DIFF
--- a/crates/event_worker/js_interceptors.rs
+++ b/crates/event_worker/js_interceptors.rs
@@ -1,4 +1,4 @@
-use crate::events::{EventMetadata, LogEvent, LogLevel, WorkerEvents, WorkerMemoryUsage};
+use crate::events::{EventMetadata, LogEvent, LogLevel, WorkerEvents};
 use crate::WorkerEventWithMetadata;
 use deno_core::error::AnyError;
 use deno_core::op;
@@ -7,12 +7,7 @@ use log::error;
 use tokio::sync::mpsc;
 
 #[op]
-pub fn op_user_worker_log(
-    state: &mut OpState,
-    msg: &str,
-    is_err: bool,
-    v8_heap_stats: Option<WorkerMemoryUsage>,
-) -> Result<(), AnyError> {
+pub fn op_user_worker_log(state: &mut OpState, msg: &str, is_err: bool) -> Result<(), AnyError> {
     let maybe_tx = state.try_borrow::<mpsc::UnboundedSender<WorkerEventWithMetadata>>();
     let mut level = LogLevel::Info;
     if is_err {
@@ -25,10 +20,7 @@ pub fn op_user_worker_log(
             .unwrap_or(&EventMetadata::default())
             .clone();
 
-        let metadata = EventMetadata {
-            v8_heap_stats,
-            ..event_metadata
-        };
+        let metadata = EventMetadata { ..event_metadata };
 
         tx.send(WorkerEventWithMetadata {
             event: WorkerEvents::Log(LogEvent {

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -264,9 +264,9 @@ globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, version) => {
 		mainModule: getterOnly(() => ops.op_main_module()),
 		version: getterOnly(() => ({
 			deno: `supabase-edge-runtime-${globalThis.SUPABASE_VERSION}`,
-			v8: "11.6.189.12",
-			typescript: "5.1.6"
-		}))
+			v8: '11.6.189.12',
+			typescript: '5.1.6',
+		})),
 	});
 	ObjectDefineProperty(globalThis, 'Deno', readOnly(denoOverrides));
 
@@ -281,7 +281,7 @@ globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, version) => {
 		ObjectDefineProperties(globalThis, {
 			console: nonEnumerable(
 				new console.Console((msg, level) => {
-					return ops.op_user_worker_log(msg, level > 1, ops.op_runtime_memory_usage());
+					return ops.op_user_worker_log(msg, level > 1);
 				}),
 			),
 		});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Excluding the v8 heap stats that were added by default to user worker logs. The op code is still there if we want to expose an explicity `console.memory` API.
