### PR TITLE
feat:  retire workers at the 50% of wall-clock limit

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -285,7 +285,7 @@ impl DenoRuntime {
                     op_state.put::<mpsc::UnboundedSender<WorkerEventWithMetadata>>(events_msg_tx);
                     op_state.put::<EventMetadata>(EventMetadata {
                         service_path: conf.service_path.clone(),
-                        execution_id: conf.execution_id,
+                        execution_id: conf.key,
                         v8_heap_stats: None,
                     });
                 }
@@ -714,7 +714,6 @@ mod test {
                 key: None,
                 pool_msg_tx: None,
                 events_msg_tx: None,
-                execution_id: None,
                 service_path: None,
             })),
         )

--- a/crates/base/src/rt_worker/utils.rs
+++ b/crates/base/src/rt_worker/utils.rs
@@ -1,9 +1,10 @@
 use event_worker::events::{EventMetadata, WorkerEventWithMetadata};
 use sb_worker_context::essentials::{UserWorkerMsgs, WorkerRuntimeOpts};
 use tokio::sync::mpsc::UnboundedSender;
+use uuid::Uuid;
 
 type WorkerCoreConfig = (
-    Option<u64>,
+    Option<Uuid>,
     Option<UnboundedSender<UserWorkerMsgs>>,
     Option<UnboundedSender<WorkerEventWithMetadata>>,
     String,

--- a/crates/base/src/rt_worker/utils.rs
+++ b/crates/base/src/rt_worker/utils.rs
@@ -38,7 +38,7 @@ pub fn get_event_metadata(conf: &WorkerRuntimeOpts) -> EventMetadata {
         let conf = conf.as_user_worker().unwrap();
         event_metadata = EventMetadata {
             service_path: conf.service_path.clone(),
-            execution_id: conf.execution_id,
+            execution_id: conf.key,
             v8_heap_stats: None,
         };
     }

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::time::Instant;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct Worker {
@@ -25,7 +26,7 @@ pub struct Worker {
     pub events_msg_tx: Option<UnboundedSender<WorkerEventWithMetadata>>,
     pub pool_msg_tx: Option<UnboundedSender<UserWorkerMsgs>>,
     pub event_metadata: EventMetadata,
-    pub worker_key: Option<u64>,
+    pub worker_key: Option<Uuid>,
     pub thread_name: String,
 }
 
@@ -100,7 +101,7 @@ impl Worker {
 
                                 // cputimer is returned from supervisor and assigned here to keep it in scope.
                                 _cputimer = create_supervisor(
-                                    worker_key.unwrap_or(0),
+                                    worker_key.unwrap_or(Uuid::nil()),
                                     &mut new_runtime,
                                     termination_event_tx,
                                 )?;

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -104,6 +104,7 @@ impl Worker {
                                     worker_key.unwrap_or(Uuid::nil()),
                                     &mut new_runtime,
                                     termination_event_tx,
+                                    pool_msg_tx.clone(),
                                 )?;
                             }
 

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -77,7 +77,6 @@ impl WorkerPool {
 
         user_worker_rt_opts.service_path = Some(service_path.clone());
         user_worker_rt_opts.key = Some(uuid);
-        user_worker_rt_opts.execution_id = Some(uuid);
 
         user_worker_rt_opts.pool_msg_tx = Some(self.worker_pool_msgs_tx.clone());
         user_worker_rt_opts.events_msg_tx = self.worker_event_sender.clone();

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -1,23 +1,30 @@
-use crate::rt_worker::worker_ctx::{create_worker, send_user_worker_request, UserWorkerProfile};
+use crate::rt_worker::worker_ctx::{create_worker, send_user_worker_request};
 use anyhow::{anyhow, Error};
-use cityhash::cityhash_1::city_hash_64;
 use event_worker::events::WorkerEventWithMetadata;
 use http::{Request, Response};
 use hyper::Body;
 use log::error;
 use sb_worker_context::essentials::{
-    CreateUserWorkerResult, UserWorkerMsgs, WorkerContextInitOpts, WorkerRequestMsg,
+    CreateUserWorkerResult, UserWorkerMsgs, UserWorkerProfile, WorkerContextInitOpts,
     WorkerRuntimeOpts,
 };
 use std::collections::HashMap;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot::Sender;
+use uuid::Uuid;
 
+// every new worker gets a new UUID (can reuse execution_id)
+// user_workers - maintain a hashmap of (uuid - workerProfile (include service path))
+// active_workers - hashmap of (service_path - uuid)
+// retire removed entry for uuid from active
+// shutdown removes uuid from both active and user_workers
+// create_worker returns true if an active_worker is available for service_path (force create
+// retires current one adds new one)
+// send_request is called with UUID
 pub struct WorkerPool {
-    pub user_workers: HashMap<u64, UserWorkerProfile>,
+    pub user_workers: HashMap<Uuid, UserWorkerProfile>,
+    pub active_workers: HashMap<String, Uuid>,
     pub worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
 
     // TODO: refactor this out of worker pool
@@ -32,6 +39,7 @@ impl WorkerPool {
         Self {
             worker_event_sender,
             user_workers: HashMap::new(),
+            active_workers: HashMap::new(),
             worker_pool_msgs_tx,
         }
     }
@@ -46,21 +54,31 @@ impl WorkerPool {
             _ => unreachable!(),
         };
 
-        let (key, service_path) = self.derive_worker_key(
-            &worker_options.service_path,
-            user_worker_rt_opts.force_create,
-        );
-
-        if self.worker_already_exists(key, user_worker_rt_opts.force_create) {
-            if tx.send(Ok(CreateUserWorkerResult { key })).is_err() {
+        let service_path = worker_options
+            .service_path
+            .to_str()
+            .unwrap_or("")
+            .to_string();
+        if let Some(active_worker_uuid) =
+            self.maybe_active_worker(&service_path, user_worker_rt_opts.force_create)
+        {
+            if tx
+                .send(Ok(CreateUserWorkerResult {
+                    key: *active_worker_uuid,
+                }))
+                .is_err()
+            {
                 error!("main worker receiver dropped")
             }
             return;
         }
 
-        user_worker_rt_opts.service_path = Some(service_path);
-        user_worker_rt_opts.key = Some(key);
-        user_worker_rt_opts.execution_id = Some(uuid::Uuid::new_v4());
+        let uuid = uuid::Uuid::new_v4();
+
+        user_worker_rt_opts.service_path = Some(service_path.clone());
+        user_worker_rt_opts.key = Some(uuid);
+        user_worker_rt_opts.execution_id = Some(uuid);
+
         user_worker_rt_opts.pool_msg_tx = Some(self.worker_pool_msgs_tx.clone());
         user_worker_rt_opts.events_msg_tx = self.worker_event_sender.clone();
 
@@ -71,13 +89,17 @@ impl WorkerPool {
             let result = create_worker(worker_options).await;
             match result {
                 Ok(worker_request_msg_tx) => {
+                    let profile = UserWorkerProfile {
+                        worker_request_msg_tx,
+                        service_path,
+                    };
                     if worker_pool_msgs_tx
-                        .send(UserWorkerMsgs::Created(key, worker_request_msg_tx))
+                        .send(UserWorkerMsgs::Created(uuid, profile))
                         .is_err()
                     {
                         error!("user worker msgs receiver dropped")
                     }
-                    if tx.send(Ok(CreateUserWorkerResult { key })).is_err() {
+                    if tx.send(Ok(CreateUserWorkerResult { key: uuid })).is_err() {
                         error!("main worker receiver dropped")
                     };
                 }
@@ -92,26 +114,19 @@ impl WorkerPool {
         });
     }
 
-    pub fn add_user_worker(
-        &mut self,
-        key: u64,
-        worker_request_msg_tx: mpsc::UnboundedSender<WorkerRequestMsg>,
-    ) {
-        self.user_workers.insert(
-            key,
-            UserWorkerProfile {
-                worker_request_msg_tx,
-            },
-        );
+    pub fn add_user_worker(&mut self, key: Uuid, profile: UserWorkerProfile) {
+        self.active_workers
+            .insert(profile.service_path.clone(), key);
+        self.user_workers.insert(key, profile);
     }
 
     pub fn send_request(
         &self,
-        key: u64,
+        key: &Uuid,
         req: Request<Body>,
         res_tx: Sender<Result<Response<Body>, Error>>,
     ) {
-        let _: Result<(), Error> = match self.user_workers.get(&key) {
+        let _: Result<(), Error> = match self.user_workers.get(key) {
             Some(worker) => {
                 let profile = worker.clone();
 
@@ -149,21 +164,21 @@ impl WorkerPool {
         };
     }
 
-    pub fn shutdown(&mut self, key: u64) {
-        self.user_workers.remove(&key);
-    }
-
-    fn derive_worker_key(&self, service_path: &Path, force_create: bool) -> (u64, String) {
-        let mut key_input = service_path.to_str().unwrap_or("").to_string();
-        if force_create {
-            let cur_epoch_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-            key_input = format!("{}-{}", key_input, cur_epoch_time.as_millis());
+    pub fn retire(&mut self, key: &Uuid) {
+        if let Some(profile) = self.user_workers.get(key) {
+            self.active_workers.remove(&profile.service_path);
         }
-
-        (city_hash_64(key_input.as_bytes()), key_input)
     }
 
-    fn worker_already_exists(&self, key: u64, force_create: bool) -> bool {
-        !force_create && self.user_workers.contains_key(&key)
+    pub fn shutdown(&mut self, key: &Uuid) {
+        self.retire(key);
+        self.user_workers.remove(key);
+    }
+
+    fn maybe_active_worker(&self, service_path: &String, force_create: bool) -> Option<&Uuid> {
+        if force_create {
+            return None;
+        }
+        self.active_workers.get(service_path)
     }
 }

--- a/crates/sb_worker_context/essentials.rs
+++ b/crates/sb_worker_context/essentials.rs
@@ -14,7 +14,6 @@ use sb_eszip::module_loader::EszipPayloadKind;
 pub struct UserWorkerRuntimeOpts {
     pub service_path: Option<String>,
     pub key: Option<Uuid>,
-    pub execution_id: Option<Uuid>, // TODO: deprecate and use key instead
 
     pub pool_msg_tx: Option<mpsc::UnboundedSender<UserWorkerMsgs>>,
     pub events_msg_tx: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
@@ -52,7 +51,6 @@ impl Default for UserWorkerRuntimeOpts {
             allow_remote_modules: true,
             custom_module_root: None,
             service_path: None,
-            execution_id: None,
         }
     }
 }

--- a/crates/sb_worker_context/essentials.rs
+++ b/crates/sb_worker_context/essentials.rs
@@ -13,8 +13,8 @@ use sb_eszip::module_loader::EszipPayloadKind;
 #[derive(Debug, Clone)]
 pub struct UserWorkerRuntimeOpts {
     pub service_path: Option<String>,
-    pub key: Option<u64>, // unique worker key based on service path hash
-    pub execution_id: Option<Uuid>,
+    pub key: Option<Uuid>,
+    pub execution_id: Option<Uuid>, // TODO: deprecate and use key instead
 
     pub pool_msg_tx: Option<mpsc::UnboundedSender<UserWorkerMsgs>>,
     pub events_msg_tx: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
@@ -58,6 +58,12 @@ impl Default for UserWorkerRuntimeOpts {
 }
 
 #[derive(Debug, Clone)]
+pub struct UserWorkerProfile {
+    pub worker_request_msg_tx: mpsc::UnboundedSender<WorkerRequestMsg>,
+    pub service_path: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct MainWorkerRuntimeOpts {
     pub worker_pool_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
 }
@@ -91,18 +97,19 @@ pub enum UserWorkerMsgs {
         WorkerContextInitOpts,
         oneshot::Sender<Result<CreateUserWorkerResult, Error>>,
     ),
-    Created(u64, mpsc::UnboundedSender<WorkerRequestMsg>),
+    Created(Uuid, UserWorkerProfile),
     SendRequest(
-        u64,
+        Uuid,
         Request<Body>,
         oneshot::Sender<Result<Response<Body>, Error>>,
     ),
-    Shutdown(u64),
+    Retire(Uuid),
+    Shutdown(Uuid),
 }
 
 #[derive(Debug)]
 pub struct CreateUserWorkerResult {
-    pub key: u64,
+    pub key: Uuid,
 }
 
 #[derive(Debug)]

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -24,6 +24,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
 
 deno_core::extension!(
     sb_user_workers,
@@ -352,7 +353,7 @@ pub async fn op_user_worker_fetch_send(
         .ok()
         .expect("multiple op_user_worker_fetch_send ongoing");
     let (result_tx, result_rx) = oneshot::channel::<Result<Response<Body>, Error>>();
-    let key_parsed = key.parse::<u64>()?;
+    let key_parsed = Uuid::try_parse(key.as_str())?;
     tx.send(UserWorkerMsgs::SendRequest(
         key_parsed, request.0, result_tx,
     ))?;

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -120,7 +120,6 @@ pub async fn op_user_worker_create(
                 pool_msg_tx: None,
                 events_msg_tx: None,
                 service_path: None,
-                execution_id: None,
             }),
         };
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

### Option to retire workers from the user worker pool - a0a7611a2e83f89a7e54e22072a9a7517c49addf

Here's how it works:
 - Every new worker gets a new UUID (this is reused for execution_id as well)
 - There's a hash map of user_worker profiles (UUID is the key)
 - Also, there's a 2nd hash map of `active_workers`  This maps `service_path` to  `key` (UUID)
 - `UserWorkerMsgs::Retire` would remove the entry for worker from `active_workers`
 -  `UserWorkerMsgs::Shutdown`  retires the worker first (if it's already not retired) and then removes it from `user_workers` hashmap.
 -  `UserWorkerMsgs::Create` would return the UUID of `active_worker` if one already exists for `service_path` (`force create` argument bypasses this and re-creates the worker)
- `send_request` is called with UUID meaning retired workers can still receive messages from main (if it still holds a reference) or send responses to requests already pending.

### Wall-clock time limit now retires workers after reaching 50% of the limit. 72d779af7a8083d035e1f9ac8c8ca29a147f262b

- With this change, existing requests can complete sending its responses
- New requests to the `service_path` will create a new worker.
