### PR TITLE
fix: provide optional entrypoints for main/events eszips

### DIFF
--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -10,6 +10,8 @@ pub async fn start_server(
     import_map_path: Option<String>,
     no_module_cache: bool,
     callback_tx: Option<Sender<ServerCodes>>,
+    maybe_main_entrypoint: Option<String>,
+    maybe_events_entrypoint: Option<String>,
 ) -> Result<(), Error> {
     let mut server = Server::new(
         ip,
@@ -19,6 +21,8 @@ pub async fn start_server(
         import_map_path,
         no_module_cache,
         callback_tx,
+        maybe_main_entrypoint,
+        maybe_events_entrypoint,
     )
     .await?;
     server.listen().await

--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -1,7 +1,8 @@
-use crate::server::{Server, ServerCodes};
+use crate::server::{Server, ServerCodes, WorkerEntrypoints};
 use anyhow::Error;
 use tokio::sync::mpsc::Sender;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_server(
     ip: &str,
     port: u16,
@@ -10,8 +11,7 @@ pub async fn start_server(
     import_map_path: Option<String>,
     no_module_cache: bool,
     callback_tx: Option<Sender<ServerCodes>>,
-    maybe_main_entrypoint: Option<String>,
-    maybe_events_entrypoint: Option<String>,
+    entrypoints: WorkerEntrypoints,
 ) -> Result<(), Error> {
     let mut server = Server::new(
         ip,
@@ -21,8 +21,7 @@ pub async fn start_server(
         import_map_path,
         no_module_cache,
         callback_tx,
-        maybe_main_entrypoint,
-        maybe_events_entrypoint,
+        entrypoints,
     )
     .await?;
     server.listen().await

--- a/crates/base/src/macros/test_macros.rs
+++ b/crates/base/src/macros/test_macros.rs
@@ -26,7 +26,11 @@ macro_rules! integration_test {
                 None,
                 None,
                 false,
-                Some(tx.clone())
+                Some(tx.clone()),
+                $crate::server::WorkerEntrypoints {
+                    main: None,
+                    events: None,
+                }
             ) => {
                 panic!("This one should not end first");
             }

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -246,15 +246,14 @@ pub async fn create_main_worker(
     import_map_path: Option<String>,
     no_module_cache: bool,
     user_worker_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
+    maybe_entrypoint: Option<String>,
 ) -> Result<mpsc::UnboundedSender<WorkerRequestMsg>, Error> {
     let mut service_path = main_worker_path.clone();
     let mut maybe_eszip = None;
-    let mut maybe_entrypoint = None;
     if let Some(ext) = main_worker_path.extension() {
         if ext == "eszip" {
             service_path = main_worker_path.parent().unwrap().to_path_buf();
             maybe_eszip = Some(EszipPayloadKind::VecKind(std::fs::read(main_worker_path)?));
-            maybe_entrypoint = Some("file:///src/index.ts".to_string());
         }
     }
 
@@ -281,19 +280,18 @@ pub async fn create_events_worker(
     events_worker_path: PathBuf,
     import_map_path: Option<String>,
     no_module_cache: bool,
+    maybe_entrypoint: Option<String>,
 ) -> Result<mpsc::UnboundedSender<WorkerEventWithMetadata>, Error> {
     let (events_tx, events_rx) = mpsc::unbounded_channel::<WorkerEventWithMetadata>();
 
     let mut service_path = events_worker_path.clone();
     let mut maybe_eszip = None;
-    let mut maybe_entrypoint = None;
     if let Some(ext) = events_worker_path.extension() {
         if ext == "eszip" {
             service_path = events_worker_path.parent().unwrap().to_path_buf();
             maybe_eszip = Some(EszipPayloadKind::VecKind(std::fs::read(
                 events_worker_path,
             )?));
-            maybe_entrypoint = Some("file:///src/index.ts".to_string());
         }
     }
 

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -89,6 +89,8 @@ impl Server {
         import_map_path: Option<String>,
         no_module_cache: bool,
         callback_tx: Option<Sender<ServerCodes>>,
+        maybe_main_entrypoint: Option<String>,
+        maybe_events_entrypoint: Option<String>,
     ) -> Result<Self, Error> {
         let mut worker_events_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>> = None;
 
@@ -97,9 +99,13 @@ impl Server {
             let events_path = Path::new(&events_service_path);
             let events_path_buf = events_path.to_path_buf();
 
-            let events_worker =
-                create_events_worker(events_path_buf, import_map_path.clone(), no_module_cache)
-                    .await?;
+            let events_worker = create_events_worker(
+                events_path_buf,
+                import_map_path.clone(),
+                no_module_cache,
+                maybe_events_entrypoint,
+            )
+            .await?;
 
             worker_events_sender = Some(events_worker);
         }
@@ -114,6 +120,7 @@ impl Server {
             import_map_path.clone(),
             no_module_cache,
             user_worker_msgs_tx,
+            maybe_main_entrypoint,
         )
         .await?;
 

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -73,6 +73,11 @@ impl Service<Request<Body>> for WorkerService {
     }
 }
 
+pub struct WorkerEntrypoints {
+    pub main: Option<String>,
+    pub events: Option<String>,
+}
+
 pub struct Server {
     ip: Ipv4Addr,
     port: u16,
@@ -81,6 +86,7 @@ pub struct Server {
 }
 
 impl Server {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         ip: &str,
         port: u16,
@@ -89,10 +95,11 @@ impl Server {
         import_map_path: Option<String>,
         no_module_cache: bool,
         callback_tx: Option<Sender<ServerCodes>>,
-        maybe_main_entrypoint: Option<String>,
-        maybe_events_entrypoint: Option<String>,
+        entrypoints: WorkerEntrypoints,
     ) -> Result<Self, Error> {
         let mut worker_events_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>> = None;
+        let maybe_events_entrypoint = entrypoints.events;
+        let maybe_main_entrypoint = entrypoints.main;
 
         // Create Event Worker
         if let Some(events_service_path) = maybe_events_service_path {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,16 +39,18 @@ fn cli() -> Command {
                         .default_value("9000")
                         .value_parser(value_parser!(u16)),
                 )
-                .arg(arg!(--"main-service" <DIR> "Path to main service directory").default_value("examples/main"))
+                .arg(arg!(--"main-service" <DIR> "Path to main service directory or eszip").default_value("examples/main"))
                 .arg(arg!(--"disable-module-cache" "Disable using module cache").default_value("false").value_parser(FalseyValueParser::new()))
                 .arg(arg!(--"import-map" <Path> "Path to import map file"))
                 .arg(arg!(--"event-worker" <Path> "Path to event worker directory"))
+                .arg(arg!(--"main-entrypoint" <Path> "Path to entrypoint in main service (only for eszips)"))
+                .arg(arg!(--"events-entrypoint" <Path> "Path to entrypoint in events worker (only for eszips)"))
         )
         .subcommand(
             Command::new("bundle")
                 .about("Creates an 'eszip' file that can be executed by the EdgeRuntime. Such file contains all the modules in contained in a single binary.")
                 .arg(arg!(--"output" <DIR> "Path to output eszip file").default_value("bin.eszip"))
-                .arg(arg!(--"entry-point" <Path> "Path to entry point").required(true))
+                .arg(arg!(--"entrypoint" <Path> "Path to entrypoint to bundle as an eszip").required(true))
         )
 }
 
@@ -96,6 +98,10 @@ fn main() -> Result<(), anyhow::Error> {
                     .unwrap();
                 let event_service_manager_path =
                     sub_matches.get_one::<String>("event-worker").cloned();
+                let maybe_main_entrypoint =
+                    sub_matches.get_one::<String>("main-entrypoint").cloned();
+                let maybe_events_entrypoint =
+                    sub_matches.get_one::<String>("events-entrypoint").cloned();
 
                 start_server(
                     ip.as_str(),
@@ -105,6 +111,8 @@ fn main() -> Result<(), anyhow::Error> {
                     import_map_path,
                     no_module_cache,
                     None,
+                    maybe_main_entrypoint,
+                    maybe_events_entrypoint,
                 )
                 .await?;
             }
@@ -112,7 +120,7 @@ fn main() -> Result<(), anyhow::Error> {
                 let output_path = sub_matches.get_one::<String>("output").cloned().unwrap();
 
                 let entry_point_path = sub_matches
-                    .get_one::<String>("entry-point")
+                    .get_one::<String>("entrypoint")
                     .cloned()
                     .unwrap();
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ mod logger;
 
 use anyhow::Error;
 use base::commands::start_server;
+use base::server::WorkerEntrypoints;
 use base::utils::graph_util::{create_eszip_from_graph, create_module_graph_from_path};
 use clap::builder::FalseyValueParser;
 use clap::{arg, crate_version, value_parser, ArgAction, Command};
@@ -111,8 +112,10 @@ fn main() -> Result<(), anyhow::Error> {
                     import_map_path,
                     no_module_cache,
                     None,
-                    maybe_main_entrypoint,
-                    maybe_events_entrypoint,
+                    WorkerEntrypoints {
+                        main: maybe_main_entrypoint,
+                        events: maybe_events_entrypoint,
+                    },
                 )
                 .await?;
             }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 GIT_V_TAG=0.1.1 cargo build && RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start --main-service ./examples/main --event-worker ./examples/event-manager
+#GIT_V_TAG=0.1.1 cargo build && RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start --main-service ./main.eszip --main-entrypoint file:///Users/lakshanperera/workspace/edge-runtime/examples/main/index.ts --event-worker ./event-manager.eszip --events-entrypoint file:///Users/lakshanperera/workspace/edge-runtime/examples/event-manager/index.ts


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added two CLI options `--main-entrypoint` and `--events-entrypoint` to provide entrypoints when eszips are used for main and events workers.