### PR TITLE
fix: include total memory usage in shutdown event

### DIFF
--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -63,14 +63,6 @@ pub enum WorkerEvents {
     Log(LogEvent),
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkerMemoryUsage {
-    pub heap_total: usize,
-    pub heap_used: usize,
-    pub external: usize,
-}
-
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct EventMetadata {
     pub service_path: Option<String>,

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -14,9 +14,10 @@ pub struct BootFailureEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct IsolateMemoryUsed {
-    pub heap_used: usize,
-    pub external_memory: usize,
+pub struct WorkerMemoryUsed {
+    pub total: usize,
+    pub heap: usize,
+    pub external: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -30,7 +31,7 @@ pub enum ShutdownReason {
 pub struct ShutdownEvent {
     pub reason: ShutdownReason,
     pub cpu_time_used: usize,
-    pub memory_used: IsolateMemoryUsed,
+    pub memory_used: WorkerMemoryUsed,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/sb_os/lib.rs
+++ b/crates/sb_os/lib.rs
@@ -1,6 +1,3 @@
-use deno_core::op;
-use deno_core::v8;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub type EnvVars = HashMap<String, String>;

--- a/crates/sb_os/lib.rs
+++ b/crates/sb_os/lib.rs
@@ -5,29 +5,4 @@ use std::collections::HashMap;
 
 pub type EnvVars = HashMap<String, String>;
 
-/// TODO: Clean it up from events.rs // Circular dependency
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkerMemoryUsage {
-    pub heap_total: usize,
-    pub heap_used: usize,
-    pub external: usize,
-}
-
-#[op(v8)]
-pub fn op_runtime_memory_usage(scope: &mut v8::HandleScope) -> WorkerMemoryUsage {
-    let mut s = v8::HeapStatistics::default();
-    scope.get_heap_statistics(&mut s);
-    WorkerMemoryUsage {
-        heap_total: s.total_heap_size(),
-        heap_used: s.used_heap_size(),
-        external: s.external_memory(),
-    }
-}
-
-deno_core::extension!(
-    sb_os,
-    ops = [op_runtime_memory_usage,],
-    esm_entry_point = "ext:sb_os/os.js",
-    esm = ["os.js"]
-);
+deno_core::extension!(sb_os, esm_entry_point = "ext:sb_os/os.js", esm = ["os.js"]);


### PR DESCRIPTION
## What kind of change does this PR introduce?

* removes unused memory usage op
* include total memory usage (heap + external) in shutdown event metadata
