### PR TITLE
fix: update rust docker builder to 1.73

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM rust:1.71.0-bookworm as builder
+FROM rust:1.73.0-bookworm as builder
 ARG TARGETPLATFORM
 ARG GIT_V_VERSION
 RUN apt-get update && apt-get install -y llvm-dev libclang-dev clang cmake


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the rust builder docker image to 1.73
