### PR TITLE
fix: crash when V8 tries to JIT compilation in the PKU-supported environment

### DIFF
--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::server::{Server, ServerCodes, WorkerEntrypoints};
 use anyhow::Error;
+use deno_core::JsRuntime;
 use tokio::sync::mpsc::Sender;
 
 #[allow(clippy::too_many_arguments)]
@@ -13,6 +14,11 @@ pub async fn start_server(
     callback_tx: Option<Sender<ServerCodes>>,
     entrypoints: WorkerEntrypoints,
 ) -> Result<(), Error> {
+    // NOTE(denoland/deno/20495): Due to the new PKU (Memory Protection Keys)
+    // feature introduced in V8 11.6, We need to initialize the V8 platform on
+    // the main thread that spawns V8 isolates.
+    JsRuntime::init_platform(None);
+
     let mut server = Server::new(
         ip,
         port,


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## Description
This PR fixes the segfault when occurred the V8 tries to JIT compilation in running environments that supports PKU(Memory Protection Key; PKeys Userspace) feature.

It should only affect the environment that the PKU feature has enabled. You can check whether your environment supports the PKU feature using the below command:

```bash
lscpu | grep pku

# output
Flags:                              ... xsaveopt arat pku ospke avx512_vnni...
```

Fixes #199 and might be
Resolves #200, resolves #204, resolves #207, resolves #226
