### PR TITLE
fix: write bundle output to stdout

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -169,8 +169,15 @@ fn main() -> Result<(), anyhow::Error> {
                 .await?;
                 let bin = eszip.into_bytes();
 
-                let mut file = File::create(output_path.as_str()).unwrap();
-                file.write_all(&bin).unwrap();
+                if output_path == "-" {
+                    let stdout = std::io::stdout();
+                    let mut handle = stdout.lock();
+
+                    handle.write_all(&bin)?
+                } else {
+                    let mut file = File::create(output_path.as_str())?;
+                    file.write_all(&bin)?
+                }
             }
             Some(("unbundle", sub_matches)) => {
                 let output_path = sub_matches.get_one::<String>("output").cloned().unwrap();


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the option to write eszip bundle output to stdout if output is provided as `-`.