### PR TITLE
refactor: set v8 flags before initialize v8 platform

### DIFF
--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::server::{Server, ServerCodes, WorkerEntrypoints};
 use anyhow::Error;
 use deno_core::JsRuntime;
+use log::error;
 use tokio::sync::mpsc::Sender;
 
 #[allow(clippy::too_many_arguments)]
@@ -14,6 +15,8 @@ pub async fn start_server(
     callback_tx: Option<Sender<ServerCodes>>,
     entrypoints: WorkerEntrypoints,
 ) -> Result<(), Error> {
+    set_v8_flags();
+
     // NOTE(denoland/deno/20495): Due to the new PKU (Memory Protection Keys)
     // feature introduced in V8 11.6, We need to initialize the V8 platform on
     // the main thread that spawns V8 isolates.
@@ -31,4 +34,21 @@ pub async fn start_server(
     )
     .await?;
     server.listen().await
+}
+
+fn set_v8_flags() {
+    let v8_flags = std::env::var("V8_FLAGS").unwrap_or("".to_string());
+    let mut vec = vec![""];
+
+    if v8_flags.is_empty() {
+        return;
+    }
+
+    vec.append(&mut v8_flags.split(' ').collect());
+
+    let ignored = deno_core::v8_set_flags(vec.iter().map(|v| v.to_string()).collect());
+
+    if *ignored.as_slice() != [""] {
+        error!("v8 flags unrecognized {:?}", ignored);
+    }
 }

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -58,20 +58,6 @@ fn get_error_class_name(e: &AnyError) -> &'static str {
     sb_core::errors_rt::get_error_class_name(e).unwrap_or("Error")
 }
 
-fn set_v8_flags() {
-    let v8_flags = std::env::var("V8_FLAGS").unwrap_or("".to_string());
-    let mut vec = vec!["IGNORED"];
-    if v8_flags.is_empty() {
-        return;
-    }
-
-    vec.append(&mut v8_flags.split(' ').collect());
-    error!(
-        "v8 flags unrecognized {:?}",
-        deno_core::v8_set_flags(vec.iter().map(|v| v.to_string()).collect())
-    );
-}
-
 pub struct DenoRuntime {
     pub js_runtime: JsRuntime,
     pub env_vars: HashMap<String, String>, // TODO: does this need to be pub?
@@ -94,8 +80,6 @@ impl DenoRuntime {
             maybe_entrypoint,
             maybe_module_code,
         } = opts;
-
-        set_v8_flags();
 
         let user_agent = "supabase-edge-runtime".to_string();
         let base_dir_path = std::env::current_dir().map(|p| p.join(&service_path))?;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, Refactor

## Description

After #227 the platform is initialized explicitly at the entry point. However, after initializing the platform, it was no longer able to set the v8 flags [\[1\]][1] [\[2\]][2] [\[3\]][3], so it is necessary to adjust the invocation order of the set v8 flag function to avoid v8's static assertion.

[1]: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/flags/flags.cc;l=1074;drc=8e78783dc1f7007bad46d657c9f332614e240fd8;bpv=1;bpt=1
[2]: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/flags/flags.cc;drc=8e78783dc1f7007bad46d657c9f332614e240fd8;l=912
[3]: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/init/v8.cc;l=261;drc=8e78783dc1f7007bad46d657c9f332614e240fd8;bpv=1;bpt=1