### PR TITLE
feat: printing out deno version in command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
  "base",
  "clap 4.3.21",
  "deno_core",
+ "dotenv-build",
  "env_logger 0.10.0",
  "log",
  "sb_graph",
@@ -1444,6 +1445,12 @@ dependencies = [
  "quote 1.0.32",
  "syn 2.0.28",
 ]
+
+[[package]]
+name = "dotenv-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4547f16c17f6051a12cdb8c62b803f94bee6807c74aa7c530b30b737df981fc"
 
 [[package]]
 name = "dprint-swc-ext"

--- a/crates/cli/.env.build
+++ b/crates/cli/.env.build
@@ -1,0 +1,1 @@
+DENO_VERSION="1.37.2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,8 +11,11 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 base = { path = "../base" }
 deno_core = { workspace = true }
-clap = { version = "4.0.29", features = ["cargo"] }
+clap = { version = "4.0.29", features = ["cargo", "string"] }
 env_logger = "0.10.0"
 log = { workspace = true }
 sb_graph = { path = "../sb_graph" }
 tokio.workspace = true
+
+[build-dependencies]
+dotenv-build = { version = "0.1.1" }

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -8,7 +8,6 @@ fn main() {
         filename: Path::new(".env.build"),
         recursive_search: false,
         fail_if_missing_dotenv: true,
-        ..Default::default()
     })
     .unwrap();
 }

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,14 @@
+use std::{env, path::Path};
+
+fn main() {
+    println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
+    println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
+
+    dotenv_build::output(dotenv_build::Config {
+        filename: Path::new(".env.build"),
+        recursive_search: false,
+        fail_if_missing_dotenv: true,
+        ..Default::default()
+    })
+    .unwrap();
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,13 +17,13 @@ use std::sync::Arc;
 fn cli() -> Command {
     Command::new("edge-runtime")
         .about("A server based on Deno runtime, capable of running JavaScript, TypeScript, and WASM services")
-        .version(String::from(format!(
+        .version(format!(
             "{}\ndeno {} ({}, {})",
             crate_version!(),
             env!("DENO_VERSION"),
             env!("PROFILE"),
             env!("TARGET")
-        )))
+        ))
         .arg_required_else_help(true)
         .arg(
             arg!(-v --verbose "Use verbose output")

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,7 +17,13 @@ use std::sync::Arc;
 fn cli() -> Command {
     Command::new("edge-runtime")
         .about("A server based on Deno runtime, capable of running JavaScript, TypeScript, and WASM services")
-        .version(crate_version!())
+        .version(String::from(format!(
+            "{}\ndeno {} ({}, {})",
+            crate_version!(),
+            env!("DENO_VERSION"),
+            env!("PROFILE"),
+            env!("TARGET")
+        )))
         .arg_required_else_help(true)
         .arg(
             arg!(-v --verbose "Use verbose output")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?
```
vscode ➜ /workspaces/edge-runtime $ ./target/debug/edge-runtime -V
edge-runtime 0.1.0
```
## What is the new behavior?
```
vscode ➜ /workspaces/edge-runtime (cli-deno-version) $ ./target/debug/edge-runtime -V
edge-runtime 0.1.0
deno 1.37.2 (debug, aarch64-unknown-linux-gnu)
```

## Additional context

Resolves #236 