### PR TITLE
fix: Identified and fixed a memory leak from `JsRuntime`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUSTY_V8_MIRROR = "https://github.com/nyannyacha/rusty_v8/releases/download"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,8 +984,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.222.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13c81b9ea8462680e7b77088a44fc36390bab3dbfa5a205a285e11b64e0919c"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1218,8 +1217,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf89da1a3e50ff7c89956495b53d9bcad29e1f1b3f3d2bc54cad7155f55419c4"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4053,8 +4051,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.131.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cafa16d0a4288d75925351bb54d06d2e830118ad3fad393947bb11f91b18f3"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.222.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.98.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.131.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#fd51ad55de7f24ac450af31a429a9902e40ad4b1"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5067,7 +5067,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]
@@ -5241,9 +5241,8 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.79.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15561535230812a1db89a696f1f16a12ae6c2c370c6b2241c68d4cb33963faf"
+version = "0.79.2-rokat.2"
+source = "git+https://github.com/nyannyacha/rusty_v8?branch=rokat#886506686112d1b41cc699a5bdd825cbf414b3d5"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.222.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#ce6fb4d31401b8c9c333d999790f04d3ebf91f6f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.98.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#ce6fb4d31401b8c9c333d999790f04d3ebf91f6f"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.131.0"
-source = "git+https://github.com/nyannyacha/deno_core?branch=222#7a458bb373095e79aa744a0daa28624ddf98145b"
+source = "git+https://github.com/nyannyacha/deno_core?branch=222#ce6fb4d31401b8c9c333d999790f04d3ebf91f6f"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5242,7 +5242,7 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "0.79.2-rokat.2"
-source = "git+https://github.com/nyannyacha/rusty_v8?branch=rokat#886506686112d1b41cc699a5bdd825cbf414b3d5"
+source = "git+https://github.com/nyannyacha/rusty_v8?branch=rokat#539b82496ba71cfaea9de9cec5b806370b8d4bb1"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,8 @@ base64 = { version = "=0.13.1" }
 futures = { version = "0.3.28" }
 futures-util = { version = "0.3.28" }
 
+[patch.crates-io]
+deno_core = { git = "https://github.com/nyannyacha/deno_core", branch = "222" }
+
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ futures-util = { version = "0.3.28" }
 
 [patch.crates-io]
 deno_core = { git = "https://github.com/nyannyacha/deno_core", branch = "222" }
+v8 = { git = "https://github.com/nyannyacha/rusty_v8", branch = "rokat" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

This PR fixes the memory leakage from `JsRuntime`.

I've already written some commits to the upstream fork to fix the memory leak problem.

The PR brings in that fork using the cargo patch[^1][^2].

CAVEATS: PR makes `edge-runtime` depend on the my upstream fork. If you have a plan that will manage upstream changes manually, it would make sense for the Supabase team to take my fork to your org repo first.

Resolves #212 

[^1]: https://github.com/nyannyacha/rusty_v8/tree/rokat
[^2]: https://github.com/nyannyacha/deno_core/tree/222

cc @laktek 
😋