### PR TITLE
chore: clippy

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -709,7 +709,7 @@ mod test {
             .as_array()
             .unwrap()
             .to_vec();
-        assert_eq!(loadavg_array.get(0).unwrap().as_f64().unwrap(), 0.0);
+        assert_eq!(loadavg_array.first().unwrap().as_f64().unwrap(), 0.0);
         assert_eq!(loadavg_array.get(1).unwrap().as_f64().unwrap(), 0.0);
         assert_eq!(loadavg_array.get(2).unwrap().as_f64().unwrap(), 0.0);
 
@@ -728,7 +728,7 @@ mod test {
             .unwrap()
             .to_vec();
         assert_eq!(
-            deno_version_array.get(0).unwrap().as_str().unwrap(),
+            deno_version_array.first().unwrap().as_str().unwrap(),
             "supabase-edge-runtime-0.1.0"
         );
         assert_eq!(

--- a/crates/node/ops/crypto/mod.rs
+++ b/crates/node/ops/crypto/mod.rs
@@ -410,16 +410,16 @@ pub fn op_node_verify(
             };
             Ok(match digest_type {
                 "sha224" => VerifyingKey::<sha2::Sha224>::new_with_prefix(key)
-                    .verify_prehash(digest, &signature.to_vec().try_into()?)
+                    .verify_prehash(digest, &signature.to_vec().into())
                     .is_ok(),
                 "sha256" => VerifyingKey::<sha2::Sha256>::new_with_prefix(key)
-                    .verify_prehash(digest, &signature.to_vec().try_into()?)
+                    .verify_prehash(digest, &signature.to_vec().into())
                     .is_ok(),
                 "sha384" => VerifyingKey::<sha2::Sha384>::new_with_prefix(key)
-                    .verify_prehash(digest, &signature.to_vec().try_into()?)
+                    .verify_prehash(digest, &signature.to_vec().into())
                     .is_ok(),
                 "sha512" => VerifyingKey::<sha2::Sha512>::new_with_prefix(key)
-                    .verify_prehash(digest, &signature.to_vec().try_into()?)
+                    .verify_prehash(digest, &signature.to_vec().into())
                     .is_ok(),
                 _ => {
                     return Err(type_error(format!(


### PR DESCRIPTION
## What kind of change does this PR introduce?

make clippy happy about `get_first` and `unnecessary_fallible_conversions` warnings

## What is the current behavior?
```
error: use of a fallible conversion when an infallible one could be used
   --> crates/node/ops/crypto/mod.rs:413:65
    |
413 |                     .verify_prehash(digest, &signature.to_vec().try_into()?)
    |                                                                 ^^^^^^^^ help: use: `into`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
```

