### PR TITLE
feat: allow creating an inspector session if using `oneshot` policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "enum-as-inner 0.6.0",
  "eszip",
  "event_worker",
+ "fastwebsockets",
  "flume",
  "futures-util",
  "http 0.2.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
  "deno_core",
  "deno_net",
  "deno_tls",
- "fastwebsockets",
+ "fastwebsockets 0.6.0",
  "h2 0.4.2",
  "http 1.0.0",
  "http-body-util",
@@ -1994,6 +1994,23 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastwebsockets"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6185b6dc9dddc4db0dedd2e213047e93bcbf7a0fb092abc4c4e4f3195efdb4"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.28",
+ "pin-project",
+ "rand",
+ "sha1",
+ "simdutf8",
+ "thiserror",
+ "tokio",
+ "utf-8",
+]
 
 [[package]]
 name = "fastwebsockets"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
  "enum-as-inner 0.6.0",
  "eszip",
  "event_worker",
- "fastwebsockets",
+ "fastwebsockets 0.4.4",
  "flume",
  "futures-util",
  "http 0.2.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ deno_webstorage = { version = "0.131.0" }
 enum-as-inner = "0.6.0"
 serde = { version = "1.0.149", features = ["derive"] }
 hyper = "0.14.26"
-tokio = { version = "1.28.1", features = ["full"] }
+tokio = { version = "1.35", features = ["full"] }
 bytes = { version = "1.4.0" }
 once_cell = "1.17.1"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ base64 = "0.21.4"
 futures = { version = "0.3.28" }
 futures-util = { version = "0.3.28" }
 ctor = { version = "0.2.6" }
+fastwebsockets = { version = "0.4.4", features = ["upgrade"] }
 percent-encoding = "=2.3.0"
 scopeguard = { version = "1.2.0" }
 

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -63,6 +63,7 @@ pin-project = { version = "1.1.3" }
 ctor = { workspace = true }
 deno_canvas.workspace = true
 deno_webgpu.workspace = true
+fastwebsockets = { workspace = true }
 sb_ai = { version = "0.1.0", path = "../sb_ai" }
 
 [dev-dependencies]

--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::{
     inspector_server::Inspector,
     rt_worker::{worker_ctx::TerminationToken, worker_pool::WorkerPoolPolicy},
-    server::{Server, ServerHealth, WorkerEntrypoints},
+    server::{Server, ServerFlags, ServerHealth, WorkerEntrypoints},
     InspectorOption,
 };
 use anyhow::Error;
@@ -15,7 +15,7 @@ pub async fn start_server(
     event_worker_path: Option<String>,
     user_worker_policy: Option<WorkerPoolPolicy>,
     import_map_path: Option<String>,
-    no_module_cache: bool,
+    flags: ServerFlags,
     callback_tx: Option<Sender<ServerHealth>>,
     entrypoints: WorkerEntrypoints,
     termination_token: Option<TerminationToken>,
@@ -28,7 +28,7 @@ pub async fn start_server(
         event_worker_path,
         user_worker_policy,
         import_map_path,
-        no_module_cache,
+        flags,
         callback_tx,
         entrypoints,
         termination_token,

--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -1,6 +1,8 @@
 use crate::{
+    inspector_server::Inspector,
     rt_worker::{worker_ctx::TerminationToken, worker_pool::WorkerPoolPolicy},
     server::{Server, ServerHealth, WorkerEntrypoints},
+    InspectorOption,
 };
 use anyhow::Error;
 use tokio::sync::mpsc::Sender;
@@ -17,6 +19,7 @@ pub async fn start_server(
     callback_tx: Option<Sender<ServerHealth>>,
     entrypoints: WorkerEntrypoints,
     termination_token: Option<TerminationToken>,
+    inspector_option: Option<InspectorOption>,
 ) -> Result<(), Error> {
     let mut server = Server::new(
         ip,
@@ -29,6 +32,7 @@ pub async fn start_server(
         callback_tx,
         entrypoints,
         termination_token,
+        inspector_option.map(Inspector::from_option),
     )
     .await?;
 

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -810,7 +810,7 @@ mod test {
     ) -> DenoRuntime {
         let (worker_pool_tx, _) = mpsc::unbounded_channel::<UserWorkerMsgs>();
 
-        let mut rt = DenoRuntime::new(WorkerContextInitOpts {
+        DenoRuntime::new(WorkerContextInitOpts {
             service_path: path.unwrap_or(PathBuf::from("./test_cases/main")),
             no_module_cache: false,
             import_map_path: None,
@@ -834,9 +834,7 @@ mod test {
             None,
         )
         .await
-        .unwrap();
-
-        rt
+        .unwrap()
     }
 
     // Main Runtime should have access to `EdgeRuntime`

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -483,7 +483,7 @@ impl DenoRuntime {
         let mut current_cpu_time_ns = 0i64;
         let mut accumulated_cpu_time_ns = 0i64;
 
-        let poll_result = poll_fn(|cx| {
+        let poll_result = poll_fn(|cx| unsafe {
             // INVARIANT: Only can steal current task by other threads when LIFO
             // task scheduler heuristic disabled. Turning off the heuristic is
             // unstable now, so it's not considered.
@@ -654,26 +654,30 @@ mod test {
     #[serial]
     async fn test_module_code_no_eszip() {
         let (worker_pool_tx, _) = mpsc::unbounded_channel::<UserWorkerMsgs>();
-        let mut rt = DenoRuntime::new(WorkerContextInitOpts {
-            service_path: PathBuf::from("./test_cases/"),
-            no_module_cache: false,
-            import_map_path: None,
-            env_vars: Default::default(),
-            events_rx: None,
-            timing: None,
-            maybe_eszip: None,
-            maybe_entrypoint: None,
-            maybe_module_code: Some(FastString::from(String::from(
-                "Deno.serve((req) => new Response('Hello World'));",
-            ))),
-            conf: {
-                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                    worker_pool_tx,
-                    shared_metric_src: None,
-                    event_worker_metric_src: None,
-                })
+
+        DenoRuntime::new(
+            WorkerContextInitOpts {
+                service_path: PathBuf::from("./test_cases/"),
+                no_module_cache: false,
+                import_map_path: None,
+                env_vars: Default::default(),
+                events_rx: None,
+                timing: None,
+                maybe_eszip: None,
+                maybe_entrypoint: None,
+                maybe_module_code: Some(FastString::from(String::from(
+                    "Deno.serve((req) => new Response('Hello World'));",
+                ))),
+                conf: {
+                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                        worker_pool_tx,
+                        shared_metric_src: None,
+                        event_worker_metric_src: None,
+                    })
+                },
             },
-        }, None)
+            None,
+        )
         .await
         .expect("It should not panic");
     }
@@ -695,24 +699,27 @@ mod test {
 
         let eszip_code = bin_eszip.into_bytes();
 
-        let runtime = DenoRuntime::new(WorkerContextInitOpts {
-            service_path: PathBuf::from("./test_cases/"),
-            no_module_cache: false,
-            import_map_path: None,
-            env_vars: Default::default(),
-            events_rx: None,
-            timing: None,
-            maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
-            maybe_entrypoint: None,
-            maybe_module_code: None,
-            conf: {
-                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                    worker_pool_tx,
-                    shared_metric_src: None,
-                    event_worker_metric_src: None,
-                })
+        let runtime = DenoRuntime::new(
+            WorkerContextInitOpts {
+                service_path: PathBuf::from("./test_cases/"),
+                no_module_cache: false,
+                import_map_path: None,
+                env_vars: Default::default(),
+                events_rx: None,
+                timing: None,
+                maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
+                maybe_entrypoint: None,
+                maybe_module_code: None,
+                conf: {
+                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                        worker_pool_tx,
+                        shared_metric_src: None,
+                        event_worker_metric_src: None,
+                    })
+                },
             },
-        }, None)
+            None,
+        )
         .await;
 
         let mut rt = runtime.unwrap();
@@ -756,24 +763,27 @@ mod test {
 
         let eszip_code = binary_eszip.into_bytes();
 
-        let runtime = DenoRuntime::new(WorkerContextInitOpts {
-            service_path,
-            no_module_cache: false,
-            import_map_path: None,
-            env_vars: Default::default(),
-            events_rx: None,
-            timing: None,
-            maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
-            maybe_entrypoint: None,
-            maybe_module_code: None,
-            conf: {
-                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                    worker_pool_tx,
-                    shared_metric_src: None,
-                    event_worker_metric_src: None,
-                })
+        let runtime = DenoRuntime::new(
+            WorkerContextInitOpts {
+                service_path,
+                no_module_cache: false,
+                import_map_path: None,
+                env_vars: Default::default(),
+                events_rx: None,
+                timing: None,
+                maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
+                maybe_entrypoint: None,
+                maybe_module_code: None,
+                conf: {
+                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                        worker_pool_tx,
+                        shared_metric_src: None,
+                        event_worker_metric_src: None,
+                    })
+                },
             },
-        }, None)
+            None,
+        )
         .await;
 
         let mut rt = runtime.unwrap();
@@ -810,26 +820,28 @@ mod test {
     ) -> DenoRuntime {
         let (worker_pool_tx, _) = mpsc::unbounded_channel::<UserWorkerMsgs>();
 
-        DenoRuntime::new(WorkerContextInitOpts {
-            service_path: path.unwrap_or(PathBuf::from("./test_cases/main")),
-            no_module_cache: false,
-            import_map_path: None,
-            env_vars: env_vars.unwrap_or_default(),
-            events_rx: None,
-            timing: None,
-            maybe_eszip: None,
-            maybe_entrypoint: None,
-            maybe_module_code: None,
-            conf: {
-                if let Some(uc) = user_conf {
-                    uc
-                } else {
-                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                        worker_pool_tx,
-                        shared_metric_src: None,
-                        event_worker_metric_src: None,
-                    })
-                }
+        DenoRuntime::new(
+            WorkerContextInitOpts {
+                service_path: path.unwrap_or(PathBuf::from("./test_cases/main")),
+                no_module_cache: false,
+                import_map_path: None,
+                env_vars: env_vars.unwrap_or_default(),
+                events_rx: None,
+                timing: None,
+                maybe_eszip: None,
+                maybe_entrypoint: None,
+                maybe_module_code: None,
+                conf: {
+                    if let Some(uc) = user_conf {
+                        uc
+                    } else {
+                        WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                            worker_pool_tx,
+                            shared_metric_src: None,
+                            event_worker_metric_src: None,
+                        })
+                    }
+                },
             },
             None,
         )

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -494,10 +494,11 @@ impl DenoRuntime {
             let get_current_cpu_time_ns_fn =
                 || get_thread_time().context("can't get current thread time");
 
-            unsafe { js_runtime.v8_isolate().enter() };
-            let mut js_runtime = scopeguard::guard(&mut js_runtime, |it| unsafe {
+            let mut js_runtime = scopeguard::guard(&mut self.js_runtime, |it| unsafe {
                 it.v8_isolate().exit();
             });
+
+            unsafe { js_runtime.v8_isolate().enter() };
 
             send_cpu_metrics_fn(CPUUsageMetrics::Enter(thread_id));
 

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -448,7 +448,7 @@ impl DenoRuntime {
             if inspector.is_some() {
                 self.wait_for_inspector_session();
 
-                if self.is_need_inspect_disconnect.is_raised() {
+                if self.is_termination_requested.is_raised() {
                     unsafe { self.js_runtime.v8_isolate().exit() };
                     return (Ok(()), 0i64);
                 }

--- a/crates/base/src/inspector_server.rs
+++ b/crates/base/src/inspector_server.rs
@@ -1,0 +1,484 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// Below code bits are cherry-picked from
+// `https://github.com/denoland/deno/blob/v1.37.2/runtime/inspector_server.rs`.
+
+// Alias for the future `!` type.
+use core::convert::Infallible as Never;
+use deno_core::futures::channel::mpsc;
+use deno_core::futures::channel::mpsc::UnboundedReceiver;
+use deno_core::futures::channel::mpsc::UnboundedSender;
+use deno_core::futures::channel::oneshot;
+use deno_core::futures::future;
+use deno_core::futures::future::Future;
+use deno_core::futures::prelude::*;
+use deno_core::futures::select;
+use deno_core::futures::stream::StreamExt;
+use deno_core::futures::task::Poll;
+use deno_core::serde_json;
+use deno_core::serde_json::json;
+use deno_core::serde_json::Value;
+use deno_core::unsync::spawn;
+use deno_core::url::Url;
+use deno_core::InspectorMsg;
+use deno_core::InspectorSessionProxy;
+use deno_core::JsRuntime;
+use enum_as_inner::EnumAsInner;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::WebSocket;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::pin::pin;
+use std::process;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::thread;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, EnumAsInner)]
+pub enum InspectorOption {
+    Inspect(SocketAddr),
+    WithBreak(SocketAddr),
+    WithWait(SocketAddr),
+}
+
+impl InspectorOption {
+    fn socket_addr(&self) -> SocketAddr {
+        match self {
+            Self::Inspect(addr) | Self::WithBreak(addr) | Self::WithWait(addr) => *addr,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Inspector {
+    pub option: InspectorOption,
+    pub server: Arc<InspectorServer>,
+}
+
+impl Inspector {
+    pub fn from_option(option: InspectorOption) -> Self {
+        const INSPECTOR_NAME: &str = "sb-edge-runtime-inspector";
+
+        Self {
+            option,
+            server: Arc::new(InspectorServer::new(option.socket_addr(), INSPECTOR_NAME)),
+        }
+    }
+
+    pub fn should_wait_for_session(&self) -> bool {
+        matches!(
+            self.option,
+            InspectorOption::WithBreak(..) | InspectorOption::WithWait(..)
+        )
+    }
+}
+
+/// Websocket server that is used to proxy connections from
+/// devtools to the inspector.
+pub struct InspectorServer {
+    pub host: SocketAddr,
+
+    _register_inspector_tx: UnboundedSender<InspectorInfo>,
+    shutdown_server_tx: Option<oneshot::Sender<()>>,
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl InspectorServer {
+    pub fn new(host: SocketAddr, name: &'static str) -> Self {
+        let (register_inspector_tx, register_inspector_rx) = mpsc::unbounded::<InspectorInfo>();
+
+        let (shutdown_server_tx, shutdown_server_rx) = oneshot::channel();
+
+        let thread_handle = thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .unwrap();
+
+            let local = tokio::task::LocalSet::new();
+            local.block_on(
+                &rt,
+                server(host, register_inspector_rx, shutdown_server_rx, name),
+            )
+        });
+
+        Self {
+            host,
+            _register_inspector_tx: register_inspector_tx,
+            shutdown_server_tx: Some(shutdown_server_tx),
+            thread_handle: Some(thread_handle),
+        }
+    }
+
+    pub fn register_inspector(
+        &self,
+        module_url: String,
+        js_runtime: &mut JsRuntime,
+        wait_for_session: bool,
+    ) {
+        let inspector_rc = js_runtime.inspector();
+        let mut inspector = inspector_rc.borrow_mut();
+        let session_sender = inspector.get_session_sender();
+        let deregister_rx = inspector.add_deregister_handler();
+        let info = InspectorInfo::new(
+            self.host,
+            session_sender,
+            deregister_rx,
+            module_url,
+            wait_for_session,
+        );
+        self._register_inspector_tx.unbounded_send(info).unwrap();
+    }
+}
+
+impl Drop for InspectorServer {
+    fn drop(&mut self) {
+        if let Some(shutdown_server_tx) = self.shutdown_server_tx.take() {
+            shutdown_server_tx
+                .send(())
+                .expect("unable to send shutdown signal");
+        }
+
+        if let Some(thread_handle) = self.thread_handle.take() {
+            thread_handle.join().expect("unable to join thread");
+        }
+    }
+}
+
+// Needed so hyper can use non Send futures
+#[derive(Clone)]
+struct LocalExecutor;
+
+impl<Fut> hyper::rt::Executor<Fut> for LocalExecutor
+where
+    Fut: Future + 'static,
+    Fut::Output: 'static,
+{
+    fn execute(&self, fut: Fut) {
+        deno_core::unsync::spawn(fut);
+    }
+}
+
+fn handle_ws_request(
+    req: http::Request<hyper::Body>,
+    inspector_map_rc: Rc<RefCell<HashMap<Uuid, InspectorInfo>>>,
+) -> http::Result<http::Response<hyper::Body>> {
+    let (parts, body) = req.into_parts();
+    let req = http::Request::from_parts(parts, ());
+
+    let maybe_uuid = req
+        .uri()
+        .path()
+        .strip_prefix("/ws/")
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    if maybe_uuid.is_none() {
+        return http::Response::builder()
+            .status(http::StatusCode::BAD_REQUEST)
+            .body("Malformed inspector UUID".into());
+    }
+
+    // run in a block to not hold borrow to `inspector_map` for too long
+    let new_session_tx = {
+        let inspector_map = inspector_map_rc.borrow();
+        let maybe_inspector_info = inspector_map.get(&maybe_uuid.unwrap());
+
+        if maybe_inspector_info.is_none() {
+            return http::Response::builder()
+                .status(http::StatusCode::NOT_FOUND)
+                .body("Invalid inspector UUID".into());
+        }
+
+        let info = maybe_inspector_info.unwrap();
+        info.new_session_tx.clone()
+    };
+    let (parts, _) = req.into_parts();
+    let mut req = http::Request::from_parts(parts, body);
+
+    let (resp, fut) = match fastwebsockets::upgrade::upgrade(&mut req) {
+        Ok(e) => e,
+        _ => {
+            return http::Response::builder()
+                .status(http::StatusCode::BAD_REQUEST)
+                .body("Not a valid Websocket Request".into());
+        }
+    };
+
+    // spawn a task that will wait for websocket connection and then pump messages between
+    // the socket and inspector proxy
+    spawn(async move {
+        let websocket = if let Ok(w) = fut.await {
+            w
+        } else {
+            eprintln!("Inspector server failed to upgrade to WS connection");
+            return;
+        };
+
+        // The 'outbound' channel carries messages sent to the websocket.
+        let (outbound_tx, outbound_rx) = mpsc::unbounded();
+        // The 'inbound' channel carries messages received from the websocket.
+        let (inbound_tx, inbound_rx) = mpsc::unbounded();
+
+        let inspector_session_proxy = InspectorSessionProxy {
+            tx: outbound_tx,
+            rx: inbound_rx,
+        };
+
+        eprintln!("Debugger session started.");
+        let _ = new_session_tx.unbounded_send(inspector_session_proxy);
+        pump_websocket_messages(websocket, inbound_tx, outbound_rx).await;
+    });
+
+    Ok(resp)
+}
+
+fn handle_json_request(
+    inspector_map: Rc<RefCell<HashMap<Uuid, InspectorInfo>>>,
+    host: Option<String>,
+) -> http::Result<http::Response<hyper::Body>> {
+    let data = inspector_map
+        .borrow()
+        .values()
+        .map(move |info| info.get_json_metadata(&host))
+        .collect::<Vec<_>>();
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&data).unwrap().into())
+}
+
+fn handle_json_version_request(
+    version_response: Value,
+) -> http::Result<http::Response<hyper::Body>> {
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&version_response).unwrap().into())
+}
+
+async fn server(
+    host: SocketAddr,
+    register_inspector_rx: UnboundedReceiver<InspectorInfo>,
+    shutdown_server_rx: oneshot::Receiver<()>,
+    name: &str,
+) {
+    let inspector_map_ = Rc::new(RefCell::new(HashMap::<Uuid, InspectorInfo>::new()));
+
+    let inspector_map = Rc::clone(&inspector_map_);
+    let mut register_inspector_handler = pin!(register_inspector_rx
+        .map(|info| {
+            eprintln!(
+                "Debugger listening on {}",
+                info.get_websocket_debugger_url(&info.host.to_string())
+            );
+            eprintln!("Visit chrome://inspect to connect to the debugger.");
+            if info.wait_for_session {
+                eprintln!("Worker is waiting for debugger to connect.");
+            }
+            if inspector_map.borrow_mut().insert(info.uuid, info).is_some() {
+                panic!("Inspector UUID already in map");
+            }
+        })
+        .collect::<()>());
+
+    let inspector_map = Rc::clone(&inspector_map_);
+    let mut deregister_inspector_handler = pin!(future::poll_fn(|cx| {
+        inspector_map
+            .borrow_mut()
+            .retain(|_, info| info.deregister_rx.poll_unpin(cx) == Poll::Pending);
+        Poll::<Never>::Pending
+    })
+    .fuse());
+
+    let json_version_response = json!({
+        "Browser": name,
+        "Protocol-Version": "1.3",
+        "V8-Version": deno_core::v8_version(),
+    });
+
+    let make_svc = hyper::service::make_service_fn(|_| {
+        let inspector_map = Rc::clone(&inspector_map_);
+        let json_version_response = json_version_response.clone();
+
+        future::ok::<_, Infallible>(hyper::service::service_fn(
+            move |req: http::Request<hyper::Body>| {
+                future::ready({
+                    // If the host header can make a valid URL, use it
+                    let host = req
+                        .headers()
+                        .get("host")
+                        .and_then(|host| host.to_str().ok())
+                        .and_then(|host| Url::parse(&format!("http://{host}")).ok())
+                        .and_then(|url| match (url.host(), url.port()) {
+                            (Some(host), Some(port)) => Some(format!("{host}:{port}")),
+                            (Some(host), None) => Some(format!("{host}")),
+                            _ => None,
+                        });
+                    match (req.method(), req.uri().path()) {
+                        (&http::Method::GET, path) if path.starts_with("/ws/") => {
+                            handle_ws_request(req, Rc::clone(&inspector_map))
+                        }
+                        (&http::Method::GET, "/json/version") => {
+                            handle_json_version_request(json_version_response.clone())
+                        }
+                        (&http::Method::GET, "/json") => {
+                            handle_json_request(Rc::clone(&inspector_map), host)
+                        }
+                        (&http::Method::GET, "/json/list") => {
+                            handle_json_request(Rc::clone(&inspector_map), host)
+                        }
+                        _ => http::Response::builder()
+                            .status(http::StatusCode::NOT_FOUND)
+                            .body("Not Found".into()),
+                    }
+                })
+            },
+        ))
+    });
+
+    // Create the server manually so it can use the Local Executor
+    let mut server_handler = pin!(hyper::server::Builder::new(
+        hyper::server::conn::AddrIncoming::bind(&host).unwrap_or_else(|e| {
+            eprintln!("Cannot start inspector server: {e}.");
+            process::exit(1);
+        }),
+        hyper::server::conn::Http::new().with_executor(LocalExecutor),
+    )
+    .serve(make_svc)
+    .with_graceful_shutdown(async {
+        shutdown_server_rx.await.ok();
+    })
+    .unwrap_or_else(|err| {
+        eprintln!("Cannot start inspector server: {err}.");
+        process::exit(1);
+    })
+    .fuse());
+
+    select! {
+      _ = register_inspector_handler => {},
+      _ = deregister_inspector_handler => unreachable!(),
+      _ = server_handler => {},
+    }
+}
+
+/// The pump future takes care of forwarding messages between the websocket
+/// and channels. It resolves when either side disconnects, ignoring any
+/// errors.
+///
+/// The future proxies messages sent and received on a warp WebSocket
+/// to a UnboundedSender/UnboundedReceiver pair. We need these "unbounded" channel ends to sidestep
+/// Tokio's task budget, which causes issues when JsRuntimeInspector::poll_sessions()
+/// needs to block the thread because JavaScript execution is paused.
+///
+/// This works because UnboundedSender/UnboundedReceiver are implemented in the
+/// 'futures' crate, therefore they can't participate in Tokio's cooperative
+/// task yielding.
+async fn pump_websocket_messages(
+    mut websocket: WebSocket<hyper::upgrade::Upgraded>,
+    inbound_tx: UnboundedSender<String>,
+    mut outbound_rx: UnboundedReceiver<InspectorMsg>,
+) {
+    'pump: loop {
+        tokio::select! {
+            Some(msg) = outbound_rx.next() => {
+                let msg = Frame::text(msg.content.into_bytes().into());
+                let _ = websocket.write_frame(msg).await;
+            }
+            Ok(msg) = websocket.read_frame() => {
+                match msg.opcode {
+                    OpCode::Text => {
+                        if let Ok(s) = String::from_utf8(msg.payload.to_vec()) {
+                          let _ = inbound_tx.unbounded_send(s);
+                        }
+                    }
+                    OpCode::Close => {
+                        // Users don't care if there was an error coming from debugger,
+                        // just about the fact that debugger did disconnect.
+                        eprintln!("Debugger session ended");
+                        break 'pump;
+                    }
+                    _ => {
+                        // Ignore other messages.
+                    }
+                }
+            }
+            else => {
+              break 'pump;
+            }
+        }
+    }
+}
+
+/// Inspector information that is sent from the isolate thread to the server
+/// thread when a new inspector is created.
+pub struct InspectorInfo {
+    pub host: SocketAddr,
+    pub uuid: Uuid,
+    pub thread_name: Option<String>,
+    pub new_session_tx: UnboundedSender<InspectorSessionProxy>,
+    pub deregister_rx: oneshot::Receiver<()>,
+    pub url: String,
+    pub wait_for_session: bool,
+}
+
+impl InspectorInfo {
+    pub fn new(
+        host: SocketAddr,
+        new_session_tx: mpsc::UnboundedSender<InspectorSessionProxy>,
+        deregister_rx: oneshot::Receiver<()>,
+        url: String,
+        wait_for_session: bool,
+    ) -> Self {
+        Self {
+            host,
+            uuid: Uuid::new_v4(),
+            thread_name: thread::current().name().map(|n| n.to_owned()),
+            new_session_tx,
+            deregister_rx,
+            url,
+            wait_for_session,
+        }
+    }
+
+    fn get_json_metadata(&self, host: &Option<String>) -> Value {
+        let host_listen = format!("{}", self.host);
+        let host = host.as_ref().unwrap_or(&host_listen);
+        json!({
+          "description": "EdgeRuntime",
+          "devtoolsFrontendUrl": self.get_frontend_url(host),
+          "faviconUrl": "https://supabase.com/favicon/favicon.ico",
+          "id": self.uuid.to_string(),
+          "title": self.get_title(),
+          "type": "node",
+          "url": self.url.to_string(),
+          "webSocketDebuggerUrl": self.get_websocket_debugger_url(host),
+        })
+    }
+
+    pub fn get_websocket_debugger_url(&self, host: &str) -> String {
+        format!("ws://{}/ws/{}", host, &self.uuid)
+    }
+
+    fn get_frontend_url(&self, host: &str) -> String {
+        format!(
+            "devtools://devtools/bundled/js_app.html?ws={}/ws/{}&experiments=true&v8only=true",
+            host, &self.uuid
+        )
+    }
+
+    fn get_title(&self) -> String {
+        format!(
+            "EdgeRuntime{} [pid: {}]",
+            self.thread_name
+                .as_ref()
+                .map(|n| format!(" - {n}"))
+                .unwrap_or_default(),
+            process::id(),
+        )
+    }
+}

--- a/crates/base/src/inspector_server.rs
+++ b/crates/base/src/inspector_server.rs
@@ -47,7 +47,7 @@ pub enum InspectorOption {
 }
 
 impl InspectorOption {
-    fn socket_addr(&self) -> SocketAddr {
+    pub fn socket_addr(&self) -> SocketAddr {
         match self {
             Self::Inspect(addr) | Self::WithBreak(addr) | Self::WithWait(addr) => *addr,
         }

--- a/crates/base/src/inspector_server.rs
+++ b/crates/base/src/inspector_server.rs
@@ -419,7 +419,7 @@ async fn pump_websocket_messages(
                     }
 
                     Err(err) => {
-                        eprintln!("Debugger session ended: {}", err.to_string());
+                        eprintln!("Debugger session ended: {}", err);
                         break 'pump;
                     }
                 }

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -7,3 +7,7 @@ pub mod rt_worker;
 pub mod server;
 pub mod snapshot;
 pub mod utils;
+
+mod inspector_server;
+
+pub use inspector_server::InspectorOption;

--- a/crates/base/src/macros/test_macros.rs
+++ b/crates/base/src/macros/test_macros.rs
@@ -32,7 +32,8 @@ macro_rules! integration_test {
                     main: None,
                     events: None,
                 },
-                integration_test!(@term $(, $termination_token)?)
+                integration_test!(@term $(, $termination_token)?),
+                None
             ) => {
                 panic!("This one should not end first");
             }

--- a/crates/base/src/macros/test_macros.rs
+++ b/crates/base/src/macros/test_macros.rs
@@ -26,7 +26,7 @@ macro_rules! integration_test {
                 None,
                 $shot_policy,
                 $import_map,
-                false,
+                $crate::server::ServerFlags::default(),
                 Some(tx.clone()),
                 $crate::server::WorkerEntrypoints {
                     main: None,

--- a/crates/base/src/rt_worker/implementation/default_handler.rs
+++ b/crates/base/src/rt_worker/implementation/default_handler.rs
@@ -16,16 +16,16 @@ impl WorkerHandler for Worker {
         }))
     }
 
-    fn handle_creation(
+    fn handle_creation<'r>(
         &self,
-        mut created_rt: DenoRuntime,
+        created_rt: &'r mut DenoRuntime,
         unix_stream_rx: UnboundedReceiver<UnixStreamEntry>,
         termination_event_rx: Receiver<WorkerEvents>,
         maybe_cpu_usage_metrics_tx: Option<UnboundedSender<CPUUsageMetrics>>,
         name: Option<String>,
-    ) -> HandleCreationType {
+    ) -> HandleCreationType<'r> {
         let run_worker_rt = async move {
-            let result = match created_rt
+            match created_rt
                 .run(unix_stream_rx, maybe_cpu_usage_metrics_tx, name)
                 .await
             {
@@ -48,14 +48,7 @@ impl WorkerHandler for Worker {
                     }
                 }
                 (Ok(()), _) => Ok(WorkerEvents::EventLoopCompleted(PseudoEvent {})),
-            };
-
-            unsafe {
-                created_rt.js_runtime.v8_isolate().enter();
             }
-
-            drop(created_rt);
-            result
         };
 
         Box::pin(run_worker_rt)

--- a/crates/base/src/rt_worker/supervisor/mod.rs
+++ b/crates/base/src/rt_worker/supervisor/mod.rs
@@ -13,6 +13,7 @@ use tokio::sync::{
     mpsc::{self, UnboundedReceiver},
     oneshot,
 };
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use super::{worker_ctx::TerminationToken, worker_pool::SupervisorPolicy};
@@ -112,6 +113,11 @@ impl CPUTimerParam {
     }
 }
 
+pub struct Tokens {
+    pub termination: Option<TerminationToken>,
+    pub supervise: CancellationToken,
+}
+
 pub struct Arguments {
     pub key: Uuid,
     pub runtime_opts: UserWorkerRuntimeOpts,
@@ -125,7 +131,7 @@ pub struct Arguments {
     pub isolate_memory_usage_tx: oneshot::Sender<IsolateMemoryStats>,
     pub thread_safe_handle: IsolateHandle,
     pub waker: Arc<AtomicWaker>,
-    pub termination_token: Option<TerminationToken>,
+    pub tokens: Tokens,
 }
 
 pub struct CPUUsage {

--- a/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
+++ b/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
@@ -9,7 +9,7 @@ use sb_workers::context::{Timing, TimingStatus, UserWorkerMsgs};
 use tokio::time::Instant;
 
 use crate::rt_worker::supervisor::{
-    handle_interrupt, wait_cpu_alarm, CPUUsage, CPUUsageMetrics, IsolateInterruptData,
+    handle_interrupt, wait_cpu_alarm, CPUUsage, CPUUsageMetrics, IsolateInterruptData, Tokens,
 };
 
 use super::Arguments;
@@ -26,7 +26,10 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
         pool_msg_tx,
         isolate_memory_usage_tx,
         thread_safe_handle,
-        termination_token,
+        tokens: Tokens {
+            termination,
+            supervise,
+        },
         ..
     } = args;
 
@@ -62,8 +65,12 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
 
     loop {
         tokio::select! {
+            _ = supervise.cancelled() => {
+                return (ShutdownReason::TerminationRequested, cpu_usage_ms);
+            }
+
             _ = async {
-                match termination_token.as_ref() {
+                match termination.as_ref() {
                     Some(token) => token.inbound.cancelled().await,
                     None => pending().await,
                 }

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -1,5 +1,6 @@
 use crate::deno_runtime::DenoRuntime;
 use crate::inspector_server::Inspector;
+use crate::rt_worker::supervisor;
 use crate::rt_worker::utils::{get_event_metadata, parse_worker_conf};
 use crate::rt_worker::worker_ctx::create_supervisor;
 use crate::utils::send_event_if_event_worker_available;

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -43,19 +43,19 @@ pub struct Worker {
     pub worker_name: String,
 }
 
-pub type HandleCreationType = Pin<Box<dyn Future<Output = Result<WorkerEvents, Error>>>>;
+pub type HandleCreationType<'r> = Pin<Box<dyn Future<Output = Result<WorkerEvents, Error>> + 'r>>;
 pub type UnixStreamEntry = (UnixStream, Option<watch::Receiver<ConnSync>>);
 
 pub trait WorkerHandler: Send {
     fn handle_error(&self, error: Error) -> Result<WorkerEvents, Error>;
-    fn handle_creation(
+    fn handle_creation<'r>(
         &self,
-        created_rt: DenoRuntime,
+        created_rt: &'r mut DenoRuntime,
         unix_stream_rx: UnboundedReceiver<UnixStreamEntry>,
         termination_event_rx: Receiver<WorkerEvents>,
         maybe_cpu_metrics_tx: Option<UnboundedSender<CPUUsageMetrics>>,
         name: Option<String>,
-    ) -> HandleCreationType;
+    ) -> HandleCreationType<'r>;
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -269,9 +269,8 @@ impl Worker {
                         if let Some(token) = termination_token.as_ref() {
                             if !worker_kind.is_user_worker() {
                                 let _ = termination_fut.await;
+                                token.outbound.cancel();
                             }
-
-                            token.outbound.cancel();
                         }
 
                         result

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -306,10 +306,13 @@ pub fn create_supervisor(
 
                                 need_inspect_disconnect.raise();
 
-                                if let Err(_) = session_tx.unbounded_send(InspectorSessionProxy {
-                                    tx: outbound_tx,
-                                    rx: inbound_rx,
-                                }) {
+                                if session_tx
+                                    .unbounded_send(InspectorSessionProxy {
+                                        tx: outbound_tx,
+                                        rx: inbound_rx,
+                                    })
+                                    .is_err()
+                                {
                                     return;
                                 }
 

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -363,9 +363,8 @@ pub fn create_supervisor(
                     .await
                     .unwrap();
             } else {
-				is_termination_requested.raise();
-			}
-
+                is_termination_requested.raise();
+            }
 
             // NOTE: If we issue a hard CPU time limit, It's OK because it is
             // still possible the worker's context is in the v8 event loop. The

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -216,7 +216,7 @@ pub fn create_supervisor(
                 .inspector()
                 .borrow_mut()
                 .get_session_sender(),
-            worker_runtime.is_need_inspect_disconnect.clone(),
+            worker_runtime.is_termination_requested.clone(),
             worker_runtime.is_terminated.clone(),
         )
     });

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -586,6 +586,7 @@ pub async fn create_main_worker(
     runtime_opts: MainWorkerRuntimeOpts,
     maybe_entrypoint: Option<String>,
     termination_token: Option<TerminationToken>,
+    inspector: Option<Inspector>,
 ) -> Result<mpsc::UnboundedSender<WorkerRequestMsg>, Error> {
     let mut service_path = main_worker_path.clone();
     let mut maybe_eszip = None;
@@ -610,7 +611,7 @@ pub async fn create_main_worker(
             env_vars: std::env::vars().collect(),
         },
         termination_token,
-    ), None)
+    ), inspector)
     .await
     .map_err(|err| anyhow!("main worker boot error: {}", err))?;
 

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -1,3 +1,4 @@
+use crate::inspector_server::Inspector;
 use crate::rt_worker::worker_ctx::{create_worker, send_user_worker_request};
 use anyhow::{anyhow, Context, Error};
 use enum_as_inner::EnumAsInner;
@@ -208,6 +209,7 @@ pub struct WorkerPool {
     pub user_workers: HashMap<Uuid, UserWorkerProfile>,
     pub active_workers: HashMap<String, ActiveWorkerRegistry>,
     pub worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
+    pub maybe_inspector: Option<Inspector>,
 
     // TODO: refactor this out of worker pool
     pub worker_event_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
@@ -219,6 +221,7 @@ impl WorkerPool {
         metric_src: SharedMetricSource,
         worker_event_sender: Option<UnboundedSender<WorkerEventWithMetadata>>,
         worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
+        inspector: Option<Inspector>,
     ) -> Self {
         Self {
             policy,
@@ -226,6 +229,7 @@ impl WorkerPool {
             worker_event_sender,
             user_workers: HashMap::new(),
             active_workers: HashMap::new(),
+            maybe_inspector: inspector,
             worker_pool_msgs_tx,
         }
     }
@@ -243,6 +247,8 @@ impl WorkerPool {
             .to_string();
 
         let is_oneshot_policy = self.policy.supervisor_policy.is_oneshot();
+        let inspector = self.maybe_inspector.clone();
+
         let force_create = worker_options
             .conf
             .as_user_worker()
@@ -405,8 +411,11 @@ impl WorkerPool {
 
             worker_options.conf = WorkerRuntimeOpts::UserWorker(user_worker_rt_opts);
 
-            match create_worker((worker_options, supervisor_policy, termination_token.clone()))
-                .await
+            match create_worker(
+                (worker_options, supervisor_policy, termination_token.clone()),
+                inspector,
+            )
+            .await
             {
                 Ok((_, worker_request_msg_tx)) => {
                     let profile = UserWorkerProfile {

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -1,3 +1,4 @@
+use crate::inspector_server::Inspector;
 use crate::rt_worker::worker_ctx::{
     create_events_worker, create_main_worker, create_user_worker_pool, TerminationToken,
 };
@@ -199,6 +200,7 @@ impl Server {
         callback_tx: Option<Sender<ServerHealth>>,
         entrypoints: WorkerEntrypoints,
         termination_token: Option<TerminationToken>,
+        inspector: Option<Inspector>,
     ) -> Result<Self, Error> {
         let mut worker_events_tx: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>> = None;
         let maybe_events_entrypoint = entrypoints.events;
@@ -230,6 +232,7 @@ impl Server {
             maybe_user_worker_policy.unwrap_or_default(),
             worker_events_tx,
             None,
+            inspector,
         )
         .await?;
 
@@ -250,6 +253,7 @@ impl Server {
         .await?;
 
         let ip = Ipv4Addr::from_str(ip)?;
+
         Ok(Self {
             ip,
             port,

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -200,6 +200,7 @@ impl TestBedBuilder {
                         .unwrap_or_else(test_user_worker_pool_policy),
                     None,
                     Some(token.clone()),
+                    None,
                 )
                 .await
                 .unwrap(),
@@ -226,7 +227,7 @@ impl TestBedBuilder {
 
         let main_termination_token = TerminationToken::new();
         let (_, main_worker_msg_tx) =
-            create_worker((main_worker_init_opts, main_termination_token.clone()))
+            create_worker((main_worker_init_opts, main_termination_token.clone()), None)
                 .await
                 .unwrap();
 
@@ -299,6 +300,7 @@ pub async fn create_test_user_worker<Opt: Into<CreateTestUserWorkerArgs>>(
         let (_, sender) = create_worker(
             opts.with_policy(policy)
                 .with_termination_token(termination_token.clone()),
+            None,
         )
         .await?;
 

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -226,10 +226,12 @@ impl TestBedBuilder {
         };
 
         let main_termination_token = TerminationToken::new();
-        let (_, main_worker_msg_tx) =
-            create_worker((main_worker_init_opts, main_termination_token.clone()), None)
-                .await
-                .unwrap();
+        let (_, main_worker_msg_tx) = create_worker(
+            (main_worker_init_opts, main_termination_token.clone()),
+            None,
+        )
+        .await
+        .unwrap();
 
         TestBed {
             pool_termination_token,

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -158,6 +158,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         integration_test_helper::test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
+        None,
     )
     .await
     .unwrap();
@@ -179,7 +180,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         }),
     };
 
-    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()))
+    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()), None)
         .await
         .unwrap();
 
@@ -316,6 +317,7 @@ async fn test_main_worker_boot_error() {
         test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
+        None,
     )
     .await
     .unwrap();
@@ -337,7 +339,7 @@ async fn test_main_worker_boot_error() {
         }),
     };
 
-    let result = create_worker((opts, main_termination_token.clone())).await;
+    let result = create_worker((opts, main_termination_token.clone()), None).await;
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "worker boot error");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,7 @@ use sb_graph::import_map::load_import_map;
 use sb_graph::{extract_from_file, generate_binary_eszip};
 use std::fs::File;
 use std::io::Write;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -75,7 +76,25 @@ fn cli() -> Command {
                 )
                 .arg(
                     arg!(--"request-wait-timeout" <MILLISECONDS> "Maximum time in milliseconds that can wait to establish a connection with a worker")
-                    .value_parser(value_parser!(u64))
+                        .value_parser(value_parser!(u64))
+                )
+                .arg(
+                    arg!(--"inspect" [HOST_AND_PORT] "Activate inspector on host:port (default: 127.0.0.1:9229)")
+                        .num_args(0..=1)
+                        .require_equals(true)
+                        .value_parser(value_parser!(SocketAddr))
+                )
+                .arg(
+                    arg!(--"inspect-brk" [HOST_AND_PORT] "Activate inspector on host:port, wait for debugger to connect and break at the start of user script")
+                        .num_args(0..=1)
+                        .require_equals(true)
+                        .value_parser(value_parser!(SocketAddr))
+                )
+                .arg(
+                    arg!(--"inspect-wait" [HOST_AND_PORT] "Activate inspector on host:port and wait for debugger to connect before running user code")
+                        .num_args(0..=1)
+                        .require_equals(true)
+                        .value_parser(value_parser!(SocketAddr))
                 )
         )
         .subcommand(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,7 @@ use base::server::WorkerEntrypoints;
 use clap::builder::{FalseyValueParser, TypedValueParser};
 use clap::{arg, crate_version, value_parser, ArgAction, Command};
 use deno_core::url::Url;
+use log::warn;
 use sb_graph::emitter::EmitterFactory;
 use sb_graph::import_map::load_import_map;
 use sb_graph::{extract_from_file, generate_binary_eszip};
@@ -111,16 +112,6 @@ fn cli() -> Command {
     )
 }
 
-//async fn exit_with_code(result: Result<(), Error>) {
-//    match result {
-//        Ok(()) => std::process::exit(0),
-//        Err(error) => {
-//            eprintln!("{:?}", error);
-//            std::process::exit(1)
-//        }
-//    }
-//}
-
 fn main() -> Result<(), anyhow::Error> {
     MAYBE_DENO_VERSION.get_or_init(|| env!("DENO_VERSION").to_string());
 
@@ -181,6 +172,12 @@ fn main() -> Result<(), anyhow::Error> {
                             .as_ref()
                             .map(SupervisorPolicy::is_oneshot)
                         {
+                            if let Some(parallelism) = maybe_max_parallelism {
+                                if parallelism == 0 || parallelism > 1 {
+                                    warn!("if `oneshot` policy is enabled, the maximum parallelism is fixed to `1` as forcibly.");
+                                }
+                            }
+                            
                             Some(1)
                         } else {
                             maybe_max_parallelism

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -83,20 +83,23 @@ fn cli() -> Command {
                 .arg(
                     arg!(--"inspect" [HOST_AND_PORT] "Activate inspector on host:port (default: 127.0.0.1:9229)")
                         .num_args(0..=1)
-                        .require_equals(true)
                         .value_parser(value_parser!(SocketAddr))
+                        .require_equals(true)
+                        .default_missing_value("127.0.0.1:9229")
                 )
                 .arg(
                     arg!(--"inspect-brk" [HOST_AND_PORT] "Activate inspector on host:port, wait for debugger to connect and break at the start of user script")
                         .num_args(0..=1)
-                        .require_equals(true)
                         .value_parser(value_parser!(SocketAddr))
+                        .require_equals(true)
+                        .default_missing_value("127.0.0.1:9229")
                 )
                 .arg(
                     arg!(--"inspect-wait" [HOST_AND_PORT] "Activate inspector on host:port and wait for debugger to connect before running user code")
                         .num_args(0..=1)
-                        .require_equals(true)
                         .value_parser(value_parser!(SocketAddr))
+                        .require_equals(true)
+                        .default_missing_value("127.0.0.1:9229")
                 )
                 .group(
                     ArgGroup::new("inspector")

--- a/crates/cpu_timer/src/lib.rs
+++ b/crates/cpu_timer/src/lib.rs
@@ -237,6 +237,13 @@ fn register_sigalrm() {
                                             debug!("failed to send cpu alarm to the provided channel");
                                         }
                                     } else {
+                                        // NOTE: Unix signals are being
+                                        // delivered asynchronously, and there
+                                        // are no guarantees to cancel the
+                                        // signal after a timer has been
+                                        // deleted, and after a signal is
+                                        // received, there may no longer be a
+                                        // target to accept it.
                                         error!("can't find the cpu alarm signal matched with the received timer id: {}", *timer_id);
                                     }
                                 }

--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -3,6 +3,7 @@ use crate::graph_util::{create_eszip_from_graph_raw, create_graph};
 use deno_ast::MediaType;
 use deno_core::error::AnyError;
 use deno_core::futures::io::{AllowStdIo, BufReader};
+use deno_core::url::Url;
 use deno_core::{serde_json, FastString, JsBuffer, ModuleSpecifier};
 use deno_fs::{FileSystem, RealFs};
 use deno_npm::NpmSystemInfo;
@@ -68,7 +69,13 @@ pub async fn generate_binary_eszip(
             String::from_utf8(entry_content.clone())?.into()
         };
         let emit_source = emitter_factory.emitter().unwrap().emit_parsed_source(
-            &ModuleSpecifier::parse("http://localhost").unwrap(),
+            &ModuleSpecifier::parse(
+                &*Url::from_file_path(&fs_path)
+                    .map(|it| Cow::Owned(it.to_string()))
+                    .ok()
+                    .unwrap_or("http://localhost".into()),
+            )
+            .unwrap(),
             MediaType::from_path(fs_path.clone().as_path()),
             &source_code,
         )?;

--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -70,7 +70,7 @@ pub async fn generate_binary_eszip(
         };
         let emit_source = emitter_factory.emitter().unwrap().emit_parsed_source(
             &ModuleSpecifier::parse(
-                &*Url::from_file_path(&fs_path)
+                &Url::from_file_path(&fs_path)
                     .map(|it| Cow::Owned(it.to_string()))
                     .ok()
                     .unwrap_or("http://localhost".into()),

--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -10,6 +10,7 @@ use deno_npm::NpmSystemInfo;
 use eszip::{EszipV2, ModuleKind};
 use sb_fs::{build_vfs, VfsOpts};
 use sb_npm::InnerCliNpmResolverRef;
+use std::borrow::Cow;
 use std::fs;
 use std::fs::{create_dir_all, File};
 use std::io::Write;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

As I said in supabase/cli#1822, using and debugging smoothly with EdgeRuntime in the local environment is quite difficult because we are providing a weak development environment.

I can't claim to solve those problems with this single PR, but I believe this will alleviate some of those difficulties.

### List of arguments to be created due to the introduction of this PR
* `--inspect [HOST_AND_PORT]` - Activate inspector on host:port (default: 127.0.0.1:9229)
* `--inspect-brk [HOST_AND_PORT]` - Activate inspector on host:port, wait for debugger to connect and break at the start of user script
* `--inspect-wait [HOST_AND_PORT]` - Activate inspector on host:port and wait for debugger to connect before running user code
* `--inspect-main` - This argument will only be used if you provide an argument that is one of the above. This argument allows the creation of the inspector for the main worker.
* `--graceful-exit-timeout` - Optional argument, This argument is the maximum amount of time, in seconds, the main worker can wait before being terminated by a termination request (ex; interrupt signal).

> Note: All the inspector-related arguments have their default value; it sets `localhost:9229` by default if the user does not specify the host and port.

## Reference Video

With Chrome Inspector

https://github.com/supabase/edge-runtime/assets/46702285/62d80790-4857-4752-8cfc-e5eccfbcfe21

With Chrome Inspector (In dedicated DevTools)

https://github.com/supabase/edge-runtime/assets/46702285/4c190f7b-61ce-4bfc-a08e-efaefc8c77c0


With VSCode Debugger

https://github.com/supabase/edge-runtime/assets/46702285/8a4b5b8b-550a-4a3c-a258-853e38e9d52d




Resolves [issue #13985](https://github.com/orgs/supabase/discussions/13985) that discussed in Github Discussions