### PR TITLE
fix: supervisor should also consider cases where the CPU time limit is zero

### DIFF
--- a/crates/base/src/rt_worker/supervisor/mod.rs
+++ b/crates/base/src/rt_worker/supervisor/mod.rs
@@ -60,6 +60,7 @@ pub struct IsolateMemoryStats {
     pub external_memory: usize,
 }
 
+#[derive(Clone, Copy)]
 pub struct CPUTimerParam {
     soft_limit_ms: u64,
     hard_limit_ms: u64,
@@ -79,7 +80,7 @@ impl CPUTimerParam {
     ) -> Option<(CPUTimer, UnboundedReceiver<()>)> {
         let (cpu_alarms_tx, cpu_alarms_rx) = mpsc::unbounded_channel::<()>();
 
-        if self.soft_limit_ms == 0 && self.hard_limit_ms == 0 {
+        if self.is_disabled() {
             return None;
         }
 
@@ -104,6 +105,10 @@ impl CPUTimerParam {
 
     pub fn limits(&self) -> (u64, u64) {
         (self.soft_limit_ms, self.hard_limit_ms)
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.soft_limit_ms == 0 && self.hard_limit_ms == 0
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After #241 CPU time limit can be disabled by specifying zero. But In #244, I refactored the calculation for CPU time, as not consider the case where there might not be a CPU time limit.

This PR makes each supervisor policy consider the case that the CPU time limit is disabled.

Reported-by: @nicetomytyuk
