### PR TITLE
fix(sb_graph): checking whether the path is relative and unix format while reading module path

### DIFF
--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -136,7 +136,7 @@ pub struct ExtractEszipPayload {
 
 fn ensure_unix_relative_path(path: &Path) -> &Path {
     assert!(path.is_relative());
-    assert!(!path.to_string_lossy().starts_with("\\"));
+    assert!(!path.to_string_lossy().starts_with('\\'));
     path
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## Description

Instead of letting the panic leak out by failing to strip a leading slash from the given module path, I add some assertions and make sure that things usually proceed instead of panicking when possible.

I don't know whether the problem is caused by the specifier being formatted to follow the Windows path format when ESZip is created in a Windows environment or caused by there being no slashes.

Because I currently don't have a Windows machine, so I take the most conservative approach possible to add logic to relax the leading slash restrictions.
