### PR TITLE
fix: `SIGSEGV` has triggered if initializing the main module was failed

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -345,15 +345,13 @@ impl DenoRuntime {
             op_state.put::<sb_env::EnvVars>(env_vars);
         }
 
-        let mut js_runtime_mut = scopeguard::guard(&mut js_runtime, |it| unsafe {
-            it.v8_isolate().exit();
-        });
-
-        let main_module_id = js_runtime_mut
+        let main_module_id = js_runtime
             .load_main_module(&main_module_url, mod_code)
             .await?;
 
-        drop(js_runtime_mut);
+        unsafe {
+            js_runtime.v8_isolate().exit();
+        }
 
         Ok(Self {
             js_runtime,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description
If exiting the V8 loop with an exception during script initialization, an isolate was explicitly detached from the thread by `scopeguard`.

It turns out an isolate calls the logic to detach itself from the thread when it is dropped by default, so the introduction of `scopeguard` was wrong.

This PR fixes `SIGSEGV` that triggered due to calling `v8::Isolate::Exit()` twice.