### PR TITLE
fix: sync drop timing of unix stream sender to timing of an isolate drops

### DIFF
--- a/crates/base/src/rt_worker/implementation/default_handler.rs
+++ b/crates/base/src/rt_worker/implementation/default_handler.rs
@@ -1,15 +1,12 @@
 use crate::deno_runtime::DenoRuntime;
 use crate::rt_worker::supervisor::CPUUsageMetrics;
-use crate::rt_worker::worker::{HandleCreationType, Worker, WorkerHandler};
+use crate::rt_worker::worker::{HandleCreationType, UnixStreamEntry, Worker, WorkerHandler};
 use anyhow::Error;
 use event_worker::events::{BootFailureEvent, PseudoEvent, UncaughtExceptionEvent, WorkerEvents};
 use log::error;
-use sb_core::conn_sync::ConnSync;
 use std::any::Any;
-use tokio::net::UnixStream;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Receiver;
-use tokio::sync::watch;
 
 impl WorkerHandler for Worker {
     fn handle_error(&self, error: Error) -> Result<WorkerEvents, Error> {
@@ -22,7 +19,7 @@ impl WorkerHandler for Worker {
     fn handle_creation(
         &self,
         mut created_rt: DenoRuntime,
-        unix_stream_rx: UnboundedReceiver<(UnixStream, Option<watch::Receiver<ConnSync>>)>,
+        unix_stream_rx: UnboundedReceiver<UnixStreamEntry>,
         termination_event_rx: Receiver<WorkerEvents>,
         maybe_cpu_usage_metrics_tx: Option<UnboundedSender<CPUUsageMetrics>>,
         name: Option<String>,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Before: [link](https://github.com/supabase/edge-runtime/actions/runs/7717869794/job/21037912456#step:6:733)
After: [link](https://github.com/supabase/edge-runtime/actions/runs/7720419397/job/21045273639#step:6:121)

This PR synchronizes the drop timing of the unix stream sender with an isolate drop timing, which fixes the appearing error spams in particular tests after the [Deno core update PR](https://github.com/supabase/edge-runtime/pull/250).