### PR TITLE
fix: show the actual deno cli version in `Deno.version`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            GIT_V_VERSION=${{ steps.semantic.outputs.new_release_version }}
+            GIT_V_VERSION=${{ needs.release.outputs.version }}
 
   publish_arm:
     needs:
@@ -103,6 +103,8 @@ jobs:
           platforms: linux/${{ env.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           no-cache: true
+          build-args: |
+            GIT_V_VERSION=${{ needs.release.outputs.version }}
 
   merge_manifest:
     needs: [release, publish_x86, publish_arm]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ mod logger;
 
 use anyhow::{anyhow, bail, Error};
 use base::commands::start_server;
+use base::deno_runtime::MAYBE_DENO_VERSION;
 use base::rt_worker::worker_pool::{SupervisorPolicy, WorkerPoolPolicy};
 use base::server::WorkerEntrypoints;
 use clap::builder::{FalseyValueParser, TypedValueParser};
@@ -102,6 +103,8 @@ fn cli() -> Command {
 //}
 
 fn main() -> Result<(), anyhow::Error> {
+    MAYBE_DENO_VERSION.get_or_init(|| env!("DENO_VERSION").to_string());
+
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -233,7 +233,7 @@ const deleteDenoApis = (apis) => {
 	});
 };
 
-globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, version) => {
+globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, edgeRuntimeVersion, denoVersion) => {
 	// We should delete this after initialization,
 	// Deleting it during bootstrapping can backfire
 	delete globalThis.__bootstrap;
@@ -255,7 +255,8 @@ globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, version) => {
 		...opts,
 	});
 
-	ObjectDefineProperty(globalThis, 'SUPABASE_VERSION', readOnly(String(version)));
+	ObjectDefineProperty(globalThis, 'SUPABASE_VERSION', readOnly(String(edgeRuntimeVersion)));
+	ObjectDefineProperty(globalThis, 'DENO_VERSION', readOnly(denoVersion))
 
 	// set these overrides after runtimeStart
 	ObjectDefineProperties(denoOverrides, {
@@ -265,7 +266,7 @@ globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, version) => {
 		args: readOnly([]), // args are set to be empty
 		mainModule: getterOnly(() => ops.op_main_module()),
 		version: getterOnly(() => ({
-			deno: `supabase-edge-runtime-${globalThis.SUPABASE_VERSION}`,
+			deno: `supabase-edge-runtime-${globalThis.SUPABASE_VERSION} (compatible with Deno v${globalThis.DENO_VERSION})`,
 			v8: '11.6.189.12',
 			typescript: '5.1.6',
 		})),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

```typescript
console.log(Deno.version);
// Output (Before / local build):
// {
//     "deno": "supabase-edge-runtime-0.1.0",
//     "v8": "11.6.189.12",
//     "typescript": "5.1.6"
// }
// Output (Before / prod):
// {
//     "deno": "supabase-edge-runtime-",
//     "v8": "11.6.189.12",
//     "typescript": "5.1.6"
// }

// Output (After / local build):
// {
//     "deno": "supabase-edge-runtime-0.1.0 (compatible with Deno v1.39.2)",
//     "v8": "11.6.189.12",
//     "typescript": "5.1.6"
// }

// Output (After / prod):
// {
//     "deno": "supabase-edge-runtime-[release version here] (compatible with Deno v1.39.2)",
//     "v8": "11.6.189.12",
//     "typescript": "5.1.6"
// }

console.log(DENO_VERSION);
// Output:
// 1.39.2
```

This PR indirectly relevant with the [question](https://discord.com/channels/839993398554656828/1202913385067577364) that discussed in Discord.

Reported-by: @paul-brenner
