### PR TITLE
feat: runtime metric API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "deno_websocket",
  "deno_webstorage",
  "encoding_rs",
+ "enum-as-inner 0.6.0",
  "fs3",
  "futures",
  "hyper 0.14.28",

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -573,7 +573,12 @@ mod test {
             maybe_module_code: Some(FastString::from(String::from(
                 "Deno.serve((req) => new Response('Hello World'));",
             ))),
-            conf: { WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts { worker_pool_tx }) },
+            conf: {
+                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                    worker_pool_tx,
+                    event_worker_metric_src: None,
+                })
+            },
         })
         .await
         .expect("It should not panic");
@@ -612,7 +617,12 @@ mod test {
             maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
             maybe_entrypoint: None,
             maybe_module_code: None,
-            conf: { WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts { worker_pool_tx }) },
+            conf: {
+                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                    worker_pool_tx,
+                    event_worker_metric_src: None,
+                })
+            },
         })
         .await;
 
@@ -673,7 +683,12 @@ mod test {
             maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
             maybe_entrypoint: None,
             maybe_module_code: None,
-            conf: { WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts { worker_pool_tx }) },
+            conf: {
+                WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                    worker_pool_tx,
+                    event_worker_metric_src: None,
+                })
+            },
         })
         .await;
 
@@ -731,7 +746,10 @@ mod test {
                 if let Some(uc) = user_conf {
                     uc
                 } else {
-                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts { worker_pool_tx })
+                    WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
+                        worker_pool_tx,
+                        event_worker_metric_src: None,
+                    })
                 }
             },
         })

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -421,7 +421,7 @@ impl DenoRuntime {
         // the task from the other threads.
         // let mut current_thread_id = std::thread::current().id();
 
-        let result = match poll_fn(|cx| {
+        let poll_result = poll_fn(|cx| {
             // INVARIANT: Only can steal current task by other threads when LIFO
             // task scheduler heuristic disabled. Turning off the heuristic is
             // unstable now, so it's not considered.
@@ -487,8 +487,9 @@ impl DenoRuntime {
 
             poll_result
         })
-        .await
-        {
+        .await;
+
+        let result = match poll_result {
             Err(err) => Err(anyhow!("event loop error: {}", err)),
             Ok(_) => match mod_result_rx.await {
                 Err(e) => {
@@ -576,6 +577,7 @@ mod test {
             conf: {
                 WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                     worker_pool_tx,
+                    shared_metric_src: None,
                     event_worker_metric_src: None,
                 })
             },
@@ -620,6 +622,7 @@ mod test {
             conf: {
                 WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                     worker_pool_tx,
+                    shared_metric_src: None,
                     event_worker_metric_src: None,
                 })
             },
@@ -686,6 +689,7 @@ mod test {
             conf: {
                 WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                     worker_pool_tx,
+                    shared_metric_src: None,
                     event_worker_metric_src: None,
                 })
             },
@@ -748,6 +752,7 @@ mod test {
                 } else {
                     WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                         worker_pool_tx,
+                        shared_metric_src: None,
                         event_worker_metric_src: None,
                     })
                 }

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -12,6 +12,7 @@ use event_worker::events::{
 use hyper::{Body, Request, Response};
 use log::{debug, error};
 use sb_core::conn_sync::ConnSync;
+use sb_core::WorkerMetricSource;
 use sb_graph::EszipPayloadKind;
 use sb_workers::context::{
     EventWorkerRuntimeOpts, MainWorkerRuntimeOpts, Timing, UserWorkerMsgs, WorkerContextInitOpts,
@@ -309,9 +310,10 @@ impl CreateWorkerArgs {
 
 pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
     init_opts: Opt,
-) -> Result<mpsc::UnboundedSender<WorkerRequestMsg>, Error> {
-    let (worker_boot_result_tx, worker_boot_result_rx) = oneshot::channel::<Result<(), Error>>();
+) -> Result<(WorkerMetricSource, mpsc::UnboundedSender<WorkerRequestMsg>), Error> {
     let (unix_stream_tx, unix_stream_rx) = mpsc::unbounded_channel::<UnixStreamEntry>();
+    let (worker_boot_result_tx, worker_boot_result_rx) =
+        oneshot::channel::<Result<WorkerMetricSource, Error>>();
 
     let CreateWorkerArgs(init_opts, maybe_supervisor_policy, maybe_termination_token) =
         init_opts.into();
@@ -370,7 +372,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
 
                 bail!(err)
             }
-            Ok(_) => {
+            Ok(metric) => {
                 let elapsed = worker_struct_ref
                     .worker_boot_start_time
                     .elapsed()
@@ -384,7 +386,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
                     worker_struct_ref.event_metadata.clone(),
                 );
 
-                Ok(worker_req_tx)
+                Ok((metric, worker_req_tx))
             }
         }
     } else {
@@ -422,7 +424,7 @@ pub async fn create_main_worker(
     main_worker_path: PathBuf,
     import_map_path: Option<String>,
     no_module_cache: bool,
-    user_worker_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
+    runtime_opts: MainWorkerRuntimeOpts,
     maybe_entrypoint: Option<String>,
     termination_token: Option<TerminationToken>,
 ) -> Result<mpsc::UnboundedSender<WorkerRequestMsg>, Error> {
@@ -435,7 +437,7 @@ pub async fn create_main_worker(
         }
     }
 
-    let main_worker_req_tx = create_worker((
+    let (_, sender) = create_worker((
         WorkerContextInitOpts {
             service_path,
             import_map_path,
@@ -445,9 +447,7 @@ pub async fn create_main_worker(
             maybe_eszip,
             maybe_entrypoint,
             maybe_module_code: None,
-            conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                worker_pool_tx: user_worker_msgs_tx,
-            }),
+            conf: WorkerRuntimeOpts::MainWorker(runtime_opts),
             env_vars: std::env::vars().collect(),
         },
         termination_token,
@@ -455,7 +455,7 @@ pub async fn create_main_worker(
     .await
     .map_err(|err| anyhow!("main worker boot error: {}", err))?;
 
-    Ok(main_worker_req_tx)
+    Ok(sender)
 }
 
 pub async fn create_events_worker(
@@ -464,7 +464,13 @@ pub async fn create_events_worker(
     no_module_cache: bool,
     maybe_entrypoint: Option<String>,
     termination_token: Option<TerminationToken>,
-) -> Result<mpsc::UnboundedSender<WorkerEventWithMetadata>, Error> {
+) -> Result<
+    (
+        WorkerMetricSource,
+        mpsc::UnboundedSender<WorkerEventWithMetadata>,
+    ),
+    Error,
+> {
     let (events_tx, events_rx) = mpsc::unbounded_channel::<WorkerEventWithMetadata>();
 
     let mut service_path = events_worker_path.clone();
@@ -478,7 +484,7 @@ pub async fn create_events_worker(
         }
     }
 
-    let _ = create_worker((
+    let (metric, _) = create_worker((
         WorkerContextInitOpts {
             service_path,
             no_module_cache,
@@ -496,7 +502,7 @@ pub async fn create_events_worker(
     .await
     .map_err(|err| anyhow!("events worker boot error: {}", err))?;
 
-    Ok(events_tx)
+    Ok((metric, events_tx))
 }
 
 pub async fn create_user_worker_pool(

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -404,7 +404,7 @@ impl WorkerPool {
             match create_worker((worker_options, supervisor_policy, termination_token.clone()))
                 .await
             {
-                Ok(worker_request_msg_tx) => {
+                Ok((_, worker_request_msg_tx)) => {
                     let profile = UserWorkerProfile {
                         worker_request_msg_tx,
                         timing_tx_pair: (req_start_timing_tx, req_end_timing_tx),

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -7,6 +7,7 @@ use hyper::Body;
 use log::error;
 use sb_core::conn_sync::ConnSync;
 use sb_core::util::sync::AtomicFlag;
+use sb_core::SharedMetricSource;
 use sb_workers::context::{
     CreateUserWorkerResult, SendRequestResult, Timing, TimingStatus, UserWorkerMsgs,
     UserWorkerProfile, WorkerContextInitOpts, WorkerRuntimeOpts,
@@ -203,6 +204,7 @@ impl ActiveWorkerRegistry {
 // send_request is called with UUID
 pub struct WorkerPool {
     pub policy: WorkerPoolPolicy,
+    pub metric_src: SharedMetricSource,
     pub user_workers: HashMap<Uuid, UserWorkerProfile>,
     pub active_workers: HashMap<String, ActiveWorkerRegistry>,
     pub worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
@@ -214,11 +216,13 @@ pub struct WorkerPool {
 impl WorkerPool {
     pub(crate) fn new(
         policy: WorkerPoolPolicy,
+        metric_src: SharedMetricSource,
         worker_event_sender: Option<UnboundedSender<WorkerEventWithMetadata>>,
         worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
     ) -> Self {
         Self {
             policy,
+            metric_src,
             worker_event_sender,
             user_workers: HashMap::new(),
             active_workers: HashMap::new(),
@@ -447,6 +451,7 @@ impl WorkerPool {
             .insert(WorkerId(key, self.policy.supervisor_policy.is_per_worker()));
 
         self.user_workers.insert(key, profile);
+        self.metric_src.incl_active_user_workers();
     }
 
     pub fn send_request(
@@ -552,6 +557,8 @@ impl WorkerPool {
         };
 
         let _ = notify_tx.send(None);
+
+        self.metric_src.decl_active_user_workers();
     }
 
     fn retire(&mut self, key: &Uuid) {
@@ -570,6 +577,7 @@ impl WorkerPool {
 
             if registry.workers.contains(key) {
                 registry.workers.remove(key);
+                self.metric_src.incl_retired_user_worker();
             }
         }
     }

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -192,7 +192,7 @@ impl TestBedBuilder {
     }
 
     pub async fn build(self) -> TestBed {
-        let (worker_pool_msg_tx, pool_termination_token) = {
+        let (worker_pool_tx, pool_termination_token) = {
             let token = TerminationToken::new();
             (
                 create_user_worker_pool(
@@ -218,12 +218,13 @@ impl TestBedBuilder {
             maybe_entrypoint: None,
             maybe_module_code: None,
             conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-                worker_pool_tx: worker_pool_msg_tx,
+                worker_pool_tx,
+                event_worker_metric_src: None,
             }),
         };
 
         let main_termination_token = TerminationToken::new();
-        let main_worker_msg_tx =
+        let (_, main_worker_msg_tx) =
             create_worker((main_worker_init_opts, main_termination_token.clone()))
                 .await
                 .unwrap();
@@ -293,20 +294,24 @@ pub async fn create_test_user_worker<Opt: Into<CreateTestUserWorkerArgs>>(
         ..Default::default()
     });
 
-    Ok((
-        create_worker(
+    Ok({
+        let (_, sender) = create_worker(
             opts.with_policy(policy)
                 .with_termination_token(termination_token.clone()),
         )
-        .await?,
-        RequestScope {
-            policy,
-            req_start_tx,
-            req_end_tx,
-            termination_token,
-            conn: (Some(conn_tx), conn_rx),
-        },
-    ))
+        .await?;
+
+        (
+            sender,
+            RequestScope {
+                policy,
+                req_start_tx,
+                req_end_tx,
+                termination_token,
+                conn: (Some(conn_tx), conn_rx),
+            },
+        )
+    })
 }
 
 pub fn test_user_worker_pool_policy() -> WorkerPoolPolicy {

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -192,7 +192,7 @@ impl TestBedBuilder {
     }
 
     pub async fn build(self) -> TestBed {
-        let (worker_pool_tx, pool_termination_token) = {
+        let ((_, worker_pool_tx), pool_termination_token) = {
             let token = TerminationToken::new();
             (
                 create_user_worker_pool(
@@ -219,6 +219,7 @@ impl TestBedBuilder {
             maybe_module_code: None,
             conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                 worker_pool_tx,
+                shared_metric_src: None,
                 event_worker_metric_src: None,
             }),
         };

--- a/crates/base/tests/linux_pku_sigsegv_test.rs
+++ b/crates/base/tests/linux_pku_sigsegv_test.rs
@@ -21,7 +21,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
     let main_termination_token = TerminationToken::new();
 
     // create a user worker pool
-    let user_worker_msgs_tx = create_user_worker_pool(
+    let worker_pool_tx = create_user_worker_pool(
         integration_test_helper::test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
@@ -40,11 +40,12 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         maybe_entrypoint: None,
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-            worker_pool_tx: user_worker_msgs_tx,
+            worker_pool_tx,
+            event_worker_metric_src: None,
         }),
     };
 
-    let worker_req_tx = create_worker((opts, main_termination_token.clone()))
+    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()))
         .await
         .unwrap();
 

--- a/crates/base/tests/linux_pku_sigsegv_test.rs
+++ b/crates/base/tests/linux_pku_sigsegv_test.rs
@@ -21,7 +21,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
     let main_termination_token = TerminationToken::new();
 
     // create a user worker pool
-    let worker_pool_tx = create_user_worker_pool(
+    let (_, worker_pool_tx) = create_user_worker_pool(
         integration_test_helper::test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
@@ -41,6 +41,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx,
+            shared_metric_src: None,
             event_worker_metric_src: None,
         }),
     };

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -111,7 +111,7 @@ async fn test_main_worker_boot_error() {
     let main_termination_token = TerminationToken::new();
 
     // create a user worker pool
-    let worker_pool_tx = create_user_worker_pool(
+    let (_, worker_pool_tx) = create_user_worker_pool(
         test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
@@ -131,6 +131,7 @@ async fn test_main_worker_boot_error() {
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx,
+            shared_metric_src: None,
             event_worker_metric_src: None,
         }),
     };

--- a/crates/base/tests/main_worker_tests.rs
+++ b/crates/base/tests/main_worker_tests.rs
@@ -111,7 +111,7 @@ async fn test_main_worker_boot_error() {
     let main_termination_token = TerminationToken::new();
 
     // create a user worker pool
-    let user_worker_msgs_tx = create_user_worker_pool(
+    let worker_pool_tx = create_user_worker_pool(
         test_user_worker_pool_policy(),
         None,
         Some(pool_termination_token.clone()),
@@ -130,7 +130,8 @@ async fn test_main_worker_boot_error() {
         maybe_entrypoint: None,
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
-            worker_pool_tx: user_worker_msgs_tx,
+            worker_pool_tx,
+            event_worker_metric_src: None,
         }),
     };
 

--- a/crates/sb_core/Cargo.toml
+++ b/crates/sb_core/Cargo.toml
@@ -48,3 +48,4 @@ base64.workspace = true
 futures.workspace = true
 percent-encoding.workspace = true
 scopeguard.workspace = true
+enum-as-inner.workspace = true

--- a/crates/sb_core/js/main_worker.js
+++ b/crates/sb_core/js/main_worker.js
@@ -1,5 +1,4 @@
 import { SUPABASE_USER_WORKERS } from "ext:sb_user_workers/user_workers.js";
-import { getterOnly } from "ext:sb_core_main_js/js/fieldUtils.js";
 import { applyWatcherRid } from "ext:sb_core_main_js/js/http.js";
 import { core } from "ext:core/mod.js";
 
@@ -9,7 +8,7 @@ Object.defineProperty(globalThis, 'EdgeRuntime', {
 	get() {
 		return {
 			userWorkers: SUPABASE_USER_WORKERS,
-			runtimeMetrics: getterOnly(() => ops.op_runtime_metrics()),
+			getRuntimeMetrics: () => /* async */ ops.op_runtime_metrics(),
 			applyConnectionWatcher: (src, dest) => {
 				applyWatcherRid(src, dest);
 			}

--- a/crates/sb_core/js/main_worker.js
+++ b/crates/sb_core/js/main_worker.js
@@ -1,10 +1,15 @@
-import { SUPABASE_USER_WORKERS } from 'ext:sb_user_workers/user_workers.js';
-import { applyWatcherRid } from 'ext:sb_core_main_js/js/http.js';
+import { SUPABASE_USER_WORKERS } from "ext:sb_user_workers/user_workers.js";
+import { getterOnly } from "ext:sb_core_main_js/js/fieldUtils.js";
+import { applyWatcherRid } from "ext:sb_core_main_js/js/http.js";
+import { core } from "ext:core/mod.js";
+
+const ops = core.ops;
 
 Object.defineProperty(globalThis, 'EdgeRuntime', {
 	get() {
 		return {
 			userWorkers: SUPABASE_USER_WORKERS,
+			runtimeMetrics: getterOnly(() => ops.op_runtime_metrics()),
 			applyConnectionWatcher: (src, dest) => {
 				applyWatcherRid(src, dest);
 			}

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -1,6 +1,16 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
 use deno_core::error::AnyError;
-use deno_core::op2;
+use deno_core::v8::IsolateHandle;
 use deno_core::OpState;
+use deno_core::{op2, JsRuntime};
+use futures::task::AtomicWaker;
+use futures::FutureExt;
+use log::error;
+use serde::Serialize;
+use tokio::sync::oneshot;
 
 pub mod auth_tokens;
 pub mod cache;
@@ -17,6 +27,147 @@ pub mod runtime;
 pub mod transpiler;
 pub mod util;
 
+#[derive(Debug, Clone)]
+pub struct WorkerMetricSource {
+    handle: IsolateHandle,
+    waker: Arc<AtomicWaker>,
+}
+
+impl From<&mut JsRuntime> for WorkerMetricSource {
+    fn from(value: &mut JsRuntime) -> Self {
+        Self::from_js_runtime(value)
+    }
+}
+
+impl WorkerMetricSource {
+    pub fn from_js_runtime(runtime: &mut JsRuntime) -> Self {
+        let handle = runtime.v8_isolate().thread_safe_handle();
+        let waker = {
+            let state = runtime.op_state();
+            let state_mut = state.borrow_mut();
+
+            state_mut.waker.clone()
+        };
+
+        Self { handle, waker }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeMetricSource {
+    main: WorkerMetricSource,
+    event: Option<WorkerMetricSource>,
+}
+
+impl RuntimeMetricSource {
+    pub fn new(main: WorkerMetricSource, maybe_event: Option<WorkerMetricSource>) -> Self {
+        Self {
+            main,
+            event: maybe_event,
+        }
+    }
+
+    async fn get_heap_statistics(&mut self) -> RuntimeHeapStatistics {
+        #[repr(C)]
+        struct InterruptData {
+            heap_tx: oneshot::Sender<WorkerHeapStatistics>,
+        }
+
+        extern "C" fn interrupt_fn(
+            isolate: &mut deno_core::v8::Isolate,
+            data: *mut std::ffi::c_void,
+        ) {
+            let arg = unsafe { Box::<InterruptData>::from_raw(data as *mut _) };
+            let mut v8_heap_stats = deno_core::v8::HeapStatistics::default();
+            let mut worker_heap_stats = WorkerHeapStatistics::default();
+
+            isolate.get_heap_statistics(&mut v8_heap_stats);
+
+            worker_heap_stats.total_heap_size = v8_heap_stats.total_heap_size();
+            worker_heap_stats.total_heap_executable = v8_heap_stats.total_heap_size_executable();
+            worker_heap_stats.total_physical_size = v8_heap_stats.total_physical_size();
+            worker_heap_stats.total_available_size = v8_heap_stats.total_available_size();
+            worker_heap_stats.total_global_handles_size = v8_heap_stats.total_global_handles_size();
+            worker_heap_stats.used_global_handles_size = v8_heap_stats.used_global_handles_size();
+            worker_heap_stats.used_heap_size = v8_heap_stats.used_heap_size();
+            worker_heap_stats.malloced_memory = v8_heap_stats.malloced_memory();
+            worker_heap_stats.external_memory = v8_heap_stats.external_memory();
+            worker_heap_stats.peak_malloced_memory = v8_heap_stats.peak_malloced_memory();
+
+            if let Err(err) = arg.heap_tx.send(worker_heap_stats) {
+                error!("failed to send worker heap statistics: {:?}", err);
+            }
+        }
+
+        let request_heap_statistics_fn = |arg: Option<&mut WorkerMetricSource>| {
+            let Some(source) = arg else {
+                return async { None::<WorkerHeapStatistics> }.boxed();
+            };
+
+            let (tx, rx) = oneshot::channel::<WorkerHeapStatistics>();
+            let data_ptr_mut = Box::into_raw(Box::new(InterruptData { heap_tx: tx }));
+
+            if !source
+                .handle
+                .request_interrupt(interrupt_fn, data_ptr_mut as *mut std::ffi::c_void)
+            {
+                drop(unsafe { Box::from_raw(data_ptr_mut) });
+                return async { None }.boxed();
+            }
+
+            let waker = source.waker.clone();
+
+            async move {
+                waker.wake();
+                rx.await.ok()
+            }
+            .boxed()
+        };
+
+        RuntimeHeapStatistics {
+            main_worker_heap_stats: request_heap_statistics_fn(Some(&mut self.main))
+                .await
+                .unwrap_or_default(),
+
+            event_worker_heap_stats: request_heap_statistics_fn(self.event.as_mut()).await,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct WorkerHeapStatistics {
+    total_heap_size: usize,
+    total_heap_executable: usize,
+    total_physical_size: usize,
+    total_available_size: usize,
+    total_global_handles_size: usize,
+    used_global_handles_size: usize,
+    used_heap_size: usize,
+    malloced_memory: usize,
+    external_memory: usize,
+    peak_malloced_memory: usize,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeHeapStatistics {
+    main_worker_heap_stats: WorkerHeapStatistics,
+    event_worker_heap_stats: Option<WorkerHeapStatistics>,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeMetrics {
+    #[serde(flatten)]
+    heap_stats: RuntimeHeapStatistics,
+
+    active_user_workers_count: usize,
+    retired_user_workers_count: usize,
+    received_requests_count: usize,
+    handled_requests_count: usize,
+}
+
 #[op2(fast)]
 fn op_is_terminal(state: &mut OpState, rid: u32) -> Result<bool, AnyError> {
     let handle = state.resource_table.get_handle(rid)?;
@@ -31,6 +182,21 @@ fn op_stdin_set_raw(_state: &mut OpState, _is_raw: bool, _cbreak: bool) -> Resul
 #[op2(fast)]
 fn op_console_size(_state: &mut OpState, #[buffer] _result: &mut [u32]) -> Result<(), AnyError> {
     Ok(())
+}
+
+#[op2(async)]
+#[serde]
+async fn op_runtime_metrics(state: Rc<RefCell<OpState>>) -> Result<RuntimeMetrics, AnyError> {
+    let state = state.borrow();
+    let mut runtime_metrics = RuntimeMetrics::default();
+
+    runtime_metrics.heap_stats = state
+        .borrow::<RuntimeMetricSource>()
+        .clone()
+        .get_heap_statistics()
+        .await;
+
+    Ok(runtime_metrics)
 }
 
 #[op2]
@@ -54,7 +220,8 @@ deno_core::extension!(
         op_stdin_set_raw,
         op_console_size,
         op_read_line_prompt,
-        op_set_exit_code
+        op_set_exit_code,
+        op_runtime_metrics
     ],
     esm_entry_point = "ext:sb_core_main_js/js/bootstrap.js",
     esm = [

--- a/crates/sb_workers/context.rs
+++ b/crates/sb_workers/context.rs
@@ -5,7 +5,7 @@ use event_worker::events::WorkerEventWithMetadata;
 use hyper::{Body, Request, Response};
 use sb_core::conn_sync::ConnSync;
 use sb_core::util::sync::AtomicFlag;
-use sb_core::WorkerMetricSource;
+use sb_core::{MetricSource, SharedMetricSource};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::{collections::HashMap, sync::Arc};
@@ -76,7 +76,8 @@ pub struct UserWorkerProfile {
 #[derive(Debug, Clone)]
 pub struct MainWorkerRuntimeOpts {
     pub worker_pool_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
-    pub event_worker_metric_src: Option<WorkerMetricSource>,
+    pub shared_metric_src: Option<SharedMetricSource>,
+    pub event_worker_metric_src: Option<MetricSource>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sb_workers/context.rs
+++ b/crates/sb_workers/context.rs
@@ -5,6 +5,7 @@ use event_worker::events::WorkerEventWithMetadata;
 use hyper::{Body, Request, Response};
 use sb_core::conn_sync::ConnSync;
 use sb_core::util::sync::AtomicFlag;
+use sb_core::WorkerMetricSource;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::{collections::HashMap, sync::Arc};
@@ -75,6 +76,7 @@ pub struct UserWorkerProfile {
 #[derive(Debug, Clone)]
 pub struct MainWorkerRuntimeOpts {
     pub worker_pool_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
+    pub event_worker_metric_src: Option<WorkerMetricSource>,
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +87,29 @@ pub enum WorkerRuntimeOpts {
     UserWorker(UserWorkerRuntimeOpts),
     MainWorker(MainWorkerRuntimeOpts),
     EventsWorker(EventWorkerRuntimeOpts),
+}
+
+impl WorkerRuntimeOpts {
+    pub fn to_worker_kind(&self) -> WorkerKind {
+        match self {
+            Self::UserWorker(_) => WorkerKind::UserWorker,
+            Self::MainWorker(_) => WorkerKind::MainWorker,
+            Self::EventsWorker(_) => WorkerKind::EventsWorker,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, EnumAsInner, PartialEq, Eq)]
+pub enum WorkerKind {
+    UserWorker,
+    MainWorker,
+    EventsWorker,
+}
+
+impl From<&WorkerRuntimeOpts> for WorkerKind {
+    fn from(value: &WorkerRuntimeOpts) -> Self {
+        value.to_worker_kind()
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -14,6 +14,11 @@ serve(async (req: Request) => {
 		);
 	}
 
+	if (pathname === '/_internal/metric') {
+		const metric = await EdgeRuntime.getRuntimeMetrics();
+		return Response.json(metric);
+	}
+
 	const path_parts = pathname.split('/');
 	const service_name = path_parts[1];
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

This PR exposes an API to get runtime metrics.

> Note: This API is only exposed in the main worker.


> Note 2: The number of pending requests is the difference between the number of handled requests and the number of received requests, so I didn’t include it in the metric.

Usage
```typescript
serve(async () => {
    ...
	if (pathname === '/_internal/metric') {
		const metric = await EdgeRuntime.getRuntimeMetrics();
		return Response.json(metric);
	}
    ...
})
```

Sample output
```json
{
    "mainWorkerHeapStats": {
        "totalHeapSize": 11730944,
        "totalHeapExecutable": 524288,
        "totalPhysicalSize": 11165696,
        "totalAvailableSize": 1508889368,
        "totalGlobalHandlesSize": 16384,
        "usedGlobalHandlesSize": 10144,
        "usedHeapSize": 10273032,
        "mallocedMemory": 278632,
        "externalMemory": 79991,
        "peakMallocedMemory": 139480
    },
    "eventWorkerHeapStats": {
        "totalHeapSize": 11468800,
        "totalHeapExecutable": 262144,
        "totalPhysicalSize": 10174464,
        "totalAvailableSize": 1509473792,
        "totalGlobalHandlesSize": 16384,
        "usedGlobalHandlesSize": 9504,
        "usedHeapSize": 9473440,
        "mallocedMemory": 278632,
        "externalMemory": 79991,
        "peakMallocedMemory": 173088
    },
    "activeUserWorkersCount": 1,
    "retiredUserWorkersCount": 2,
    "receivedRequestsCount": 17,
    "handledRequestsCount": 17
}
```