### PR TITLE
fix: make the runtime user agent respect the convention

### DIFF
--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -336,7 +336,7 @@ globalThis.bootstrapSBEdge = (opts, isUserWorker, isEventsWorker, edgeRuntimeVer
 	ObjectDefineProperty(globalThis, 'Deno', readOnly(denoOverrides));
 
 	setNumCpus(1); // explicitly setting no of CPUs to 1 (since we don't allow workers)
-	setUserAgent('Supabase Edge Runtime');
+	setUserAgent(`Deno/${globalThis.DENO_VERSION} (variant; SupabaseEdgeRuntime/${globalThis.SUPABASE_VERSION})`);
 	setLanguage('en');
 
 	if (isUserWorker) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Make edge-runtime conform to a known convention to make it more compatible with some services that check the prefix of the user agent.

Before
```typescript
console.log(navigator.userAgent);

// Output
// Supabase Edge Runtime
```

After
```typescript
console.log(navigator.userAgent);

// Output
// Deno/[deno version here] (variant; SupabaseEdgeRuntime/[release version here])
```

Before (Remote Server)
```json
{
    ...
    "headers": {
        "user-agent": "supabase-edge-runtime"
    },
    ...
}
```

After (Remote Server)
```json
{
    ...
    "headers": {
        "user-agent": "Deno/[deno version here](variant; SupabaseEdgeRuntime/[release version here])"
    },
    ...
}
```