### PR TITLE
feat: WebSocket upgrade support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0f8d64ef9351752fbe5462f242c625d9c4910d2bc3f7ec44c43857ca123f5d"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +419,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tungstenite",
  "url",
  "urlencoding",
  "uuid",
@@ -5994,6 +6008,7 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "hashbrown 0.14.3",
@@ -6091,6 +6106,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "async-tungstenite",
  "bytes",
  "cityhash",
  "cpu_timer",
@@ -380,6 +381,7 @@ dependencies = [
  "flume",
  "futures-util",
  "http 0.2.11",
+ "http_utils",
  "httparse",
  "hyper 0.14.28",
  "import_map",
@@ -2618,6 +2620,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "http_utils"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 0.2.11",
+ "hyper 0.14.28",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4795,6 +4809,7 @@ dependencies = [
  "enum-as-inner 0.6.0",
  "event_worker",
  "futures-util",
+ "http_utils",
  "hyper 0.14.28",
  "log",
  "sb_core",

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+http_utils = { version = "0.1.0", path = "../http_utils" }
 async-trait.workspace = true
 thiserror.workspace = true
 monch.workspace = true
@@ -31,7 +32,7 @@ deno_webidl = { workspace = true }
 deno_web = { workspace = true }
 deno_websocket = { workspace = true }
 httparse = { version = "1.8.0" }
-hyper = { workspace = true, features = ["full"] }
+hyper = { workspace = true, features = ["full", "backports"] }
 http = { version = "0.2" }
 import_map.workspace = true
 log = { workspace = true }

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -66,7 +66,10 @@ deno_webgpu.workspace = true
 sb_ai = { version = "0.1.0", path = "../sb_ai" }
 
 [dev-dependencies]
+tokio-util = { workspace = true, features = ["rt", "compat"] }
 serial_test = { version = "3.0.0" }
+async-tungstenite = { version = "0.25.0", default-features = false }
+tungstenite = { version = "0.21.0", default-features = false, features = ["handshake"] }
 
 [build-dependencies]
 sb_core = { version = "0.1.0", path = "../sb_core" }

--- a/crates/base/build.rs
+++ b/crates/base/build.rs
@@ -12,7 +12,8 @@ mod supabase_startup_snapshot {
     use event_worker::js_interceptors::sb_events_js_interceptors;
     use event_worker::sb_user_event_worker;
     use sb_ai::sb_ai;
-    use sb_core::http_start::sb_core_http;
+    use sb_core::http::sb_core_http;
+    use sb_core::http_start::sb_core_http_start;
     use sb_core::net::sb_core_net;
     use sb_core::permissions::sb_core_permissions;
     use sb_core::runtime::sb_core_runtime;
@@ -206,6 +207,7 @@ mod supabase_startup_snapshot {
             sb_core_main_js::init_ops_and_esm(),
             sb_core_net::init_ops_and_esm(),
             sb_core_http::init_ops_and_esm(),
+            sb_core_http_start::init_ops_and_esm(),
             deno_node::init_ops_and_esm::<Permissions>(None, fs),
             sb_core_runtime::init_ops_and_esm(None),
         ];

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -20,6 +20,8 @@ use futures_util::future::poll_fn;
 use log::{error, trace};
 use once_cell::sync::{Lazy, OnceCell};
 use sb_core::conn_sync::ConnSync;
+use sb_core::http::sb_core_http;
+use sb_core::http_start::sb_core_http_start;
 use sb_core::util::sync::AtomicFlag;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
@@ -37,7 +39,6 @@ use sb_ai::sb_ai;
 use sb_core::cache::CacheSetting;
 use sb_core::cert::ValueRootCertStoreProvider;
 use sb_core::external_memory::custom_allocator;
-use sb_core::http_start::sb_core_http;
 use sb_core::net::sb_core_net;
 use sb_core::permissions::{sb_core_permissions, Permissions};
 use sb_core::runtime::sb_core_runtime;
@@ -286,6 +287,7 @@ impl DenoRuntime {
             sb_core_main_js::init_ops(),
             sb_core_net::init_ops(),
             sb_core_http::init_ops(),
+            sb_core_http_start::init_ops(),
             deno_node::init_ops::<Permissions>(Some(npm_resolver), file_system),
             sb_core_runtime::init_ops(Some(main_module_url.clone())),
         ];

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -1,6 +1,6 @@
 use crate::deno_runtime::DenoRuntime;
+use crate::utils::send_event_if_event_worker_available;
 use crate::utils::units::bytes_to_display;
-use crate::utils::{emit_status_code, get_upgrade_type, send_event_if_event_worker_available};
 
 use crate::rt_worker::worker::{Worker, WorkerHandler};
 use crate::rt_worker::worker_pool::WorkerPool;
@@ -11,6 +11,7 @@ use event_worker::events::{
 };
 use http::StatusCode;
 use http_utils::io::Upgraded2;
+use http_utils::utils::{emit_status_code, get_upgrade_type};
 use hyper::client::conn::http1;
 use hyper::upgrade::OnUpgrade;
 use hyper::{Body, Request, Response};

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -160,7 +160,7 @@ impl Service<Request<Body>> for WorkerService {
                 parts,
                 Body::wrap_stream(NotifyOnEos {
                     inner: body,
-                    cancel: Some(cancel.clone()),
+                    cancel: Some(cancel),
                 }),
             );
 
@@ -294,7 +294,8 @@ impl Server {
                                     let _guard = cancel.drop_guard();
 
                                     let conn_fut = Http::new()
-                                        .serve_connection(conn, service);
+                                        .serve_connection(conn, service)
+                                        .with_upgrades();
 
                                     if let Err(e) = conn_fut.await {
                                         // Most common cause for these errors are

--- a/crates/base/src/utils.rs
+++ b/crates/base/src/utils.rs
@@ -1,4 +1,6 @@
 use event_worker::events::{EventMetadata, WorkerEventWithMetadata, WorkerEvents};
+use http::{header, response, HeaderMap, Response, StatusCode};
+use hyper::Body;
 use tokio::sync::mpsc;
 
 pub mod units;
@@ -11,4 +13,31 @@ pub fn send_event_if_event_worker_available(
     if let Some(event_worker) = maybe_event_worker {
         let _ = event_worker.send(WorkerEventWithMetadata { event, metadata });
     }
+}
+
+pub fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
+    let connection_header_exists = headers
+        .get(header::CONNECTION)
+        .map(|it| {
+            it.to_str()
+                .unwrap_or("")
+                .split(',')
+                .any(|str| str.trim() == header::UPGRADE)
+        })
+        .unwrap_or(false);
+
+    if connection_header_exists {
+        if let Some(upgrade) = headers.get(header::UPGRADE) {
+            return upgrade.to_str().ok().map(str::to_owned);
+        }
+    }
+
+    None
+}
+
+pub fn emit_status_code(status: StatusCode) -> Response<Body> {
+    response::Builder::new()
+        .status(status)
+        .body(Body::empty())
+        .unwrap()
 }

--- a/crates/base/src/utils.rs
+++ b/crates/base/src/utils.rs
@@ -1,6 +1,4 @@
 use event_worker::events::{EventMetadata, WorkerEventWithMetadata, WorkerEvents};
-use http::{header, response, HeaderMap, Response, StatusCode};
-use hyper::Body;
 use tokio::sync::mpsc;
 
 pub mod units;
@@ -13,31 +11,4 @@ pub fn send_event_if_event_worker_available(
     if let Some(event_worker) = maybe_event_worker {
         let _ = event_worker.send(WorkerEventWithMetadata { event, metadata });
     }
-}
-
-pub fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
-    let connection_header_exists = headers
-        .get(header::CONNECTION)
-        .map(|it| {
-            it.to_str()
-                .unwrap_or("")
-                .split(',')
-                .any(|str| str.trim() == header::UPGRADE)
-        })
-        .unwrap_or(false);
-
-    if connection_header_exists {
-        if let Some(upgrade) = headers.get(header::UPGRADE) {
-            return upgrade.to_str().ok().map(str::to_owned);
-        }
-    }
-
-    None
-}
-
-pub fn emit_status_code(status: StatusCode) -> Response<Body> {
-    response::Builder::new()
-        .status(status)
-        .body(Body::empty())
-        .unwrap()
 }

--- a/crates/base/test_cases/websocket-upgrade/index.ts
+++ b/crates/base/test_cases/websocket-upgrade/index.ts
@@ -1,0 +1,13 @@
+Deno.serve(async (req: Request) => {
+	const { socket, response } = Deno.upgradeWebSocket(req);
+
+	socket.onopen = () => {
+		socket.send("meow");
+	};
+
+	socket.onmessage = ev => {
+		socket.send(ev.data);
+	};
+
+	return response;
+});

--- a/crates/http_utils/Cargo.toml
+++ b/crates/http_utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "http_utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
+futures-util = { workspace = true }
+bytes = { workspace = true }
+hyper = { workspace = true, features = ["full"] }
+http = { version = "0.2" }

--- a/crates/http_utils/src/io/mod.rs
+++ b/crates/http_utils/src/io/mod.rs
@@ -1,0 +1,5 @@
+mod rewind;
+mod upgraded2;
+
+pub use self::rewind::Rewind;
+pub use self::upgraded2::Upgraded2;

--- a/crates/http_utils/src/io/rewind.rs
+++ b/crates/http_utils/src/io/rewind.rs
@@ -1,3 +1,6 @@
+// Copyright 2014-2021 Sean McArthur
+// SPDX-License-Identifier: MIT
+
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/crates/http_utils/src/io/rewind.rs
+++ b/crates/http_utils/src/io/rewind.rs
@@ -1,0 +1,84 @@
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{cmp, io};
+
+use bytes::{Buf, Bytes};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// Combine a buffer with an IO, rewinding reads to use the buffer.
+#[derive(Debug)]
+pub struct Rewind<T> {
+    pre: Option<Bytes>,
+    inner: T,
+}
+
+impl<T> Rewind<T> {
+    pub fn new_buffered(io: T, buf: Bytes) -> Self {
+        Rewind {
+            pre: Some(buf),
+            inner: io,
+        }
+    }
+}
+
+impl<T> AsyncRead for Rewind<T>
+where
+    T: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if let Some(mut prefix) = self.pre.take() {
+            // If there are no remaining bytes, let the bytes get dropped.
+            if !prefix.is_empty() {
+                let copy_len = cmp::min(prefix.len(), buf.remaining());
+                // TODO: There should be a way to do following two lines cleaner...
+                buf.put_slice(&prefix[..copy_len]);
+                prefix.advance(copy_len);
+                // Put back what's left
+                if !prefix.is_empty() {
+                    self.pre = Some(prefix);
+                }
+
+                return Poll::Ready(Ok(()));
+            }
+        }
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<T> AsyncWrite for Rewind<T>
+where
+    T: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}

--- a/crates/http_utils/src/io/upgraded2.rs
+++ b/crates/http_utils/src/io/upgraded2.rs
@@ -1,0 +1,75 @@
+use std::{
+    fmt, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::Rewind;
+
+trait Io: AsyncRead + AsyncWrite + Unpin + 'static {}
+
+impl<T: AsyncRead + AsyncWrite + Unpin + 'static> Io for T {}
+
+pub struct Upgraded2 {
+    io: Rewind<Box<dyn Io + Send>>,
+}
+
+impl Upgraded2 {
+    pub fn new<T>(io: T, read_buf: Bytes) -> Self
+    where
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        Upgraded2 {
+            io: Rewind::new_buffered(Box::new(io), read_buf),
+        }
+    }
+}
+
+impl AsyncRead for Upgraded2 {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for Upgraded2 {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.io).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.io.is_write_vectored()
+    }
+}
+
+impl fmt::Debug for Upgraded2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Upgraded2").finish()
+    }
+}

--- a/crates/http_utils/src/io/upgraded2.rs
+++ b/crates/http_utils/src/io/upgraded2.rs
@@ -1,3 +1,6 @@
+// Copyright 2014-2021 Sean McArthur
+// SPDX-License-Identifier: MIT
+
 use std::{
     fmt, io,
     pin::Pin,

--- a/crates/http_utils/src/lib.rs
+++ b/crates/http_utils/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod io;
+pub mod utils;

--- a/crates/http_utils/src/utils.rs
+++ b/crates/http_utils/src/utils.rs
@@ -1,0 +1,29 @@
+use http::{header, response, HeaderMap, Response, StatusCode};
+use hyper::Body;
+
+pub fn get_upgrade_type(headers: &HeaderMap) -> Option<String> {
+    let connection_header_exists = headers
+        .get(header::CONNECTION)
+        .map(|it| {
+            it.to_str()
+                .unwrap_or("")
+                .split(',')
+                .any(|str| str.trim() == header::UPGRADE)
+        })
+        .unwrap_or(false);
+
+    if connection_header_exists {
+        if let Some(upgrade) = headers.get(header::UPGRADE) {
+            return upgrade.to_str().ok().map(str::to_owned);
+        }
+    }
+
+    None
+}
+
+pub fn emit_status_code(status: StatusCode) -> Response<Body> {
+    response::Builder::new()
+        .status(status)
+        .body(Body::empty())
+        .unwrap()
+}

--- a/crates/sb_core/http.rs
+++ b/crates/sb_core/http.rs
@@ -1,0 +1,131 @@
+use std::{cell::RefCell, pin::Pin, rc::Rc, task::Poll};
+
+use deno_core::{
+    error::{custom_error, AnyError},
+    op2, Op, OpDecl, OpState, RcRef, ResourceId,
+};
+use deno_http::{HttpRequestReader, HttpStreamResource};
+use deno_websocket::ws_create_server_stream;
+use futures::pin_mut;
+use futures::ready;
+use futures::Future;
+use hyper::upgrade::Parts;
+use log::error;
+use tokio::net::UnixStream;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::watch,
+};
+
+use crate::conn_sync::ConnSync;
+
+deno_core::extension!(
+    sb_core_http,
+    ops = [op_http_upgrade_websocket2],
+    middleware = sb_http_middleware,
+);
+
+pub(crate) struct UnixStream2(UnixStream, Option<watch::Receiver<ConnSync>>);
+
+impl UnixStream2 {
+    pub fn new(stream: UnixStream, watcher: Option<watch::Receiver<ConnSync>>) -> Self {
+        Self(stream, watcher)
+    }
+}
+
+impl AsyncRead for UnixStream2 {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut Pin::into_inner(self).0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for UnixStream2 {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut Pin::into_inner(self).0).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut Pin::into_inner(self).0).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        if let Some(ref mut sync) = self.1 {
+            let fut = sync.wait_for(|it| *it == ConnSync::Recv);
+
+            pin_mut!(fut);
+            ready!(fut.poll(cx).map(|it| {
+                if let Err(ex) = it {
+                    error!("cannot track outbound connection correctly");
+                    return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, ex));
+                }
+
+                Ok(())
+            }))?
+        }
+
+        Pin::new(&mut Pin::into_inner(self).0).poll_shutdown(cx)
+    }
+}
+
+fn http_error(message: &'static str) -> AnyError {
+    custom_error("Http", message)
+}
+
+#[op2(async)]
+#[smi]
+async fn op_http_upgrade_websocket2(
+    state: Rc<RefCell<OpState>>,
+    #[smi] rid: ResourceId,
+) -> Result<ResourceId, AnyError> {
+    let stream = state
+        .borrow_mut()
+        .resource_table
+        .get::<HttpStreamResource>(rid)?;
+
+    let mut rd = RcRef::map(&stream, |r| &r.rd).borrow_mut().await;
+
+    let request = match &mut *rd {
+        HttpRequestReader::Headers(request) => request,
+        _ => return Err(http_error("cannot upgrade because request body was used")),
+    };
+
+    let upgraded = hyper::upgrade::on(request).await?;
+    let Parts { io, read_buf, .. } = upgraded.downcast::<UnixStream2>().unwrap();
+
+    let ws_rid = ws_create_server_stream(&mut state.borrow_mut(), io.0.into(), read_buf)?;
+    Ok(ws_rid)
+}
+
+fn sb_http_middleware(decl: OpDecl) -> OpDecl {
+    match decl.name {
+        "op_http_upgrade_websocket" => op_http_upgrade_websocket2::DECL,
+        _ => decl,
+    }
+}

--- a/crates/sb_core/http_start.rs
+++ b/crates/sb_core/http_start.rs
@@ -1,94 +1,22 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
-use std::pin::Pin;
 use std::rc::Rc;
-use std::task::Poll;
 
 use deno_core::error::bad_resource;
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
+use deno_core::op2;
 use deno_core::OpState;
 use deno_core::ResourceId;
-use deno_core::{op2, ToJsBuffer};
 use deno_http::http_create_conn_resource;
 use deno_net::io::UnixStreamResource;
-use futures::pin_mut;
-use futures::ready;
-use futures::Future;
-use log::error;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
-use tokio::net::UnixStream;
+
 use tokio::sync::watch;
 
 use crate::conn_sync::ConnSync;
 use crate::conn_sync::ConnWatcher;
-use serde::Serialize;
-
-struct UnixStream2(UnixStream, Option<watch::Receiver<ConnSync>>);
-
-impl AsyncRead for UnixStream2 {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut Pin::into_inner(self).0).poll_read(cx, buf)
-    }
-}
-
-impl AsyncWrite for UnixStream2 {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(&mut Pin::into_inner(self).0).poll_write(cx, buf)
-    }
-
-    fn poll_write_vectored(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        bufs: &[std::io::IoSlice<'_>],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(&mut Pin::into_inner(self).0).poll_write_vectored(cx, bufs)
-    }
-
-    fn is_write_vectored(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        if let Some(ref mut sync) = self.1 {
-            let fut = sync.wait_for(|it| *it == ConnSync::Recv);
-
-            pin_mut!(fut);
-            ready!(fut.poll(cx).map(|it| {
-                if let Err(ex) = it {
-                    error!("cannot track outbound connection correctly");
-                    return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, ex));
-                }
-
-                Ok(())
-            }))?
-        }
-
-        Pin::new(&mut Pin::into_inner(self).0).poll_shutdown(cx)
-    }
-}
+use crate::http::UnixStream2;
 
 #[op2]
 #[serde]
@@ -114,7 +42,7 @@ fn op_http_start(
         let addr: std::net::SocketAddr = "0.0.0.0:9999".parse().unwrap();
         let conn = http_create_conn_resource(
             state,
-            UnixStream2(unix_stream, watcher.clone()),
+            UnixStream2::new(unix_stream, watcher.clone()),
             addr,
             "http",
         )?;
@@ -127,21 +55,4 @@ fn op_http_start(
     Err(bad_resource_id())
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HttpUpgradeResult {
-    conn_rid: ResourceId,
-    conn_type: &'static str,
-    read_buf: ToJsBuffer,
-}
-
-#[op2(async)]
-#[serde]
-async fn op_http_upgrade(
-    _state: Rc<RefCell<OpState>>,
-    #[smi] _rid: ResourceId,
-) -> Result<(), AnyError> {
-    Ok(())
-}
-
-deno_core::extension!(sb_core_http, ops = [op_http_start, op_http_upgrade]);
+deno_core::extension!(sb_core_http_start, ops = [op_http_start]);

--- a/crates/sb_core/js/01_http.js
+++ b/crates/sb_core/js/01_http.js
@@ -1,0 +1,554 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { core, internals, primordials } from "ext:core/mod.js";
+const {
+  BadResourcePrototype,
+  InterruptedPrototype,
+} = core;
+import {
+  op_http_accept,
+  op_http_headers,
+  op_http_shutdown,
+  op_http_upgrade_websocket,
+  op_http_websocket_accept_header,
+  op_http_write,
+  op_http_write_headers,
+  op_http_write_resource,
+} from "ext:core/ops";
+const {
+  ArrayPrototypeIncludes,
+  ArrayPrototypeMap,
+  ArrayPrototypePush,
+  ObjectPrototypeIsPrototypeOf,
+  SafeSet,
+  SafeSetIterator,
+  SetPrototypeAdd,
+  SetPrototypeDelete,
+  StringPrototypeCharCodeAt,
+  StringPrototypeIncludes,
+  StringPrototypeSplit,
+  StringPrototypeToLowerCase,
+  StringPrototypeToUpperCase,
+  Symbol,
+  SymbolAsyncIterator,
+  TypeError,
+  TypedArrayPrototypeGetSymbolToStringTag,
+  Uint8Array,
+} = primordials;
+
+import { InnerBody } from "ext:deno_fetch/22_body.js";
+import { Event, setEventTargetData } from "ext:deno_web/02_event.js";
+import { BlobPrototype } from "ext:deno_web/09_file.js";
+import {
+  fromInnerResponse,
+  newInnerResponse,
+  ResponsePrototype,
+  toInnerResponse,
+} from "ext:deno_fetch/23_response.js";
+import {
+  fromInnerRequest,
+  newInnerRequest,
+  toInnerRequest,
+} from "ext:deno_fetch/23_request.js";
+import { AbortController } from "ext:deno_web/03_abort_signal.js";
+import {
+  _eventLoop,
+  _idleTimeoutDuration,
+  _idleTimeoutTimeout,
+  _protocol,
+  _readyState,
+  _rid,
+  _role,
+  _server,
+  _serverHandleIdleTimeout,
+  createWebSocketBranded,
+  SERVER,
+  WebSocket,
+} from "ext:deno_websocket/01_websocket.js";
+import {
+  getReadableStreamResourceBacking,
+  readableStreamClose,
+  readableStreamForRid,
+  ReadableStreamPrototype,
+} from "ext:deno_web/06_streams.js";
+import { serve } from "ext:deno_http/00_serve.js";
+import { SymbolDispose } from "ext:deno_web/00_infra.js";
+
+const connErrorSymbol = Symbol("connError");
+
+/** @type {(self: HttpConn, rid: number) => boolean} */
+let deleteManagedResource;
+
+class HttpConn {
+  #rid = 0;
+  #closed = false;
+  #remoteAddr;
+  #localAddr;
+
+  // This set holds resource ids of resources
+  // that were created during lifecycle of this request.
+  // When the connection is closed these resources should be closed
+  // as well.
+  #managedResources = new SafeSet();
+
+  static {
+    deleteManagedResource = (self, rid) =>
+      SetPrototypeDelete(self.#managedResources, rid);
+  }
+
+  constructor(rid, remoteAddr, localAddr) {
+    this.#rid = rid;
+    this.#remoteAddr = remoteAddr;
+    this.#localAddr = localAddr;
+  }
+
+  /** @returns {number} */
+  get rid() {
+    return this.#rid;
+  }
+
+  /** @returns {Promise<RequestEvent | null>} */
+  async nextRequest() {
+    let nextRequest;
+    try {
+      nextRequest = await op_http_accept(this.#rid);
+    } catch (error) {
+      this.close();
+      // A connection error seen here would cause disrupted responses to throw
+      // a generic `BadResource` error. Instead store this error and replace
+      // those with it.
+      this[connErrorSymbol] = error;
+      if (
+        ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error) ||
+        ObjectPrototypeIsPrototypeOf(InterruptedPrototype, error) ||
+        StringPrototypeIncludes(error.message, "connection closed")
+      ) {
+        return null;
+      }
+      throw error;
+    }
+    if (nextRequest == null) {
+      // Work-around for servers (deno_std/http in particular) that call
+      // `nextRequest()` before upgrading a previous request which has a
+      // `connection: upgrade` header.
+      await null;
+
+      this.close();
+      return null;
+    }
+
+    const { 0: streamRid, 1: method, 2: url } = nextRequest;
+    SetPrototypeAdd(this.#managedResources, streamRid);
+
+    /** @type {ReadableStream<Uint8Array> | undefined} */
+    let body = null;
+    // There might be a body, but we don't expose it for GET/HEAD requests.
+    // It will be closed automatically once the request has been handled and
+    // the response has been sent.
+    if (method !== "GET" && method !== "HEAD") {
+      body = readableStreamForRid(streamRid, false);
+    }
+
+    const innerRequest = newInnerRequest(
+      method,
+      url,
+      () => op_http_headers(streamRid),
+      body !== null ? new InnerBody(body) : null,
+      false,
+    );
+
+    const abortController = new AbortController();
+    const request = fromInnerRequest(
+      innerRequest,
+      abortController.signal,
+      "immutable",
+      false,
+    );
+
+    const respondWith = createRespondWith(
+      this,
+      streamRid,
+      abortController,
+    );
+
+    return { request, respondWith, streamRid };
+  }
+
+  /** @returns {void} */
+  close() {
+    if (!this.#closed) {
+      this.#closed = true;
+      core.close(this.#rid);
+      for (const rid of new SafeSetIterator(this.#managedResources)) {
+        SetPrototypeDelete(this.#managedResources, rid);
+        core.close(rid);
+      }
+    }
+  }
+
+  [SymbolDispose]() {
+    core.tryClose(this.#rid);
+    for (const rid of new SafeSetIterator(this.#managedResources)) {
+      SetPrototypeDelete(this.#managedResources, rid);
+      core.tryClose(rid);
+    }
+  }
+
+  [SymbolAsyncIterator]() {
+    // deno-lint-ignore no-this-alias
+    const httpConn = this;
+    return {
+      async next() {
+        const reqEvt = await httpConn.nextRequest();
+        // Change with caution, current form avoids a v8 deopt
+        return { value: reqEvt ?? undefined, done: reqEvt === null };
+      },
+    };
+  }
+}
+
+function createRespondWith(
+  httpConn,
+  streamRid,
+  abortController,
+) {
+  return async function respondWith(resp) {
+    try {
+      resp = await resp;
+      if (!(ObjectPrototypeIsPrototypeOf(ResponsePrototype, resp))) {
+        throw new TypeError(
+          "First argument to respondWith must be a Response or a promise resolving to a Response.",
+        );
+      }
+
+      const innerResp = toInnerResponse(resp);
+
+      // If response body length is known, it will be sent synchronously in a
+      // single op, in other case a "response body" resource will be created and
+      // we'll be streaming it.
+      /** @type {ReadableStream<Uint8Array> | Uint8Array | null} */
+      let respBody = null;
+      if (innerResp.body !== null) {
+        if (innerResp.body.unusable()) {
+          throw new TypeError("Body is unusable.");
+        }
+        if (
+          ObjectPrototypeIsPrototypeOf(
+            ReadableStreamPrototype,
+            innerResp.body.streamOrStatic,
+          )
+        ) {
+          if (
+            innerResp.body.length === null ||
+            ObjectPrototypeIsPrototypeOf(
+              BlobPrototype,
+              innerResp.body.source,
+            )
+          ) {
+            respBody = innerResp.body.stream;
+          } else {
+            const reader = innerResp.body.stream.getReader();
+            const r1 = await reader.read();
+            if (r1.done) {
+              respBody = new Uint8Array(0);
+            } else {
+              respBody = r1.value;
+              const r2 = await reader.read();
+              if (!r2.done) throw new TypeError("Unreachable");
+            }
+          }
+        } else {
+          innerResp.body.streamOrStatic.consumed = true;
+          respBody = innerResp.body.streamOrStatic.body;
+        }
+      } else {
+        respBody = new Uint8Array(0);
+      }
+      const isStreamingResponseBody = !(
+        typeof respBody === "string" ||
+        TypedArrayPrototypeGetSymbolToStringTag(respBody) === "Uint8Array"
+      );
+      try {
+        await op_http_write_headers(
+          streamRid,
+          innerResp.status ?? 200,
+          innerResp.headerList,
+          isStreamingResponseBody ? null : respBody,
+        );
+      } catch (error) {
+        const connError = httpConn[connErrorSymbol];
+        if (
+          ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error) &&
+          connError != null
+        ) {
+          // deno-lint-ignore no-ex-assign
+          error = new connError.constructor(connError.message);
+        }
+        if (
+          respBody !== null &&
+          ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, respBody)
+        ) {
+          await respBody.cancel(error);
+        }
+        throw error;
+      }
+
+      if (isStreamingResponseBody) {
+        let success = false;
+        if (
+          respBody === null ||
+          !ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, respBody)
+        ) {
+          throw new TypeError("Unreachable");
+        }
+        const resourceBacking = getReadableStreamResourceBacking(respBody);
+        let reader;
+        if (resourceBacking) {
+          if (respBody.locked) {
+            throw new TypeError("ReadableStream is locked.");
+          }
+          reader = respBody.getReader(); // Acquire JS lock.
+          try {
+            await op_http_write_resource(
+              streamRid,
+              resourceBacking.rid,
+            );
+            if (resourceBacking.autoClose) core.tryClose(resourceBacking.rid);
+            readableStreamClose(respBody); // Release JS lock.
+            success = true;
+          } catch (error) {
+            const connError = httpConn[connErrorSymbol];
+            if (
+              ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error) &&
+              connError != null
+            ) {
+              // deno-lint-ignore no-ex-assign
+              error = new connError.constructor(connError.message);
+            }
+            await reader.cancel(error);
+            throw error;
+          }
+        } else {
+          reader = respBody.getReader();
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            if (
+              TypedArrayPrototypeGetSymbolToStringTag(value) !== "Uint8Array"
+            ) {
+              await reader.cancel(new TypeError("Value not a Uint8Array"));
+              break;
+            }
+            try {
+              await op_http_write(streamRid, value);
+            } catch (error) {
+              const connError = httpConn[connErrorSymbol];
+              if (
+                ObjectPrototypeIsPrototypeOf(BadResourcePrototype, error) &&
+                connError != null
+              ) {
+                // deno-lint-ignore no-ex-assign
+                error = new connError.constructor(connError.message);
+              }
+              await reader.cancel(error);
+              throw error;
+            }
+          }
+          success = true;
+        }
+
+        if (success) {
+          try {
+            await op_http_shutdown(streamRid);
+          } catch (error) {
+            await reader.cancel(error);
+            throw error;
+          }
+        }
+      }
+
+      const ws = resp[_ws];
+      if (ws) {
+        const wsRid = await op_http_upgrade_websocket(
+          streamRid,
+        );
+        ws[_rid] = wsRid;
+        ws[_protocol] = resp.headers.get("sec-websocket-protocol");
+
+        httpConn.close();
+
+        ws[_readyState] = WebSocket.OPEN;
+        ws[_role] = SERVER;
+        const event = new Event("open");
+        ws.dispatchEvent(event);
+
+        ws[_eventLoop]();
+        if (ws[_idleTimeoutDuration]) {
+          ws.addEventListener(
+            "close",
+            () => clearTimeout(ws[_idleTimeoutTimeout]),
+          );
+        }
+        ws[_serverHandleIdleTimeout]();
+      }
+    } catch (error) {
+      abortController.abort(error);
+      throw error;
+    } finally {
+      if (deleteManagedResource(httpConn, streamRid)) {
+        core.close(streamRid);
+      }
+    }
+  };
+}
+
+const _ws = Symbol("[[associated_ws]]");
+const websocketCvf = buildCaseInsensitiveCommaValueFinder("websocket");
+const upgradeCvf = buildCaseInsensitiveCommaValueFinder("upgrade");
+
+function upgradeWebSocket(request, options = {}) {
+  const inner = toInnerRequest(request);
+  const upgrade = request.headers.get("upgrade");
+  const upgradeHasWebSocketOption = upgrade !== null &&
+    websocketCvf(upgrade);
+  if (!upgradeHasWebSocketOption) {
+    throw new TypeError(
+      "Invalid Header: 'upgrade' header must contain 'websocket'",
+    );
+  }
+
+  const connection = request.headers.get("connection");
+  const connectionHasUpgradeOption = connection !== null &&
+    upgradeCvf(connection);
+  if (!connectionHasUpgradeOption) {
+    throw new TypeError(
+      "Invalid Header: 'connection' header must contain 'Upgrade'",
+    );
+  }
+
+  const websocketKey = request.headers.get("sec-websocket-key");
+  if (websocketKey === null) {
+    throw new TypeError(
+      "Invalid Header: 'sec-websocket-key' header must be set",
+    );
+  }
+
+  const accept = op_http_websocket_accept_header(websocketKey);
+
+  const r = newInnerResponse(101);
+  r.headerList = [
+    ["upgrade", "websocket"],
+    ["connection", "Upgrade"],
+    ["sec-websocket-accept", accept],
+  ];
+
+  const protocolsStr = request.headers.get("sec-websocket-protocol") || "";
+  const protocols = StringPrototypeSplit(protocolsStr, ", ");
+  if (protocols && options.protocol) {
+    if (ArrayPrototypeIncludes(protocols, options.protocol)) {
+      ArrayPrototypePush(r.headerList, [
+        "sec-websocket-protocol",
+        options.protocol,
+      ]);
+    } else {
+      throw new TypeError(
+        `Protocol '${options.protocol}' not in the request's protocol list (non negotiable)`,
+      );
+    }
+  }
+
+  const socket = createWebSocketBranded(WebSocket);
+  setEventTargetData(socket);
+  socket[_server] = true;
+  socket[_idleTimeoutDuration] = options.idleTimeout ?? 120;
+  socket[_idleTimeoutTimeout] = null;
+
+  if (inner._wantsUpgrade) {
+    return inner._wantsUpgrade("upgradeWebSocket", r, socket);
+  }
+
+  const response = fromInnerResponse(r, "immutable");
+
+  response[_ws] = socket;
+
+  return { response, socket };
+}
+
+const spaceCharCode = StringPrototypeCharCodeAt(" ", 0);
+const tabCharCode = StringPrototypeCharCodeAt("\t", 0);
+const commaCharCode = StringPrototypeCharCodeAt(",", 0);
+
+/** Builds a case function that can be used to find a case insensitive
+ * value in some text that's separated by commas.
+ *
+ * This is done because it doesn't require any allocations.
+ * @param checkText {string} - The text to find. (ex. "websocket")
+ */
+function buildCaseInsensitiveCommaValueFinder(checkText) {
+  const charCodes = ArrayPrototypeMap(
+    StringPrototypeSplit(
+      StringPrototypeToLowerCase(checkText),
+      "",
+    ),
+    (c) => [
+      StringPrototypeCharCodeAt(c, 0),
+      StringPrototypeCharCodeAt(StringPrototypeToUpperCase(c), 0),
+    ],
+  );
+  /** @type {number} */
+  let i;
+  /** @type {number} */
+  let char;
+
+  /** @param {string} value */
+  return function (value) {
+    for (i = 0; i < value.length; i++) {
+      char = StringPrototypeCharCodeAt(value, i);
+      skipWhitespace(value);
+
+      if (hasWord(value)) {
+        skipWhitespace(value);
+        if (i === value.length || char === commaCharCode) {
+          return true;
+        }
+      } else {
+        skipUntilComma(value);
+      }
+    }
+
+    return false;
+  };
+
+  /** @param value {string} */
+  function hasWord(value) {
+    for (let j = 0; j < charCodes.length; ++j) {
+      const { 0: cLower, 1: cUpper } = charCodes[j];
+      if (cLower === char || cUpper === char) {
+        char = StringPrototypeCharCodeAt(value, ++i);
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @param value {string} */
+  function skipWhitespace(value) {
+    while (char === spaceCharCode || char === tabCharCode) {
+      char = StringPrototypeCharCodeAt(value, ++i);
+    }
+  }
+
+  /** @param value {string} */
+  function skipUntilComma(value) {
+    while (char !== commaCharCode && i < value.length) {
+      char = StringPrototypeCharCodeAt(value, ++i);
+    }
+  }
+}
+
+// Expose this function for unit tests
+internals.buildCaseInsensitiveCommaValueFinder =
+  buildCaseInsensitiveCommaValueFinder;
+
+export { _ws, HttpConn, serve, upgradeWebSocket };

--- a/crates/sb_core/js/denoOverrides.js
+++ b/crates/sb_core/js/denoOverrides.js
@@ -3,7 +3,7 @@ import * as tls from 'ext:deno_net/02_tls.js';
 import * as timers from 'ext:deno_web/02_timers.js';
 import * as permissions from 'ext:sb_core_main_js/js/permissions.js';
 import { errors } from 'ext:sb_core_main_js/js/errors.js';
-import { serve, serveHttp } from 'ext:sb_core_main_js/js/http.js';
+import { serve, serveHttp, upgradeWebSocket } from 'ext:sb_core_main_js/js/http.js';
 import * as fs from 'ext:deno_fs/30_fs.js';
 import { osCalls } from 'ext:sb_os/os.js';
 import * as io from 'ext:deno_io/12_io.js';
@@ -95,20 +95,21 @@ const ioVars = {
 };
 
 const denoOverrides = {
+	serve,
+	serveHttp,
+	upgradeWebSocket,
 	listen: net.listen,
 	connect: net.connect,
 	connectTls: tls.connectTls,
 	startTls: tls.startTls,
 	resolveDns: net.resolveDns,
-	serveHttp: serveHttp,
-	serve: serve,
 	permissions: permissions.permissions,
 	Permissions: permissions.Permissions,
 	PermissionStatus: permissions.PermissionStatus,
 	errors: errors,
 	refTimer: timers.refTimer,
 	unrefTimer: timers.unrefTimer,
-	isatty: (arg) => false,
+	isatty: (_arg) => false,
 	...ioVars,
 	...fsVars,
 	...osCallsVars,

--- a/crates/sb_core/js/http.js
+++ b/crates/sb_core/js/http.js
@@ -1,6 +1,8 @@
-import { HttpConn } from 'ext:deno_http/01_http.js';
-import { RequestPrototype } from 'ext:deno_fetch/23_request.js';
+import "ext:deno_http/01_http.js";
+
 import { core, primordials } from "ext:core/mod.js";
+import { RequestPrototype } from "ext:deno_fetch/23_request.js";
+import { HttpConn, upgradeWebSocket } from "ext:sb_core_main_js/js/01_http.js";
 
 const { internalRidSymbol } = core;
 const { ObjectPrototypeIsPrototypeOf } = primordials;
@@ -9,7 +11,7 @@ const HttpConnPrototypeNextRequest = HttpConn.prototype.nextRequest;
 const HttpConnPrototypeClose = HttpConn.prototype.close;
 const ops = core.ops;
 
-const watcher = Symbol("watcher");
+const kSupabaseTag = Symbol("kSupabaseTag");
 
 function internalServerError() {
 	// "Internal Server Error"
@@ -52,7 +54,10 @@ function serveHttp(conn) {
 			return null;
 		}
 
-		nextRequest.request[watcher] = watcherRid;
+		nextRequest.request[kSupabaseTag] = {
+			watcherRid,
+			streamRid: nextRequest.streamRid
+		};
 
 		return nextRequest;
 	};
@@ -138,19 +143,25 @@ async function serve(args1, args2) {
 	};
 }
 
-function getWatcherRid(req) {
-	return req[watcher];
+function getSupabaseTag(req) {
+	return req[kSupabaseTag];
 }
 
-function applyWatcherRid(src, dest) {
+function applySupabaseTag(src, dest) {
 	if (
 		!ObjectPrototypeIsPrototypeOf(RequestPrototype, src) 
 		|| !ObjectPrototypeIsPrototypeOf(RequestPrototype, dest)
 	) {
-		throw new TypeError("Only Request instance can apply the connection watcher");
+		throw new TypeError("Only Request instance can apply the supabase tag");
 	}
 
-	dest[watcher] = src[watcher];
+	dest[kSupabaseTag] = src[kSupabaseTag];
 }
 
-export { serve, serveHttp, getWatcherRid, applyWatcherRid };
+export { 
+	serve,
+	serveHttp,
+	getSupabaseTag,
+	applySupabaseTag,
+	upgradeWebSocket
+};

--- a/crates/sb_core/js/main_worker.js
+++ b/crates/sb_core/js/main_worker.js
@@ -1,5 +1,5 @@
 import { SUPABASE_USER_WORKERS } from "ext:sb_user_workers/user_workers.js";
-import { applyWatcherRid } from "ext:sb_core_main_js/js/http.js";
+import { applySupabaseTag } from "ext:sb_core_main_js/js/http.js";
 import { core } from "ext:core/mod.js";
 
 const ops = core.ops;
@@ -9,9 +9,7 @@ Object.defineProperty(globalThis, 'EdgeRuntime', {
 		return {
 			userWorkers: SUPABASE_USER_WORKERS,
 			getRuntimeMetrics: () => /* async */ ops.op_runtime_metrics(),
-			applyConnectionWatcher: (src, dest) => {
-				applyWatcherRid(src, dest);
-			}
+			applySupabaseTag: (src, dest) => applySupabaseTag(src, dest),
 		};
 	},
 	configurable: true,

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -22,6 +22,7 @@ pub mod emit;
 pub mod errors_rt;
 pub mod external_memory;
 pub mod file_fetcher;
+pub mod http;
 pub mod http_start;
 pub mod net;
 pub mod permissions;

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -303,5 +303,6 @@ deno_core::extension!(
         "js/navigator.js",
         "js/bootstrap.js",
         "js/main_worker.js",
+        "js/01_http.js"
     ]
 );

--- a/crates/sb_workers/Cargo.toml
+++ b/crates/sb_workers/Cargo.toml
@@ -23,6 +23,7 @@ log.workspace = true
 enum-as-inner.workspace = true
 futures-util.workspace = true
 thiserror.workspace = true
+http_utils = { version = "0.1.0", path = "../http_utils" }
 event_worker = { version = "0.1.0", path = "../event_worker" }
 sb_graph = { version = "0.1.0", path = "../sb_graph" }
 sb_core = { version = "0.1.0", path = "../sb_core" }

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -15,9 +15,12 @@ use deno_core::{
     AsyncRefCell, AsyncResult, BufView, ByteString, CancelFuture, CancelHandle, CancelTryFuture,
     JsBuffer, OpState, RcRef, Resource, ResourceId, WriteOutcome,
 };
+use deno_http::{HttpRequestReader, HttpStreamResource};
 use errors::WorkerError;
+use http_utils::utils::get_upgrade_type;
 use hyper::body::HttpBody;
 use hyper::header::{HeaderName, HeaderValue, CONTENT_LENGTH};
+use hyper::upgrade::OnUpgrade;
 use hyper::{Body, Method, Request};
 use log::error;
 use sb_core::conn_sync::{ConnSync, ConnWatcher};
@@ -324,7 +327,7 @@ pub fn op_user_worker_fetch_build(
 ) -> Result<UserWorkerBuiltRequest, AnyError> {
     let method = Method::from_bytes(&req.method)?;
 
-    let mut request = Request::builder().uri(req.url).method(&method);
+    let mut builder = Request::builder().uri(req.url).method(&method);
     let mut body = Body::empty();
     let mut request_body_rid = None;
 
@@ -353,12 +356,12 @@ pub fn op_user_worker_fetch_build(
                 header_value = HeaderValue::from(0);
             }
 
-            request = request.header(header_name, header_value);
+            builder = builder.header(header_name, header_value);
         }
     }
 
-    let request = request.body(body)?;
-    let request_rid = state.resource_table.add(UserWorkerRequestResource(request));
+    let req = builder.body(body)?;
+    let request_rid = state.resource_table.add(UserWorkerRequestResource(req));
 
     Ok(UserWorkerBuiltRequest {
         request_rid,
@@ -375,22 +378,41 @@ pub async fn op_user_worker_fetch_send(
     #[smi] stream_rid: ResourceId,
     #[smi] watcher_rid: Option<ResourceId>,
 ) -> Result<UserWorkerResponse, AnyError> {
-    let (tx, request) = {
-        let mut op_state = state.borrow_mut();
-        let tx = op_state
-            .borrow::<mpsc::UnboundedSender<UserWorkerMsgs>>()
-            .clone();
+    let (tx, req) = {
+        let (tx, mut req) = {
+            let mut op_state = state.borrow_mut();
+            let tx = op_state
+                .borrow::<mpsc::UnboundedSender<UserWorkerMsgs>>()
+                .clone();
 
-        let request = op_state
-            .resource_table
-            .take::<UserWorkerRequestResource>(rid)?;
+            let req = Rc::try_unwrap(
+                op_state
+                    .resource_table
+                    .take::<UserWorkerRequestResource>(rid)?,
+            )
+            .ok()
+            .expect("multiple op_user_worker_fetch_send ongoing");
 
-        (tx, request)
+            (tx, req)
+        };
+
+        if get_upgrade_type(req.0.headers()).is_some() {
+            let req_stream = state
+                .borrow_mut()
+                .resource_table
+                .get::<HttpStreamResource>(stream_rid)?;
+
+            let mut req_reader_mut = RcRef::map(&req_stream, |r| &r.rd).borrow_mut().await;
+
+            if let HttpRequestReader::Headers(orig_req) = &mut *req_reader_mut {
+                if let Some(upgrade) = orig_req.extensions_mut().remove::<OnUpgrade>() {
+                    let _ = req.0.extensions_mut().insert(upgrade);
+                }
+            }
+        }
+
+        (tx, req)
     };
-
-    let request = Rc::try_unwrap(request)
-        .ok()
-        .expect("multiple op_user_worker_fetch_send ongoing");
 
     let (result_tx, result_rx) = oneshot::channel::<Result<SendRequestResult, Error>>();
     let key_parsed = Uuid::try_parse(key.as_str())?;
@@ -417,14 +439,14 @@ pub async fn op_user_worker_fetch_send(
 
     tx.send(UserWorkerMsgs::SendRequest(
         key_parsed,
-        request.0,
+        req.0,
         result_tx,
         watcher.clone(),
     ))?;
 
-    let result = result_rx.await?;
-    let (result, req_end_tx) = match result {
-        Ok((result, req_end_tx)) => (result, req_end_tx),
+    let res = result_rx.await?;
+    let (res, req_end_tx) = match res {
+        Ok((res, req_end_tx)) => (res, req_end_tx),
         Err(err) => {
             error!("user worker failed to respond: {}", err);
             match err.downcast_ref() {
@@ -443,24 +465,23 @@ pub async fn op_user_worker_fetch_send(
     };
 
     let mut headers = vec![];
-    for (key, value) in result.headers().iter() {
+    for (key, value) in res.headers().iter() {
         headers.push((
             ByteString::from(key.as_str()),
             ByteString::from(value.to_str().unwrap_or_default()),
         ));
     }
 
-    let status = result.status().as_u16();
-    let status_text = result
+    let status = res.status().as_u16();
+    let status_text = res
         .status()
         .canonical_reason()
         .unwrap_or("<unknown status code>")
         .to_string();
 
-    let size = HttpBody::size_hint(result.body()).exact();
+    let size = HttpBody::size_hint(res.body()).exact();
     let stream: BytesStream = Box::pin(
-        result
-            .into_body()
+        res.into_body()
             .map(|r| r.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))),
     );
 

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -372,6 +372,7 @@ pub async fn op_user_worker_fetch_send(
     state: Rc<RefCell<OpState>>,
     #[string] key: String,
     #[smi] rid: ResourceId,
+    #[smi] stream_rid: ResourceId,
     #[smi] watcher_rid: Option<ResourceId>,
 ) -> Result<UserWorkerResponse, AnyError> {
     let (tx, request) = {

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -19,6 +19,28 @@ serve(async (req: Request) => {
 		return Response.json(metric);
 	}
 
+	// NOTE: You can test WebSocket in the main worker by uncommenting below.
+	// if (pathname === '/_internal/ws') {
+	// 	const upgrade = req.headers.get("upgrade") || "";
+
+	// 	if (upgrade.toLowerCase() != "websocket") {
+	// 		return new Response("request isn't trying to upgrade to websocket.");
+	// 	}
+	
+	// 	const { socket, response } = Deno.upgradeWebSocket(req);
+	
+	// 	socket.onopen = () => console.log("socket opened");
+	// 	socket.onmessage = (e) => {
+	// 		console.log("socket message:", e.data);
+	// 		socket.send(new Date().toString());
+	// 	};
+	
+	// 	socket.onerror = e => console.log("socket errored:", e.message);
+	// 	socket.onclose = () => console.log("socket closed");
+	
+	// 	return response; // 101 (Switching Protocols)
+	// }
+
 	const path_parts = pathname.split('/');
 	const service_name = path_parts[1];
 

--- a/examples/oak-ws/index.ts
+++ b/examples/oak-ws/index.ts
@@ -1,0 +1,33 @@
+import { Application, Router } from "https://deno.land/x/oak@v12.3.0/mod.ts";
+
+const router = new Router();
+
+router
+    // Note: path will be prefixed with function name
+    .get("/oak-ws", ctx => {
+        if (!ctx.isUpgradable) {
+            ctx.throw(501);
+        }
+
+        const ws = ctx.upgrade();
+
+        ws.onopen = () => {
+            console.log("Connected to client");
+            ws.send("Hello from server!");
+        };
+
+        ws.onmessage = m => {
+            console.log("Got message from client: ", m.data);
+            ws.send(m.data as string);
+            ws.close();
+        };
+
+        ws.onclose = () => console.log("Disconncted from client");
+    })
+
+const app = new Application();
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen();

--- a/examples/ws/index.ts
+++ b/examples/ws/index.ts
@@ -1,0 +1,20 @@
+Deno.serve(req => {
+    const upgrade = req.headers.get("upgrade") || "";
+
+    if (upgrade.toLowerCase() != "websocket") {
+        return new Response("request isn't trying to upgrade to websocket.");
+    }
+
+    const { socket, response } = Deno.upgradeWebSocket(req);
+
+    socket.onopen = () => console.log("socket opened");
+    socket.onmessage = (e) => {
+        console.log("socket message:", e.data);
+        socket.send(new Date().toString());
+    };
+
+    socket.onerror = e => console.log("socket errored:", e.message);
+    socket.onclose = () => console.log("socket closed");
+
+    return response;
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

This PR is to make it possible for the (user/main) worker to upgrade incoming requests to the WebSocket protocol.

### Breaking changes

* `EdgeRuntime.applyConnectionWatcher` is replaced by `EdgeRuntime.applySupabaseTag`
  This change is a result of the need to track multiple pieces of data.