### PR TITLE
fix: value must be aligned to the time unit being logged

### DIFF
--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -260,7 +260,7 @@ impl Worker {
                                 cpu_time_used,
                                 ..
                             }) => {
-                                debug!("CPU time used: {:?}ms", cpu_time_used);
+                                debug!("CPU time used: {:?}ms", cpu_time_used / 1_000_000);
                             }
 
                             _ => {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Align the value correctly to the time unit