### PR TITLE
fix: use `core.build` variable instead of maintain own `build` constant

### DIFF
--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -235,29 +235,6 @@ const globalScope = {
 	[webidl.brand]: nonEnumerable(webidl.brand),
 };
 
-// set build info
-const build = {
-	target: 'unknown',
-	arch: 'unknown',
-	os: 'unknown',
-	vendor: 'unknown',
-	env: undefined,
-};
-
-function setBuildInfo(target) {
-	const { 0: arch, 1: vendor, 2: os, 3: env } = StringPrototypeSplit(
-		target,
-		'-',
-		4,
-	);
-	build.target = target;
-	build.arch = arch;
-	build.vendor = vendor;
-	build.os = os;
-	build.env = env;
-
-	ObjectFreeze(build);
-}
 
 function runtimeStart(runtimeOptions, source) {
 	core.setMacrotaskCallback(timers.handleTimerMacrotask);
@@ -266,7 +243,6 @@ function runtimeStart(runtimeOptions, source) {
 
 	ops.op_set_format_exception_callback(formatException);
 
-	setBuildInfo(runtimeOptions.target);
 	core.setBuildInfo(runtimeOptions.target);
 
 	// deno-lint-ignore prefer-primordials
@@ -330,7 +306,7 @@ globalThis.bootstrapSBEdge = (
 
 	// set these overrides after runtimeStart
 	ObjectDefineProperties(denoOverrides, {
-		build: readOnly(build),
+		build: readOnly(core.build),
 		env: readOnly(SUPABASE_ENV),
 		pid: readOnly(globalThis.__pid),
 		args: readOnly([]), // args are set to be empty


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Keep build info more concisely.

```typescript
console.log("Deno.build: ", Deno.build);
console.log("node.process.arch: ", process.arch);
console.log("Deno.version: ", Deno.version);
// ...

// Output

// Deno.build: {
//   target: "aarch64-unknown-linux-gnu",
//   arch: "aarch64",
//   os: "linux",
//   vendor: "unknown",
//   env: "gnu"
// }

// node.process.arch: arm64

// Deno.version: {
//   deno: "supabase-edge-runtime-0.1.0 (compatible with Deno v1.40.3)",
//   v8: "11.6.189.12",
//   typescript: "5.1.6"
// }
```

cc @laktek @andreespirela