### PR TITLE
chore: rid some rustc and clippy lints introduced in v1.77.0

### DIFF
--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -603,22 +603,16 @@ impl WorkerPool {
         }
     }
 
-    #[allow(clippy::question_mark)]
     fn maybe_active_worker(&mut self, service_path: &String, force_create: bool) -> Option<Uuid> {
         if force_create {
             return None;
         }
 
-        let Some(registry) = self.active_workers.get_mut(service_path) else {
-            return None;
-        };
-
+        let registry = self.active_workers.get_mut(service_path)?;
         let policy = self.policy.supervisor_policy;
-        let mut advance_fn = move || registry.mark_used_and_try_advance(policy).copied();
 
-        let Some(worker_uuid) = advance_fn() else {
-            return None;
-        };
+        let mut advance_fn = move || registry.mark_used_and_try_advance(policy).copied();
+        let worker_uuid = advance_fn()?;
 
         match self
             .user_workers

--- a/crates/cpu_timer/src/lib.rs
+++ b/crates/cpu_timer/src/lib.rs
@@ -26,13 +26,15 @@ mod linux {
         Remove(usize),
     }
 
-    pub static TIMER_COUNTER: AtomicUsize = AtomicUsize::new(0);
-    pub static mut SIG_MSG_CHAN: Lazy<(
+    type SignalMessageChannel = (
         mpsc::UnboundedSender<SignalMsg>,
-        Option<mpsc::UnboundedReceiver<SignalMsg>>,
-    )> = Lazy::new(|| {
+        std::sync::Mutex<Option<mpsc::UnboundedReceiver<SignalMsg>>>,
+    );
+
+    pub static TIMER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    pub static SIG_MSG_CHAN: Lazy<SignalMessageChannel> = Lazy::new(|| {
         let (sig_msg_tx, sig_msg_rx) = mpsc::unbounded_channel::<SignalMsg>();
-        (sig_msg_tx, Some(sig_msg_rx))
+        (sig_msg_tx, std::sync::Mutex::new(Some(sig_msg_rx)))
     });
 }
 
@@ -64,7 +66,9 @@ pub struct CPUTimer {
 impl Drop for CPUTimer {
     fn drop(&mut self) {
         if Arc::strong_count(&self.timer) == 2 {
-            unsafe { linux::SIG_MSG_CHAN.0.clone() }
+            linux::SIG_MSG_CHAN
+                .0
+                .clone()
                 .send(linux::SignalMsg::Remove(self.id))
                 .unwrap();
         }
@@ -122,7 +126,9 @@ impl CPUTimer {
         Ok({
             this.reset()?;
 
-            unsafe { linux::SIG_MSG_CHAN.0.clone() }
+            linux::SIG_MSG_CHAN
+                .0
+                .clone()
                 .send(SignalMsg::Add((id, this.clone())))
                 .unwrap();
 
@@ -187,14 +193,12 @@ pub fn get_thread_time() -> Result<i64, Error> {
 
 #[cfg_attr(target_os = "linux", linux::ctor)]
 #[cfg(target_os = "linux")]
-#[allow(static_mut_refs)]
 fn register_sigalrm() {
     use std::collections::HashMap;
 
     use futures::StreamExt;
     use linux::SignalMsg;
     use log::{debug, error};
-    use once_cell::sync::Lazy;
     use signal_hook::{consts::signal, iterator::exfiltrator::raw};
     use signal_hook_tokio::SignalsInfo;
 
@@ -202,11 +206,8 @@ fn register_sigalrm() {
 
     let mut registry = HashMap::<usize, CPUTimer>::new();
 
-    let sig_msg_tx = unsafe { linux::SIG_MSG_CHAN.0.clone() };
-    let mut sig_msg_rx = Lazy::force_mut(unsafe { &mut linux::SIG_MSG_CHAN })
-        .1
-        .take()
-        .unwrap();
+    let sig_msg_tx = linux::SIG_MSG_CHAN.0.clone();
+    let mut sig_msg_rx = linux::SIG_MSG_CHAN.1.lock().unwrap().take().unwrap();
 
     std::thread::Builder::new()
         .name("sb-cpu-timer".into())


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove lint

## Description

Remove some rustc and clippy warning introduced in v1.77.0.

Note(static_mut_refs): https://github.com/rust-lang/rust/issues/114447