### PR TITLE
feat: support graceful shutdown by unix signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
  "deno_net",
  "deno_tls",
  "fastwebsockets 0.6.0",
- "h2 0.4.2",
+ "h2 0.4.4",
  "http 1.0.0",
  "http-body-util",
  "hyper 1.1.0",
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",
@@ -2716,7 +2716,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.2",
+ "h2 0.4.4",
  "http 1.0.0",
  "http-body 1.0.0",
  "httparse",

--- a/crates/base/src/macros/test_macros.rs
+++ b/crates/base/src/macros/test_macros.rs
@@ -1,20 +1,21 @@
 #[macro_export]
 macro_rules! integration_test {
-    ($main_file:expr, $port:expr, $url:expr, $policy:expr, $import_map:expr, $req_builder:expr, $tls:expr, ($($function:tt)+) $(, $termination_token:expr)?) => {
+    ($main_file:expr, $port:expr, $url:expr, $policy:expr, $import_map:expr, $req_builder:expr, $tls:expr, ($($function:tt)+) $(, $($token:tt)+)?) => {
         use futures_util::FutureExt;
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<base::server::ServerHealth>(1);
 
         let req_builder: Option<reqwest::RequestBuilder> = $req_builder;
         let tls: Option<base::server::Tls> = $tls;
+        let schema = if tls.is_some() { "https" } else { "http" };
         let signal = tokio::spawn(async move {
-            while let Some(base::server::ServerHealth::Listening(event_rx)) = rx.recv().await {
-                integration_test!(@req event_rx, $port, $url, req_builder, ($($function)+));
+            while let Some(base::server::ServerHealth::Listening(event_rx, metric_src)) = rx.recv().await {
+                integration_test!(@req event_rx, metric_src, schema, $port, $url, req_builder, ($($function)+));
             }
             None
         });
 
-        let termination_token = integration_test!(@term $(, $termination_token)?);
+        let token = integration_test!(@term $(, $($token)+)?);
         let mut listen_fut = base::commands::start_server(
             "0.0.0.0",
             $port,
@@ -30,11 +31,52 @@ macro_rules! integration_test {
                 main: None,
                 events: None,
             },
-            termination_token.clone(),
+            token.clone(),
             vec![],
             None
         )
         .boxed();
+
+        async fn __req_fn<F, R>(
+            input_fn: F,
+            port: u16,
+            url: &'static str,
+            req_builder: Option<reqwest::RequestBuilder>,
+            event_rx: mpsc::UnboundedReceiver<base::server::ServerEvent>,
+            metric_src: sb_core::SharedMetricSource
+        ) -> Option<Result<reqwest::Response, reqwest::Error>>
+        where
+            F: FnOnce(
+                u16,
+                &'static str,
+                Option<reqwest::RequestBuilder>,
+                mpsc::UnboundedReceiver<base::server::ServerEvent>,
+                sb_core::SharedMetricSource
+            ) -> R,
+            R: std::future::Future<Output = Option<Result<reqwest::Response, reqwest::Error>>>,
+        {
+            input_fn(
+                port,
+                url,
+                req_builder,
+                event_rx,
+                metric_src
+            )
+            .await
+        }
+
+        async fn __resp_fn <F, R>(
+            input_fn: F,
+            resp: Result<reqwest::Response, reqwest::Error>
+        )
+        where
+            F: FnOnce(
+                Result<reqwest::Response, reqwest::Error>
+            ) -> R,
+            R: std::future::Future<Output = ()>,
+        {
+            input_fn(resp).await;
+        }
 
         tokio::select! {
             resp = signal => {
@@ -55,55 +97,70 @@ macro_rules! integration_test {
 
         // if we have a termination token, we should advence a listen future to
         // the end for a graceful exit. (3)
-        if let Some(token) = termination_token {
+        if let Some(token) = token {
             let join_fut = tokio::spawn(async move {
                 let _ = listen_fut.await;
             });
 
-            let wait_fut = async move {
-                token.cancel_and_wait().await;
-                join_fut.await.unwrap();
-            };
-
-            if tokio::time::timeout(
-                // XXX(Nyannyacha): Should we apply variable timeout?
-                core::time::Duration::from_secs(10),
-                wait_fut
-            )
-            .await
-            .is_err()
-            {
-                panic!("failed to terminate server within 10 seconds");
-            }
+            integration_test!(@term_cleanup $($($token)+)?, token, join_fut);
         }
     };
 
-    (@term , $termination_token:expr) => {
-        Some($termination_token)
+    (@term , #[manual] $token:expr) => {
+        Some($token)
     };
+
+    (@term , $token:expr) => {
+        Some($token)
+    };
+
 
     (@term) => {
         None
     };
 
-    (@req $event_rx:ident, $port:expr, $url:expr, $req_builder:expr, ($req:expr, $_:expr)) => {
-        return $req($port, $url, $req_builder, $event_rx).await;
+    (@term_cleanup $(#[manual] $_:expr)?, $__:ident, $___:ident) => {};
+    (@term_cleanup $_:expr, $token:ident, $join_fut:ident) => {
+        let wait_fut = async move {
+            $token.cancel_and_wait().await;
+            $join_fut.await.unwrap();
+        };
+
+        if tokio::time::timeout(
+            // XXX(Nyannyacha): Should we apply variable timeout?
+            core::time::Duration::from_secs(10),
+            wait_fut
+        )
+        .await
+        .is_err()
+        {
+            panic!("failed to terminate server within 10 seconds");
+        }
     };
 
-    (@req $_:ident, $port:expr, $url:expr, $req_builder:expr, $__:expr) => {
+    (@req $event_rx:ident, $metric_src:ident, $schema:expr, $port:expr, $url:expr, $req_builder:expr, ($req:expr, $_:expr)) => {
+        if let Some(resp) = __req_fn($req, $port, $url, $req_builder, $event_rx, $metric_src).await {
+            return Some(resp);
+        } else {
+            let resp = reqwest::get(format!("{}://localhost:{}/{}", $schema, $port, $url)).await;
+            return Some(resp);
+        }
+    };
+
+    (@req $_:ident, $__:ident, $schema:expr, $port:expr, $url:expr, $req_builder:expr, $___:expr) => {
         if let Some(req_factory) = $req_builder {
             return Some(req_factory.send().await);
         } else {
-            let req = reqwest::get(format!("http://localhost:{}/{}", $port, $url)).await;
-            return Some(req);
+            let resp = reqwest::get(format!("{}://localhost:{}/{}", $schema, $port, $url)).await;
+            return Some(resp);
         }
     };
 
     (@resp $var:ident, ($_:expr, $resp:expr)) => {
-        $resp($var)
+        __resp_fn($resp, $var)
     };
 
     (@resp $var:ident, $resp:expr) => {
-        $resp($var)
+        __resp_fn($resp, $var)
     };
 }

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -585,12 +585,8 @@ impl Server {
                     error!("received interrupt signal while waiting workers");
                 }
             }
-        } else {
-            if metric_src.received_requests() != metric_src.handled_requests() {
-                warn!(
-                    "runtime exits immediately because the `--graceful-exit-timeout` is not specified"
-                );
-            }
+        } else if metric_src.received_requests() != metric_src.handled_requests() {
+            warn!("runtime exits immediately since the graceful exit feature has been disabled");
         }
 
         Ok(())

--- a/crates/base/test_cases/wasm/grow_standalone/index.ts
+++ b/crates/base/test_cases/wasm/grow_standalone/index.ts
@@ -36,3 +36,4 @@ Deno.serve(() => { /* do nothing */ });
 grow(
     350 // 350 pages ~= 22.9376 Mib
 );
+console.log(wasm.memory.buffer.byteLength); // to prevent optimization

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -925,7 +925,7 @@ async fn req_failure_case_intentional_peer_reset(maybe_tls: Option<Tls>) {
         None,
         maybe_tls.clone(),
         (
-            |_, url, _req_builder, mut ev, _| async move {
+            |(_, url, _, mut ev, ..)| async move {
                 tokio::spawn(async move {
                     loop {
                         tokio::select! {
@@ -1104,7 +1104,7 @@ async fn test_graceful_shutdown() {
         None,
         None,
         (
-            |_port, _url, _req_builder, mut ev, metric_src| async move {
+            |(.., mut ev, metric_src)| async move {
                 metric_tx.send(metric_src).unwrap();
                 tokio::spawn(async move {
                     while let Some(ev) = ev.recv().await {

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -873,9 +873,10 @@ async fn req_failure_case_wall_clock_reached() {
 
     let buf = to_bytes(res.body_mut()).await.unwrap();
 
-    assert_eq!(
-        buf,
-        "{\"msg\":\"WorkerRequestCancelled: request has been cancelled by supervisor\"}"
+    assert!(
+        buf == "{\"msg\":\"InvalidWorkerResponse: user worker failed to respond\"}"
+            || buf
+                == "{\"msg\":\"WorkerRequestCancelled: request has been cancelled by supervisor\"}"
     );
 
     tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -885,6 +885,9 @@ async fn req_failure_case_wall_clock_reached() {
 #[tokio::test]
 #[serial]
 async fn req_failure_case_wall_clock_reached_less_than_100ms() {
+    // TODO(Nyannyacha): This test seems a little flaky. If running the entire test
+    // dozens of times on the local machine, it will fail with a timeout.
+
     let tb = TestBedBuilder::new("./test_cases/main_small_wall_clock_less_than_100ms")
         .with_oneshot_policy(100000)
         .build()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -94,8 +94,12 @@ fn cli() -> Command {
                         .value_parser(["tc39", "typescript", "typescript_with_metadata"])
                 )
                 .arg(
-                    arg!(--"graceful-exit-timeout" <SECONDS> "Maximum time in seconds that can wait for workers before terminating forcibly")
-                        .default_value("0")
+                    arg!(--"graceful-exit-timeout" [SECONDS] "Maximum time in seconds that can wait for workers before terminating forcibly. If providing zero value, the runtime will not try a graceful exit.")
+                        // NOTE(Nyannyacha): Default timeout value follows the
+                        // value[1] defined in moby.
+                        //
+                        // [1]: https://github.com/moby/moby/blob/master/daemon/config/config.go#L45-L47
+                        .default_value("15")
                         .value_parser(
                             value_parser!(u64)
                                 .range(0..u64::MAX)

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -49,6 +49,22 @@ pub struct SharedMetricSource {
 }
 
 impl SharedMetricSource {
+    pub fn active_user_workers(&self) -> usize {
+        self.active_user_workers.load(Ordering::Relaxed)
+    }
+
+    pub fn retired_user_workers(&self) -> usize {
+        self.retired_user_workers.load(Ordering::Relaxed)
+    }
+
+    pub fn received_requests(&self) -> usize {
+        self.received_requests.load(Ordering::Relaxed)
+    }
+
+    pub fn handled_requests(&self) -> usize {
+        self.handled_requests.load(Ordering::Relaxed)
+    }
+
     pub fn incl_active_user_workers(&self) {
         self.active_user_workers.fetch_add(1, Ordering::Relaxed);
     }

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -46,21 +46,20 @@ pub struct SharedMetricSource {
     retired_user_workers: Arc<AtomicUsize>,
     received_requests: Arc<AtomicUsize>,
     handled_requests: Arc<AtomicUsize>,
+    active_io: Arc<AtomicUsize>,
 }
 
 impl SharedMetricSource {
-    pub fn active_user_workers(&self) -> usize {
-        self.active_user_workers.load(Ordering::Relaxed)
+    pub fn active_io(&self) -> usize {
+        self.active_io.load(Ordering::Relaxed)
     }
 
-    pub fn retired_user_workers(&self) -> usize {
-        self.retired_user_workers.load(Ordering::Relaxed)
-    }
-
+    #[cfg(debug_assertions)]
     pub fn received_requests(&self) -> usize {
         self.received_requests.load(Ordering::Relaxed)
     }
 
+    #[cfg(debug_assertions)]
     pub fn handled_requests(&self) -> usize {
         self.handled_requests.load(Ordering::Relaxed)
     }
@@ -85,11 +84,20 @@ impl SharedMetricSource {
         self.handled_requests.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn incl_active_io(&self) {
+        self.active_io.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn decl_active_io(&self) {
+        self.active_io.fetch_sub(1, Ordering::Relaxed);
+    }
+
     pub fn reset(&self) {
         self.active_user_workers.store(0, Ordering::Relaxed);
         self.retired_user_workers.store(0, Ordering::Relaxed);
         self.received_requests.store(0, Ordering::Relaxed);
         self.handled_requests.store(0, Ordering::Relaxed);
+        self.active_io.store(0, Ordering::Relaxed);
     }
 }
 

--- a/scripts/test_indefinitely.sh
+++ b/scripts/test_indefinitely.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+count=0
+
+while true; do
+    ((count++))
+    
+    echo "Running cargo test (Attempt $count)..."
+    cargo test -q $@
+
+    if [ $? -ne 0 ]; then
+        echo "Tests failed after $count attempts! Exiting..."
+        break
+    fi
+
+    echo "Tests passed. Running again..."
+done


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

This PR introduces a grace period to ensure that requests that were being processed when the runtime was about to be terminated by a `SIGTERM` or `SIGINT` unix signal can be processed reliably.

It is necessary for a reliable request-draining implementation in containerized software environments such as Docker, which uses the SIGTERM signal to terminate containers.

### List of arguments to be created due to the introduction of this PR

* `--graceful-exit-timeout` flag allows the user to specify the maximum amount of grace the runtime can wait, **in seconds**, with a default value of `15`.
  > Note that this flag is introduced because arbitrary requests cannot wait indefinitely.
* (Experimental) `--experimental-graceful-exit-keepalive-deadline-ratio` flag specifies maximum period of time that incoming requests can be processed over a pre-established keep-alive HTTP connection. This is specified as a percentage of the `--graceful-exit-timeout` value. The percentage cannot be greater than 95.

  See [this link](https://github.com/supabase/edge-runtime/pull/298#issuecomment-2031143708) for the change in behaviour of graceful shutdown due to specifying this flag.

### Behaviors by unix signals
|Signal|Shutdown Behavior|
|------|---------|
|SIGTERM|Shutdown Gracefully|
|SIGWINCH|Shutdown Gracefully|
|SIGINT|Shutdown Immediately|
|SIGKILL|Shutdown Immediately by OS|

Resolves #284 