### PR TITLE
chore: adjust dev container base image as `dev-1-bookworm`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+FROM mcr.microsoft.com/devcontainers/rust:dev-1-bookworm
 RUN apt-get update && apt-get install -y build-essential cmake libclang-dev lldb \
     nodejs npm hyperfine


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

This is to ensure that the rust toolchain in the dev container is always tracking the latest version.

For more information on the toolchains and other packages tracked by the tag that will change due to the introduction of this PR, please see the link below:
https://github.com/devcontainers/images/blob/main/src/rust/history/dev.md