### PR TITLE
feat: expose decorator options

### DIFF
--- a/crates/base/src/commands.rs
+++ b/crates/base/src/commands.rs
@@ -5,6 +5,7 @@ use crate::{
     InspectorOption,
 };
 use anyhow::Error;
+use sb_graph::DecoratorType;
 use tokio::sync::mpsc::Sender;
 
 #[allow(clippy::too_many_arguments)]
@@ -14,6 +15,7 @@ pub async fn start_server(
     tls: Option<Tls>,
     main_service_path: String,
     event_worker_path: Option<String>,
+    decorator: Option<DecoratorType>,
     user_worker_policy: Option<WorkerPoolPolicy>,
     import_map_path: Option<String>,
     flags: ServerFlags,
@@ -29,6 +31,7 @@ pub async fn start_server(
         tls,
         main_service_path,
         event_worker_path,
+        decorator,
         user_worker_policy,
         import_map_path,
         flags,

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -220,6 +220,7 @@ impl DenoRuntime {
             conf,
             maybe_eszip,
             maybe_entrypoint,
+            maybe_decorator,
             maybe_module_code,
             static_patterns,
             ..
@@ -239,8 +240,10 @@ impl DenoRuntime {
 
         let mut net_access_disabled = false;
         let mut allow_remote_modules = true;
+
         if is_user_worker {
             let user_conf = conf.as_user_worker().unwrap();
+
             net_access_disabled = user_conf.net_access_disabled;
             allow_remote_modules = user_conf.allow_remote_modules;
         }
@@ -262,6 +265,7 @@ impl DenoRuntime {
 
             emitter_factory.set_file_fetcher_allow_remote(allow_remote_modules);
             emitter_factory.set_file_fetcher_cache_strategy(cache_strategy);
+            emitter_factory.set_decorator_type(maybe_decorator);
 
             let maybe_import_map = load_import_map(import_map_path.clone())?;
             emitter_factory.set_import_map(maybe_import_map);
@@ -917,6 +921,7 @@ mod test {
                 timing: None,
                 maybe_eszip: None,
                 maybe_entrypoint: None,
+                maybe_decorator: None,
                 maybe_module_code: Some(FastString::from(String::from(
                     "Deno.serve((req) => new Response('Hello World'));",
                 ))),
@@ -962,6 +967,7 @@ mod test {
                 timing: None,
                 maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
                 maybe_entrypoint: None,
+                maybe_decorator: None,
                 maybe_module_code: None,
                 conf: {
                     WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
@@ -1027,6 +1033,7 @@ mod test {
                 timing: None,
                 maybe_eszip: Some(EszipPayloadKind::VecKind(eszip_code)),
                 maybe_entrypoint: None,
+                maybe_decorator: None,
                 maybe_module_code: None,
                 conf: {
                     WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
@@ -1089,6 +1096,7 @@ mod test {
                 timing: None,
                 maybe_eszip: None,
                 maybe_entrypoint: None,
+                maybe_decorator: None,
                 maybe_module_code: None,
                 conf: {
                     if let Some(uc) = user_conf {

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -11,3 +11,4 @@ pub mod utils;
 mod inspector_server;
 
 pub use inspector_server::InspectorOption;
+pub use sb_graph::DecoratorType;

--- a/crates/base/src/macros/test_macros.rs
+++ b/crates/base/src/macros/test_macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! integration_test {
-    ($main_file:expr, $port:expr, $url:expr, $shot_policy:expr, $import_map:expr, $req_builder:expr, $tls:expr, ($($function:tt)+) $(, $termination_token:expr)?) => {
+    ($main_file:expr, $port:expr, $url:expr, $policy:expr, $import_map:expr, $req_builder:expr, $tls:expr, ($($function:tt)+) $(, $termination_token:expr)?) => {
         use futures_util::FutureExt;
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<base::server::ServerHealth>(1);
@@ -21,7 +21,8 @@ macro_rules! integration_test {
             tls,
             String::from($main_file),
             None,
-            $shot_policy,
+            None,
+            $policy,
             $import_map,
             $crate::server::ServerFlags::default(),
             Some(tx.clone()),

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -21,7 +21,7 @@ use hyper::{Body, Request, Response};
 use log::{debug, error};
 use sb_core::conn_sync::ConnSync;
 use sb_core::{MetricSource, SharedMetricSource};
-use sb_graph::EszipPayloadKind;
+use sb_graph::{DecoratorType, EszipPayloadKind};
 use sb_workers::context::{
     EventWorkerRuntimeOpts, MainWorkerRuntimeOpts, Timing, UserWorkerMsgs, WorkerContextInitOpts,
     WorkerRequestMsg, WorkerRuntimeOpts,
@@ -627,12 +627,14 @@ pub async fn send_user_worker_request(
     Ok(res)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_main_worker(
     main_worker_path: PathBuf,
     import_map_path: Option<String>,
     no_module_cache: bool,
     runtime_opts: MainWorkerRuntimeOpts,
     maybe_entrypoint: Option<String>,
+    maybe_decorator: Option<DecoratorType>,
     termination_token: Option<TerminationToken>,
     inspector: Option<Inspector>,
 ) -> Result<mpsc::UnboundedSender<WorkerRequestMsg>, Error> {
@@ -655,6 +657,7 @@ pub async fn create_main_worker(
                 timing: None,
                 maybe_eszip,
                 maybe_entrypoint,
+                maybe_decorator,
                 maybe_module_code: None,
                 conf: WorkerRuntimeOpts::MainWorker(runtime_opts),
                 env_vars: std::env::vars().collect(),
@@ -675,6 +678,7 @@ pub async fn create_events_worker(
     import_map_path: Option<String>,
     no_module_cache: bool,
     maybe_entrypoint: Option<String>,
+    maybe_decorator: Option<DecoratorType>,
     termination_token: Option<TerminationToken>,
 ) -> Result<(MetricSource, mpsc::UnboundedSender<WorkerEventWithMetadata>), Error> {
     let (events_tx, events_rx) = mpsc::unbounded_channel::<WorkerEventWithMetadata>();
@@ -701,6 +705,7 @@ pub async fn create_events_worker(
                 timing: None,
                 maybe_eszip,
                 maybe_entrypoint,
+                maybe_decorator,
                 maybe_module_code: None,
                 conf: WorkerRuntimeOpts::EventsWorker(EventWorkerRuntimeOpts {}),
                 static_patterns: vec![],

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -353,6 +353,7 @@ impl WorkerPool {
                         maybe_eszip,
                         maybe_module_code,
                         maybe_entrypoint,
+                        maybe_decorator,
                         ..
                     } = worker_options;
 
@@ -369,6 +370,7 @@ impl WorkerPool {
                                 maybe_eszip,
                                 maybe_module_code,
                                 maybe_entrypoint,
+                                maybe_decorator,
                                 static_patterns: vec![],
                             },
                             tx,

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -13,6 +13,7 @@ use rustls_pemfile::read_one_from_slice;
 use rustls_pemfile::Item;
 use sb_core::conn_sync::ConnSync;
 use sb_core::SharedMetricSource;
+use sb_graph::DecoratorType;
 use sb_workers::context::{MainWorkerRuntimeOpts, WorkerRequestMsg};
 use std::future::{pending, Future};
 use std::net::IpAddr;
@@ -320,6 +321,7 @@ impl Server {
         tls: Option<Tls>,
         main_service_path: String,
         maybe_events_service_path: Option<String>,
+        maybe_decorator: Option<DecoratorType>,
         maybe_user_worker_policy: Option<WorkerPoolPolicy>,
         import_map_path: Option<String>,
         flags: ServerFlags,
@@ -345,6 +347,7 @@ impl Server {
                 import_map_path.clone(),
                 flags.no_module_cache,
                 maybe_events_entrypoint,
+                maybe_decorator,
                 Some(termination_tokens.event.clone().unwrap()),
             )
             .await?;
@@ -377,6 +380,7 @@ impl Server {
                 event_worker_metric_src,
             },
             maybe_main_entrypoint,
+            maybe_decorator,
             Some(termination_tokens.main.clone()),
             if flags.allow_main_inspector {
                 inspector.map(|it| Inspector {

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -222,6 +222,7 @@ impl TestBedBuilder {
             timing: None,
             maybe_eszip: None,
             maybe_entrypoint: None,
+            maybe_decorator: None,
             maybe_module_code: None,
             conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
                 worker_pool_tx,

--- a/crates/base/test_cases/decorator_tc39/index.ts
+++ b/crates/base/test_cases/decorator_tc39/index.ts
@@ -1,0 +1,17 @@
+function func1(fn: any, _ctx: ClassMethodDecoratorContext) {
+    return function (...args: unknown[]) {
+        fn(...args);
+        return "meow?";
+    };
+}
+
+class Class {
+    @func1
+    static func2() {
+        return "meow";
+    }
+}
+
+Deno.serve(async (_req) => {
+    return new Response(Class.func2());
+})

--- a/crates/base/test_cases/decorator_typescript_with_metadata/index.ts
+++ b/crates/base/test_cases/decorator_typescript_with_metadata/index.ts
@@ -1,0 +1,26 @@
+function func1(
+    _target: any,
+    _methodName: string,
+    descriptor: PropertyDescriptor,
+) {
+    const orig = descriptor.value
+
+    descriptor.value = function (...args: any[]) {
+        orig.call(this, ...args);
+        return "meow?";
+    }
+
+    return descriptor
+}
+
+class Class {
+    @func1
+    func2() {
+        return "meow";
+    }
+}
+
+Deno.serve(async (_req) => {
+    const cls = new Class();
+    return new Response(cls.func2());
+})

--- a/crates/base/test_cases/main_with_decorator/index.ts
+++ b/crates/base/test_cases/main_with_decorator/index.ts
@@ -1,0 +1,73 @@
+import { serve } from "https://deno.land/std@0.131.0/http/server.ts"
+
+console.log('main function started');
+
+serve(async (req: Request) => {
+  const url = new URL(req.url);
+  const {pathname} = url;
+  const path_parts = pathname.split("/");
+  const service_name = path_parts[1];
+
+  if (!service_name || service_name === "") {
+    const error = { msg: "missing function name in request" }
+    return new Response(
+        JSON.stringify(error),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+    )
+  }
+
+  const servicePath = `./test_cases/${service_name}`;
+  
+  let decoratorType: string | undefined;
+
+  try {
+    const payload = await req.json();
+    decoratorType = payload.decoratorType;
+  } catch {}
+
+  console.error(`serving the request with ${servicePath}`);
+
+  const createWorker = async () => {
+    const memoryLimitMb = 150;
+    const workerTimeoutMs = 10 * 60 * 1000;
+    const cpuTimeSoftLimitMs = 10 * 60 * 1000;
+    const cpuTimeHardLimitMs = 10 * 60 * 1000;
+    const noModuleCache = false;
+    const importMapPath = null;
+    const envVarsObj = Deno.env.toObject();
+    const envVars = Object.keys(envVarsObj).map(k => [k, envVarsObj[k]]);
+
+    return await EdgeRuntime.userWorkers.create({
+        servicePath,
+        memoryLimitMb,
+        workerTimeoutMs,
+        cpuTimeSoftLimitMs,
+        cpuTimeHardLimitMs,
+        noModuleCache,
+        importMapPath,
+        envVars,
+        decoratorType
+    });
+  }
+
+  const callWorker = async () => {
+    try {
+      const worker = await createWorker();
+      return await worker.fetch(req);
+    } catch (e) {
+      console.error(e);
+
+			// if (e instanceof Deno.errors.WorkerRequestCancelled) {
+			// 	return await callWorker();
+			// }
+
+      const error = { msg: e.toString() }
+      return new Response(
+          JSON.stringify(error),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+  }
+
+  return callWorker();
+})

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -1057,7 +1057,7 @@ async fn test_decorators(ty: Option<DecoratorType>) {
     let endpoint = if is_disabled {
         "tc39".to_string()
     } else {
-        serde_json::to_string(&ty).unwrap().replace("\"", "")
+        serde_json::to_string(&ty).unwrap().replace('\"', "")
     };
 
     let payload = if is_disabled {

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -175,6 +175,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         timing: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_decorator: None,
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx,
@@ -330,6 +331,7 @@ async fn test_main_worker_boot_error() {
         timing: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_decorator: None,
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::MainWorker(MainWorkerRuntimeOpts {
             worker_pool_tx,
@@ -730,6 +732,7 @@ async fn test_worker_boot_invalid_imports() {
         timing: None,
         maybe_eszip: None,
         maybe_entrypoint: None,
+        maybe_decorator: None,
         maybe_module_code: None,
         conf: WorkerRuntimeOpts::UserWorker(test_user_runtime_opts()),
         static_patterns: vec![],

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -90,7 +90,7 @@ fn cli() -> Command {
                         .value_parser(["per_worker", "per_request", "oneshot"])
                 )
                 .arg(
-                    arg!(--"decorator" [TYPE] "Type of decorator to use on the main worker and event worker. If not specified, the decorator feature is disabled.")
+                    arg!(--"decorator" <TYPE> "Type of decorator to use on the main worker and event worker. If not specified, the decorator feature is disabled.")
                         .value_parser(["tc39", "typescript", "typescript_with_metadata"])
                 )
                 .arg(
@@ -154,7 +154,7 @@ fn cli() -> Command {
                 .arg(arg!(--"static" <Path> "Glob pattern for static files to be included"))
                 .arg(arg!(--"import-map" <Path> "Path to import map file"))
                 .arg(
-                    arg!(--"decorator" [TYPE] "Type of decorator to use when bundling. If not specified, the decorator feature is disabled.")
+                    arg!(--"decorator" <TYPE> "Type of decorator to use when bundling. If not specified, the decorator feature is disabled.")
                         .value_parser(["tc39", "typescript", "typescript_with_metadata"])
                 )
         ).subcommand(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,9 +5,9 @@ use base::commands::start_server;
 use base::deno_runtime::MAYBE_DENO_VERSION;
 use base::rt_worker::worker_pool::{SupervisorPolicy, WorkerPoolPolicy};
 use base::server::{ServerFlags, Tls, WorkerEntrypoints};
-use base::InspectorOption;
+use base::{DecoratorType, InspectorOption};
 use clap::builder::{FalseyValueParser, TypedValueParser};
-use clap::{arg, crate_version, value_parser, ArgAction, ArgGroup, Command};
+use clap::{arg, crate_version, value_parser, ArgAction, ArgGroup, ArgMatches, Command};
 use deno_core::url::Url;
 use log::warn;
 use sb_graph::emitter::EmitterFactory;
@@ -90,6 +90,10 @@ fn cli() -> Command {
                         .value_parser(["per_worker", "per_request", "oneshot"])
                 )
                 .arg(
+                    arg!(--"decorator" [TYPE] "Type of decorator to use on the main worker and event worker. If not specified, the decorator feature is disabled.")
+                        .value_parser(["tc39", "typescript", "typescript_with_metadata"])
+                )
+                .arg(
                     arg!(--"graceful-exit-timeout" <SECONDS> "Maximum time in seconds that can wait for workers before terminating forcibly")
                         .default_value("0")
                         .value_parser(
@@ -149,6 +153,10 @@ fn cli() -> Command {
                 .arg(arg!(--"entrypoint" <Path> "Path to entrypoint to bundle as an eszip").required(true))
                 .arg(arg!(--"static" <Path> "Glob pattern for static files to be included"))
                 .arg(arg!(--"import-map" <Path> "Path to import map file"))
+                .arg(
+                    arg!(--"decorator" [TYPE] "Type of decorator to use when bundling. If not specified, the decorator feature is disabled.")
+                        .value_parser(["tc39", "typescript", "typescript_with_metadata"])
+                )
         ).subcommand(
         Command::new("unbundle")
             .about("Unbundles an .eszip file into the specified directory")
@@ -267,6 +275,7 @@ fn main() -> Result<(), anyhow::Error> {
                     maybe_tls,
                     main_service_path,
                     event_service_manager_path,
+                    get_decorator_option(sub_matches),
                     Some(WorkerPoolPolicy::new(
                         maybe_supervisor_policy,
                         if let Some(true) = maybe_supervisor_policy
@@ -305,6 +314,7 @@ fn main() -> Result<(), anyhow::Error> {
             Some(("bundle", sub_matches)) => {
                 let output_path = sub_matches.get_one::<String>("output").cloned().unwrap();
                 let import_map_path = sub_matches.get_one::<String>("import-map").cloned();
+                let maybe_decorator = get_decorator_option(sub_matches);
                 let static_patterns = if let Some(val_ref) = sub_matches
                     .get_many::<String>("static") {
                     val_ref.map(|s| s.as_str()).collect::<Vec<&str>>()
@@ -335,6 +345,8 @@ fn main() -> Result<(), anyhow::Error> {
                             .to_string(),
                     );
                 }
+
+                emitter_factory.set_decorator_type(maybe_decorator);
                 emitter_factory.set_import_map(maybe_import_map.clone());
 
                 let mut eszip = generate_binary_eszip(
@@ -381,6 +393,18 @@ fn main() -> Result<(), anyhow::Error> {
     });
 
     res
+}
+
+fn get_decorator_option(sub_matches: &ArgMatches) -> Option<DecoratorType> {
+    sub_matches
+        .get_one::<String>("decorator")
+        .cloned()
+        .and_then(|it| match it.to_lowercase().as_str() {
+            "tc39" => Some(DecoratorType::Tc39),
+            "typescript" => Some(DecoratorType::Typescript),
+            "typescript_with_metadata" => Some(DecoratorType::TypescriptWithMetadata),
+            _ => None,
+        })
 }
 
 fn get_inspector_option(key: &str, addr: &SocketAddr) -> Result<InspectorOption, anyhow::Error> {

--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -14,6 +14,7 @@ use sb_core::util::fs::specifier_to_file_path;
 use sb_core::util::path::{closest_common_directory, find_lowest_path};
 use sb_fs::{build_vfs, VfsOpts};
 use sb_npm::InnerCliNpmResolverRef;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fs;
 use std::fs::{create_dir_all, File};
@@ -30,6 +31,37 @@ pub const VFS_ESZIP_KEY: &str = "---SUPABASE-VFS-DATA-ESZIP---";
 pub const SOURCE_CODE_ESZIP_KEY: &str = "---SUPABASE-SOURCE-CODE-ESZIP---";
 pub const STATIC_FILES_ESZIP_KEY: &str = "---SUPABASE-STATIC-FILES-ESZIP---";
 pub const STATIC_FS_PREFIX: &str = "mnt/data";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecoratorType {
+    /// Use TC39 Decorators Proposal - https://github.com/tc39/proposal-decorators
+    Tc39,
+    /// Use TypeScript experimental decorators.
+    Typescript,
+    /// Use TypeScript experimental decorators. It also emits metadata.
+    TypescriptWithMetadata,
+}
+
+impl Default for DecoratorType {
+    fn default() -> Self {
+        Self::Typescript
+    }
+}
+
+impl DecoratorType {
+    fn is_use_decorators_proposal(self) -> bool {
+        matches!(self, Self::Tc39)
+    }
+
+    fn is_use_ts_decorators(self) -> bool {
+        matches!(self, Self::Typescript | Self::TypescriptWithMetadata)
+    }
+
+    fn is_emit_metadata(self) -> bool {
+        matches!(self, Self::TypescriptWithMetadata)
+    }
+}
 
 #[derive(Debug)]
 pub enum EszipPayloadKind {

--- a/crates/sb_workers/context.rs
+++ b/crates/sb_workers/context.rs
@@ -14,7 +14,7 @@ use tokio::sync::{mpsc, oneshot, watch, Notify, OwnedSemaphorePermit};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use sb_graph::EszipPayloadKind;
+use sb_graph::{DecoratorType, EszipPayloadKind};
 
 #[derive(Debug, Clone)]
 pub struct UserWorkerRuntimeOpts {
@@ -153,6 +153,7 @@ pub struct WorkerContextInitOpts {
     pub maybe_eszip: Option<EszipPayloadKind>,
     pub maybe_module_code: Option<FastString>,
     pub maybe_entrypoint: Option<String>,
+    pub maybe_decorator: Option<DecoratorType>,
     pub static_patterns: Vec<String>,
 }
 

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -24,7 +24,7 @@ use hyper::upgrade::OnUpgrade;
 use hyper::{Body, Method, Request};
 use log::error;
 use sb_core::conn_sync::{ConnSync, ConnWatcher};
-use sb_graph::EszipPayloadKind;
+use sb_graph::{DecoratorType, EszipPayloadKind};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -67,6 +67,8 @@ pub struct UserWorkerCreateOptions {
     worker_timeout_ms: u64,
     cpu_time_soft_limit_ms: u64,
     cpu_time_hard_limit_ms: u64,
+
+    decorator_type: Option<DecoratorType>,
 }
 
 #[op2(async)]
@@ -98,6 +100,8 @@ pub async fn op_user_worker_create(
             worker_timeout_ms,
             cpu_time_soft_limit_ms,
             cpu_time_hard_limit_ms,
+
+            decorator_type: maybe_decorator,
         } = opts;
 
         let mut env_vars_map = HashMap::new();
@@ -115,6 +119,7 @@ pub async fn op_user_worker_create(
             maybe_eszip: maybe_eszip.map(EszipPayloadKind::JsBufferKind),
             maybe_entrypoint,
             maybe_module_code: maybe_module_code.map(|v| v.into()),
+            maybe_decorator,
             conf: WorkerRuntimeOpts::UserWorker(UserWorkerRuntimeOpts {
                 memory_limit_mb,
                 low_memory_multiplier,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

### List of arguments to be created due to the introduction of this PR
* `--decorator` flag in subcommand `start` specifies the type of decorator to use on the main worker and event worker. If not specified, the decorator feature is disabled. (possible inputs: `tc39`, `typescript`, `typescript_with_metadata`)
* `--decorator` flag in subcommand `bundle` specifies the type of decorator to use when bundling. If not specified, the decorator feature is disabled. (possible inputs are same above)

Apart from the CLI arguments above, when you create a User Worker via the API in the main service, you can specify the type of decorator to use on the User Worker.

```rust
#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
#[serde(rename_all = "snake_case")]
pub enum DecoratorType {
    /// Use TC39 Decorators Proposal - https://github.com/tc39/proposal-decorators
    Tc39,
    /// Use TypeScript experimental decorators.
    Typescript,
    /// Use TypeScript experimental decorators. It also emits metadata.
    TypescriptWithMetadata,
}
```

```typescript
...

// type DecoratorType = "tc39" | "typescript" | "typescript_with_metadata"
const decoratorType = "typescript_with_metadata";

return await EdgeRuntime.userWorkers.create({
	...
	decoratorType
});
```

|type|experimentalDecorators|emitDecoratorMetadata|
|----|------------------------|-------------------------|
|tc39|-|-|
|typescript|✅|❌|
|typescript_with_metadata|✅|✅|

There are differences between Typescript's implementation of the decorator specification and the decorator specification specified by Ecma TC39, see the link below for a description of the differences:
https://github.com/tc39/proposal-decorators/issues/329

Note that the `typescript_with_metadata` option allows concrete types in design time to be output with metadata during the transpiling process. This option is equivalent to `emitDecoratorMetadata` of `tsconfig.json`.
For more information on this topic, see the link below:
https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata

Resolves #296 