### PR TITLE
feat: use `DuplexStream` instead of `UnixStream` to communicate with workers

### DIFF
--- a/crates/base/src/rt_worker/implementation/default_handler.rs
+++ b/crates/base/src/rt_worker/implementation/default_handler.rs
@@ -1,6 +1,6 @@
 use crate::deno_runtime::DenoRuntime;
 use crate::rt_worker::supervisor::CPUUsageMetrics;
-use crate::rt_worker::worker::{HandleCreationType, UnixStreamEntry, Worker, WorkerHandler};
+use crate::rt_worker::worker::{DuplexStreamEntry, HandleCreationType, Worker, WorkerHandler};
 use anyhow::Error;
 use event_worker::events::{BootFailureEvent, PseudoEvent, UncaughtExceptionEvent, WorkerEvents};
 use log::error;
@@ -19,14 +19,14 @@ impl WorkerHandler for Worker {
     fn handle_creation<'r>(
         &self,
         created_rt: &'r mut DenoRuntime,
-        unix_stream_rx: UnboundedReceiver<UnixStreamEntry>,
+        duplex_stream_rx: UnboundedReceiver<DuplexStreamEntry>,
         termination_event_rx: Receiver<WorkerEvents>,
         maybe_cpu_usage_metrics_tx: Option<UnboundedSender<CPUUsageMetrics>>,
         name: Option<String>,
     ) -> HandleCreationType<'r> {
         let run_worker_rt = async move {
             match created_rt
-                .run(unix_stream_rx, maybe_cpu_usage_metrics_tx, name)
+                .run(duplex_stream_rx, maybe_cpu_usage_metrics_tx, name)
                 .await
             {
                 // if the error is execution terminated, check termination event reason

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -32,8 +32,8 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::copy_bidirectional;
-use tokio::net::{TcpStream, UnixStream};
+use tokio::io::{self, copy_bidirectional};
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tokio_rustls::server::TlsStream;
@@ -42,7 +42,7 @@ use uuid::Uuid;
 
 use super::rt;
 use super::supervisor::{self, CPUTimerParam, CPUUsageMetrics};
-use super::worker::UnixStreamEntry;
+use super::worker::DuplexStreamEntry;
 use super::worker_pool::{SupervisorPolicy, WorkerPoolPolicy};
 
 #[derive(Clone)]
@@ -93,28 +93,25 @@ impl TerminationToken {
 }
 
 async fn handle_request(
-    unix_stream_tx: mpsc::UnboundedSender<UnixStreamEntry>,
+    duplex_stream_tx: mpsc::UnboundedSender<DuplexStreamEntry>,
     msg: WorkerRequestMsg,
 ) -> Result<(), Error> {
-    // create a unix socket pair
-    let (sender_stream, recv_stream) = UnixStream::pair()?;
+    let (ours, theirs) = io::duplex(1024);
     let WorkerRequestMsg {
         mut req,
         res_tx,
         conn_watch,
     } = msg;
 
-    let _ = unix_stream_tx.send((recv_stream, conn_watch.clone()));
+    let _ = duplex_stream_tx.send((theirs, conn_watch.clone()));
     let req_upgrade_type = get_upgrade_type(req.headers());
     let req_upgrade = req_upgrade_type
         .clone()
         .and_then(|it| Some(it).zip(req.extensions_mut().remove::<OnUpgrade>()));
 
-    // send the HTTP request to the worker over Unix stream
-    let (mut request_sender, connection) = http1::Builder::new()
-        .writev(true)
-        .handshake(sender_stream)
-        .await?;
+    // send the HTTP request to the worker over duplex stream
+    let (mut request_sender, connection) =
+        http1::Builder::new().writev(true).handshake(ours).await?;
 
     let (upgrade_tx, upgrade_rx) = oneshot::channel();
 
@@ -177,7 +174,7 @@ async fn handle_request(
 
 async fn relay_upgraded_request_and_response(
     downstream: OnUpgrade,
-    parts: http1::Parts<UnixStream>,
+    parts: http1::Parts<io::DuplexStream>,
 ) {
     let mut upstream = Upgraded2::new(parts.io, parts.read_buf);
     let mut downstream = downstream.await.expect("failed to upgrade request");
@@ -190,7 +187,7 @@ async fn relay_upgraded_request_and_response(
                 // `close_notify` before shutdown an upstream if downstream is a
                 // TLS stream.
 
-                // INVARIANT: `UnexpectedEof` due to shutdown `UnixStream` is
+                // INVARIANT: `UnexpectedEof` due to shutdown `DuplexStream` is
                 // only expected to occur in the context of `TlsStream`.
                 panic!("unhandleable unexpected eof");
             };
@@ -516,7 +513,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
     init_opts: Opt,
     inspector: Option<Inspector>,
 ) -> Result<(MetricSource, mpsc::UnboundedSender<WorkerRequestMsg>), Error> {
-    let (unix_stream_tx, unix_stream_rx) = mpsc::unbounded_channel::<UnixStreamEntry>();
+    let (duplex_stream_tx, duplex_stream_rx) = mpsc::unbounded_channel::<DuplexStreamEntry>();
     let (worker_boot_result_tx, worker_boot_result_rx) =
         oneshot::channel::<Result<MetricSource, Error>>();
 
@@ -539,7 +536,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
     if let Some(worker_struct_ref) = downcast_reference {
         worker_struct_ref.start(
             init_opts,
-            (unix_stream_tx.clone(), unix_stream_rx),
+            (duplex_stream_tx.clone(), duplex_stream_rx),
             worker_boot_result_tx,
             maybe_termination_token.clone(),
             inspector,
@@ -549,7 +546,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
         let (worker_req_tx, mut worker_req_rx) = mpsc::unbounded_channel::<WorkerRequestMsg>();
 
         let worker_req_handle: tokio::task::JoinHandle<Result<(), Error>> = tokio::task::spawn({
-            let stream_tx = unix_stream_tx;
+            let stream_tx = duplex_stream_tx;
             async move {
                 while let Some(msg) = worker_req_rx.recv().await {
                     tokio::task::spawn({

--- a/crates/sb_core/http.rs
+++ b/crates/sb_core/http.rs
@@ -13,13 +13,11 @@ use futures::Future;
 use hyper::upgrade::{OnUpgrade, Parts};
 use log::error;
 use serde::Serialize;
+use tokio::io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    sync::{oneshot, watch},
-};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
     net::UnixStream,
+    sync::{oneshot, watch},
 };
 
 use crate::{
@@ -37,15 +35,27 @@ deno_core::extension!(
     middleware = sb_http_middleware,
 );
 
-pub(crate) struct UnixStream2(UnixStream, Option<watch::Receiver<ConnSync>>);
+pub(crate) struct Stream2<S>(S, Option<watch::Receiver<ConnSync>>);
 
-impl UnixStream2 {
-    pub fn new(stream: UnixStream, watcher: Option<watch::Receiver<ConnSync>>) -> Self {
+impl<S> Stream2<S>
+where
+    S: AsyncWrite + AsyncRead + Unpin,
+{
+    pub fn new(stream: S, watcher: Option<watch::Receiver<ConnSync>>) -> Self {
         Self(stream, watcher)
     }
 }
 
-impl AsyncRead for UnixStream2 {
+impl<S> Stream2<S> {
+    fn into_inner(self) -> (S, Option<watch::Receiver<ConnSync>>) {
+        (self.0, self.1)
+    }
+}
+
+impl<S> AsyncRead for Stream2<S>
+where
+    S: AsyncRead + Unpin,
+{
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -55,7 +65,10 @@ impl AsyncRead for UnixStream2 {
     }
 }
 
-impl AsyncWrite for UnixStream2 {
+impl<S> AsyncWrite for Stream2<S>
+where
+    S: AsyncWrite + Unpin,
+{
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -106,6 +119,9 @@ impl AsyncWrite for UnixStream2 {
     }
 }
 
+pub(crate) type DuplexStream2 = Stream2<DuplexStream>;
+pub(crate) type UnixStream2 = Stream2<UnixStream>;
+
 fn http_error(message: &'static str) -> AnyError {
     custom_error("Http", message)
 }
@@ -129,10 +145,19 @@ async fn op_http_upgrade_websocket2(
     };
 
     let upgraded = hyper::upgrade::on(request).await?;
-    let Parts { io, read_buf, .. } = upgraded.downcast::<UnixStream2>().unwrap();
+    let Parts { io, read_buf, .. } = upgraded.downcast::<DuplexStream2>().unwrap();
+    let (mut rw, conn_sync) = io.into_inner();
 
-    let ws_rid = ws_create_server_stream(&mut state.borrow_mut(), io.0.into(), read_buf)?;
-    Ok(ws_rid)
+    // NOTE(Nyannyacha): We use `UnixStream` out of necessity here because
+    // `ws_create_server_stream` only supports network stream types.
+    let (ours, theirs) = UnixStream::pair()?;
+
+    tokio::spawn(async move {
+        let mut theirs = UnixStream2::new(theirs, conn_sync);
+        let _ = copy_bidirectional(&mut rw, &mut theirs).await;
+    });
+
+    ws_create_server_stream(&mut state.borrow_mut(), ours.into(), read_buf)
 }
 
 #[op2]

--- a/crates/sb_core/http_start.rs
+++ b/crates/sb_core/http_start.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::os::fd::AsRawFd;
-use std::os::fd::RawFd;
 use std::rc::Rc;
 
 use deno_core::error::bad_resource;
@@ -10,13 +8,12 @@ use deno_core::op2;
 use deno_core::OpState;
 use deno_core::ResourceId;
 use deno_http::http_create_conn_resource;
-use deno_net::io::UnixStreamResource;
-
 use tokio::sync::watch;
 
 use crate::conn_sync::ConnSync;
 use crate::conn_sync::ConnWatcher;
-use crate::http::UnixStream2;
+use crate::http::DuplexStream2;
+use crate::net::TokioDuplexResource;
 
 #[op2]
 #[serde]
@@ -24,25 +21,23 @@ fn op_http_start(
     state: &mut OpState,
     #[smi] stream_rid: ResourceId,
 ) -> Result<(ResourceId, ResourceId), AnyError> {
-    if let Ok(resource_rc) = state.resource_table.take::<UnixStreamResource>(stream_rid) {
+    if let Ok(resource_rc) = state.resource_table.take::<TokioDuplexResource>(stream_rid) {
         // This connection might be used somewhere else. If it's the case, we cannot proceed with the
         // process of starting a HTTP server on top of this connection, so we just return a bad
         // resource error. See also: https://github.com/denoland/deno/pull/16242
         let resource = Rc::try_unwrap(resource_rc)
-            .map_err(|_| bad_resource("Unix stream is currently in use"))?;
+            .map_err(|_| bad_resource("upstream is currently in use"))?;
 
-        let (read_half, write_half) = resource.into_inner();
-        let unix_stream = read_half.reunite(write_half)?;
-        let fd = unix_stream.as_raw_fd();
+        let (id, stream) = resource.into_inner();
         let watcher = state
-            .borrow_mut::<HashMap<RawFd, watch::Receiver<ConnSync>>>()
-            .remove(&fd);
+            .borrow_mut::<HashMap<usize, watch::Receiver<ConnSync>>>()
+            .remove(&id);
 
         // set a hardcoded address
         let addr: std::net::SocketAddr = "0.0.0.0:9999".parse().unwrap();
         let conn = http_create_conn_resource(
             state,
-            UnixStream2::new(unix_stream, watcher.clone()),
+            DuplexStream2::new(stream, watcher.clone()),
             addr,
             "http",
         )?;

--- a/crates/sb_core/http_start.rs
+++ b/crates/sb_core/http_start.rs
@@ -26,7 +26,7 @@ fn op_http_start(
         // process of starting a HTTP server on top of this connection, so we just return a bad
         // resource error. See also: https://github.com/denoland/deno/pull/16242
         let resource = Rc::try_unwrap(resource_rc)
-            .map_err(|_| bad_resource("upstream is currently in use"))?;
+            .map_err(|_| bad_resource("Duplex stream is currently in use"))?;
 
         let (id, stream) = resource.into_inner();
         let watcher = state

--- a/crates/sb_core/net.rs
+++ b/crates/sb_core/net.rs
@@ -1,7 +1,7 @@
-use anyhow::Error;
 use deno_core::error::bad_resource;
 use deno_core::error::AnyError;
 use deno_core::op2;
+use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
 use deno_core::AsyncResult;
 use deno_core::CancelHandle;
@@ -11,13 +11,14 @@ use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
-use deno_net::io::UnixStreamResource;
 use deno_net::ops::IpAddr;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::os::fd::AsRawFd;
-use std::os::fd::RawFd;
 use std::rc::Rc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use tokio::io;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
@@ -25,56 +26,72 @@ use tokio::sync::watch;
 
 use crate::conn_sync::ConnSync;
 
-pub struct TcpStreamResource {
-    rd: AsyncRefCell<tokio::net::tcp::OwnedReadHalf>,
-    wr: AsyncRefCell<tokio::net::tcp::OwnedWriteHalf>,
-    // When a `TcpStream` resource is closed, all pending 'read' ops are
-    // canceled, while 'write' ops are allowed to complete. Therefore only
-    // 'read' futures are attached to this cancel handle.
-    cancel: CancelHandle,
+pub struct TokioDuplexResource {
+    id: usize,
+    rw: AsyncRefCell<io::DuplexStream>,
+    cancel_handle: CancelHandle,
 }
 
-impl TcpStreamResource {
-    pub fn into_inner(
-        self,
-    ) -> (
-        tokio::net::tcp::OwnedReadHalf,
-        tokio::net::tcp::OwnedWriteHalf,
-    ) {
-        (self.rd.into_inner(), self.wr.into_inner())
+impl TokioDuplexResource {
+    pub fn new(rw: io::DuplexStream) -> Self {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        Self {
+            id: COUNTER.fetch_add(1, Ordering::SeqCst),
+            rw: rw.into(),
+            cancel_handle: CancelHandle::default(),
+        }
     }
 
-    async fn read(self: Rc<Self>, data: &mut [u8]) -> Result<usize, Error> {
-        let mut rd = RcRef::map(&self, |r| &r.rd).borrow_mut().await;
-        let cancel = RcRef::map(self, |r| &r.cancel);
-        let nread = rd.read(data).try_or_cancel(cancel).await?;
+    pub fn into_inner(self) -> (usize, io::DuplexStream) {
+        (self.id, self.rw.into_inner())
+    }
+
+    pub fn borrow_mut(self: &Rc<Self>) -> AsyncMutFuture<io::DuplexStream> {
+        RcRef::map(self, |r| &r.rw).borrow_mut()
+    }
+
+    pub fn cancel_handle(self: &Rc<Self>) -> RcRef<CancelHandle> {
+        RcRef::map(self, |r| &r.cancel_handle)
+    }
+
+    pub fn cancel_read_ops(&self) {
+        self.cancel_handle.cancel()
+    }
+
+    pub async fn read(self: Rc<Self>, data: &mut [u8]) -> Result<usize, AnyError> {
+        let mut rw = self.borrow_mut().await;
+        let nread = rw.read(data).try_or_cancel(self.cancel_handle()).await?;
         Ok(nread)
     }
 
-    async fn write(self: Rc<Self>, data: &[u8]) -> Result<usize, Error> {
-        let mut wr = RcRef::map(self, |r| &r.wr).borrow_mut().await;
-        let nwritten = wr.write(data).await?;
+    pub async fn write(self: Rc<Self>, data: &[u8]) -> Result<usize, AnyError> {
+        let mut rw = self.borrow_mut().await;
+        let nwritten = rw.write(data).await?;
         Ok(nwritten)
+    }
+
+    pub async fn shutdown(self: Rc<Self>) -> Result<(), AnyError> {
+        let mut rw = self.borrow_mut().await;
+        rw.shutdown().await?;
+        Ok(())
     }
 }
 
-impl Resource for TcpStreamResource {
+impl Resource for TokioDuplexResource {
     deno_core::impl_readable_byob!();
     deno_core::impl_writable!();
 
-    fn close(self: Rc<Self>) {
-        self.cancel.cancel()
+    fn name(&self) -> Cow<str> {
+        "tokioDuplexStream".into()
     }
-}
 
-impl From<tokio::net::TcpStream> for TcpStreamResource {
-    fn from(s: tokio::net::TcpStream) -> Self {
-        let (rd, wr) = s.into_split();
-        Self {
-            rd: rd.into(),
-            wr: wr.into(),
-            cancel: Default::default(),
-        }
+    fn shutdown(self: Rc<Self>) -> AsyncResult<()> {
+        Box::pin(self.shutdown())
+    }
+
+    fn close(self: Rc<Self>) {
+        self.cancel_read_ops();
     }
 }
 
@@ -102,11 +119,11 @@ pub async fn op_net_accept(
     // we need to add it back later after processing a message.
     let rx = {
         let mut op_state = state.borrow_mut();
-        op_state.try_take::<mpsc::UnboundedReceiver<(tokio::net::UnixStream, Option<watch::Receiver<ConnSync>>)>>()
+        op_state.try_take::<mpsc::UnboundedReceiver<(io::DuplexStream, Option<watch::Receiver<ConnSync>>)>>()
     };
 
     if rx.is_none() {
-        return Err(bad_resource("unix channel receiver is already used"));
+        return Err(bad_resource("duplex stream receiver is already used"));
     }
 
     let rx = rx.unwrap();
@@ -115,18 +132,18 @@ pub async fn op_net_accept(
         move |value| {
             let mut op_state = state.borrow_mut();
             op_state.put::<mpsc::UnboundedReceiver<(
-                tokio::net::UnixStream,
+                io::DuplexStream,
                 Option<watch::Receiver<ConnSync>>,
             )>>(value);
         }
     });
 
-    let Some((unix_stream, conn_sync)) = rx.recv().await else {
-        return Err(bad_resource("unix stream channel is closed"));
+    let Some((stream, conn_sync)) = rx.recv().await else {
+        return Err(bad_resource("duplex stream channel is closed"));
     };
 
-    let fd = unix_stream.as_raw_fd();
-    let resource = UnixStreamResource::new(unix_stream.into_split());
+    let resource = TokioDuplexResource::new(stream);
+    let id = resource.id;
 
     // since the op state was dropped before,
     // reborrow and add the channel receiver again
@@ -137,8 +154,8 @@ pub async fn op_net_accept(
 
     if let Some(watcher) = conn_sync {
         let _ = op_state
-            .borrow_mut::<HashMap<RawFd, watch::Receiver<ConnSync>>>()
-            .insert(fd, watcher);
+            .borrow_mut::<HashMap<usize, watch::Receiver<ConnSync>>>()
+            .insert(id, watcher);
     }
 
     Ok((

--- a/examples/chunked-text/index.ts
+++ b/examples/chunked-text/index.ts
@@ -1,0 +1,20 @@
+Deno.serve(() => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+        start(controller) {
+            const input = ["m", "e", "o", "w"];
+
+            for (const char of input) {
+                controller.enqueue(encoder.encode(char));
+            }
+
+            controller.close();
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/plain"
+        }
+    });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## Description

This PR changes the stream type used to communicate between workers to `DuplexStream` instead of `UnixStream` to improve request throughput.

It was tested on a local machine, so it's imprecise, but it showed an improvement of about 10% in request throughput per second.

### List of arguments to be created due to the introduction of this PR
* `--tcp-nodelay` flag disables Nagle's algorithm. (Default is `true`)


Figure1. UnixStream, Debug
<img width="811" alt="unixstream_debug" src="https://github.com/supabase/edge-runtime/assets/46702285/9a5fd380-07b6-4b00-8cae-a5629ff2f8f2">

Figure2. DuplexStream, Debug
<img width="842" alt="duplexstream_debug" src="https://github.com/supabase/edge-runtime/assets/46702285/14fbddae-dde0-4ad8-b973-4ca8798e0823">

Figure3. UnixStream, Release
<img width="838" alt="unixstream_release" src="https://github.com/supabase/edge-runtime/assets/46702285/bf82a921-3043-468e-8478-49e8631c9923">

Figure4. DuplexStream, Release
<img width="840" alt="duplexstream_release" src="https://github.com/supabase/edge-runtime/assets/46702285/e051e7a7-dcc5-4871-a443-5562c14de1a6">

Figure5. DuplexStream, Debug (examples/chunked-text, TCP_NODELAY OFF)
<img width="834" alt="duplex-chunked-debug" src="https://github.com/supabase/edge-runtime/assets/46702285/601e828d-0c7c-4262-bd05-9e82c5b2aadc">

Figure6. DuplexStream, Debug (examples/chunked-text, TCP_NODELAY ON)
<img width="806" alt="스크린샷 2024-04-17 오후 1 32 45" src="https://github.com/supabase/edge-runtime/assets/46702285/650a2285-03c9-4212-940c-4daebf285dec">
