### PR TITLE
perf: optimise hash function to use single memory allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastwebsockets"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4653,7 @@ dependencies = [
  "deno_webstorage",
  "encoding_rs",
  "enum-as-inner 0.6.0",
+ "faster-hex",
  "fs3",
  "futures",
  "http 0.2.11",
@@ -6202,7 +6212,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ scopeguard = { version = "1.2.0" }
 glob = "0.3.1"
 httparse = "1.8"
 http = "0.2"
-
+faster-hex = "0.9.0"
 # DEBUG
 #[patch.crates-io]
 #deno_core = { path = "/your/path/to/deno_core/core" }

--- a/crates/sb_core/Cargo.toml
+++ b/crates/sb_core/Cargo.toml
@@ -52,3 +52,4 @@ enum-as-inner.workspace = true
 httparse.workspace = true
 http.workspace = true
 memmem = "0.1"
+faster-hex.workspace=true

--- a/crates/sb_core/util/checksum.rs
+++ b/crates/sb_core/util/checksum.rs
@@ -18,6 +18,9 @@ mod tests {
     fn test() {
         let input = vec![b"hello", b"world", b"hello", b"hello"];
         let output = gen(&input);
-        assert_eq!("00d03979f1c2c9cece94003e15ced43d1de8bf126f28d27b93f1e37874fb5395",output.as_str());
+        assert_eq!(
+            "00d03979f1c2c9cece94003e15ced43d1de8bf126f28d27b93f1e37874fb5395",
+            output.as_str()
+        );
     }
 }

--- a/crates/sb_core/util/checksum.rs
+++ b/crates/sb_core/util/checksum.rs
@@ -2,22 +2,12 @@
 
 use ring::digest::Context;
 use ring::digest::SHA256;
-use std::fmt::Write;
-
 pub fn gen(v: &[impl AsRef<[u8]>]) -> String {
     let mut ctx = Context::new(&SHA256);
     for src in v {
         ctx.update(src.as_ref());
     }
-    let digest = ctx.finish();
-    let mut hash_str = String::with_capacity(64);
-    digest
-        .as_ref()
-        .iter()
-        .for_each(|byte| write!(hash_str, "{byte:02x}")
-            .expect("write! macro on string cannot fail"));
-
-    hash_str
+    faster_hex::hex_string(ctx.finish().as_ref())
 }
 
 #[cfg(test)]

--- a/crates/sb_core/util/checksum.rs
+++ b/crates/sb_core/util/checksum.rs
@@ -2,6 +2,7 @@
 
 use ring::digest::Context;
 use ring::digest::SHA256;
+use std::fmt::Write;
 
 pub fn gen(v: &[impl AsRef<[u8]>]) -> String {
     let mut ctx = Context::new(&SHA256);
@@ -9,10 +10,24 @@ pub fn gen(v: &[impl AsRef<[u8]>]) -> String {
         ctx.update(src.as_ref());
     }
     let digest = ctx.finish();
-    let out: Vec<String> = digest
+    let mut hash_str = String::with_capacity(64);
+    digest
         .as_ref()
         .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect();
-    out.join("")
+        .for_each(|byte| write!(hash_str, "{byte:02x}")
+            .expect("write! macro on string cannot fail"));
+
+    hash_str
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::checksum::gen;
+
+    #[test]
+    fn test() {
+        let input = vec![b"hello", b"world", b"hello", b"hello"];
+        let pdf = gen(&input);
+        assert_eq!("00d03979f1c2c9cece94003e15ced43d1de8bf126f28d27b93f1e37874fb5395",pdf.as_str());
+    }
 }


### PR DESCRIPTION

## What kind of change does this PR introduce?

Performance optimisation

## What is the current behavior?
Currently the gen function performs atleast 33 separate string memory allocations which  can be avoided
## What is the new behavior?
Init a string with 64 bytes and push hashed bytes into that. This is only 1 allocation
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
