### PR TITLE
fix: fallback to ollama if model is not locally available

### DIFF
--- a/crates/sb_ai/ai.js
+++ b/crates/sb_ai/ai.js
@@ -46,11 +46,11 @@ class Session {
 		this.model = model;
 		this.is_ollama = false;
 
-		this.inferenceAPIHost = core.ops.op_get_env('AI_INFERENCE_API_HOST');
-		if (model === 'llama2' || model === 'mixtral' || model === 'mistral') {
-			this.is_ollama = !!this.inferenceAPIHost; // only enable ollama if env variable is set
-		} else {
+		if (model === 'gte-small') {
 			core.ops.op_sb_ai_init_model(model);
+		} else {
+			this.inferenceAPIHost = core.ops.op_get_env('AI_INFERENCE_API_HOST');
+			this.is_ollama = !!this.inferenceAPIHost; // only enable ollama if env variable is set
 		}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes `sb_ai` to fallback to ollama for all models that are not locally available (ie. except for `gte-small`).