### PR TITLE
docs: change default port in DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -7,14 +7,14 @@
 - [Running load tests inside a Dev Container](#running-load-tests-inside-a-dev-container)
 
 ## How to run locally
-To serve all functions in the examples folder on port 9000, you can do this with the [example main service](./examples/main/index.ts) provided with this repo
+To serve all functions in the examples folder on port 9998, you can do this with the [example main service](./examples/main/index.ts) provided with this repo
 ```sh
 ./scripts/run.sh
 ```
 
 Test by calling the [hello world function](./examples/hello-world/index.ts)
 ```sh
-curl --request POST 'http://localhost:9000/hello-world' \
+curl --request POST 'http://localhost:9998/hello-world' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "name": "John Doe"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Drive-by PR. Had to follow the `DEVELOPERS.md` to setup edge-runtime into a container and realized that the [run script defaults to port 9998 rather than 9000](https://github.com/supabase/edge-runtime/blob/main/scripts/run.sh#L3)

We can also change the run script if that's better.