### PR TITLE
fix: make the wall clock limit handle some edge cases correctly

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -268,13 +268,12 @@ impl DenoRuntime {
             emitter_factory.set_decorator_type(maybe_decorator);
 
             let maybe_import_map = load_import_map(import_map_path.clone())?;
+
             emitter_factory.set_import_map(maybe_import_map);
-            maybe_arc_import_map = emitter_factory.maybe_import_map.clone();
+            maybe_arc_import_map.clone_from(&emitter_factory.maybe_import_map);
 
             let arc_emitter_factory = Arc::new(emitter_factory);
-
             let main_module_url_file_path = main_module_url.clone().to_file_path().unwrap();
-
             let maybe_code = if only_module_code {
                 maybe_module_code
             } else {

--- a/crates/base/src/rt_worker/implementation/default_handler.rs
+++ b/crates/base/src/rt_worker/implementation/default_handler.rs
@@ -55,6 +55,9 @@ impl WorkerHandler for Worker {
                 }
 
                 (Ok(()), cpu_usage_ms) => {
+                    // NOTE(Nyannyacha): If a supervisor unconditionally
+                    // requests the isolate to terminate, it might not come to
+                    // this branch, so it might be removed in the future.
                     if created_rt.is_termination_requested.is_raised() {
                         static EVENT_RECV_DEADLINE_DUR: Duration = Duration::from_secs(5);
 

--- a/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
+++ b/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
@@ -54,11 +54,14 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
     let mut req_ack_count = 0usize;
     let mut req_start_ack = false;
 
-    // reduce 100ms from wall clock duration, so the interrupt can be handled before
-    // isolate is dropped
-    let wall_clock_duration = Duration::from_millis(runtime_opts.worker_timeout_ms)
-        .saturating_sub(Duration::from_millis(100));
+    let worker_timeout_ms = runtime_opts.worker_timeout_ms;
+    let worker_timeout_ms = if worker_timeout_ms < 1 {
+        1
+    } else {
+        worker_timeout_ms
+    };
 
+    let wall_clock_duration = Duration::from_millis(worker_timeout_ms);
     let wall_clock_duration_alert = tokio::time::sleep(wall_clock_duration);
 
     tokio::pin!(wall_clock_duration_alert);

--- a/crates/base/src/rt_worker/supervisor/strategy_per_worker.rs
+++ b/crates/base/src/rt_worker/supervisor/strategy_per_worker.rs
@@ -42,7 +42,6 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
     let mut current_thread_id = Option::<ThreadId>::None;
 
     let mut is_worker_entered = false;
-    let mut is_wall_clock_expired = false;
     let mut cpu_usage_metrics_rx = cpu_usage_metrics_rx.unwrap();
     let mut cpu_usage_ms = 0i64;
 
@@ -63,11 +62,11 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
             .unwrap_or(Duration::from_millis(0)),
     );
 
-    let interrupt_fn = {
+    let terminate_fn = {
         let thread_safe_handle = thread_safe_handle.clone();
-        move |should_terminate: bool| {
+        move || {
             let data_ptr_mut = Box::into_raw(Box::new(IsolateInterruptData {
-                should_terminate,
+                should_terminate: true,
                 isolate_memory_usage_tx: Some(isolate_memory_usage_tx),
             }));
 
@@ -93,7 +92,7 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
                     None => pending().await,
                 }
             } => {
-                interrupt_fn(true);
+                terminate_fn();
                 return (ShutdownReason::TerminationRequested, cpu_usage_ms);
             }
 
@@ -126,8 +125,7 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
 
                         if !cpu_timer_param.is_disabled() {
                             if cpu_usage_ms >= hard_limit_ms as i64 {
-                                // shutdown worker
-                                interrupt_fn(true);
+                                terminate_fn();
                                 error!("CPU time hard limit reached. isolate: {:?}", key);
                                 return (ShutdownReason::CPUTime, cpu_usage_ms);
                             } else if cpu_usage_ms >= soft_limit_ms as i64 && !cpu_time_soft_limit_reached {
@@ -137,7 +135,7 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
                                     cpu_time_soft_limit_reached = true;
 
                                     if req_ack_count == demand.load(Ordering::Acquire) {
-                                        interrupt_fn(true);
+                                        terminate_fn();
                                         error!("early termination due to the last request being completed. isolate: {:?}", key);
                                         return (ShutdownReason::EarlyDrop, cpu_usage_ms);
                                     }
@@ -156,13 +154,12 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
                         cpu_time_soft_limit_reached = true;
 
                         if req_ack_count == demand.load(Ordering::Acquire) {
-                            interrupt_fn(true);
+                            terminate_fn();
                             error!("early termination due to the last request being completed. isolate: {:?}", key);
                             return (ShutdownReason::EarlyDrop, cpu_usage_ms);
                         }
                     } else {
-                        // shutdown worker
-                        interrupt_fn(true);
+                        terminate_fn();
                         error!("CPU time hard limit reached. isolate: {:?}", key);
                         return (ShutdownReason::CPUTime, cpu_usage_ms);
                     }
@@ -184,13 +181,13 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
                     continue;
                 }
 
-                interrupt_fn(true);
+                terminate_fn();
                 error!("early termination due to the last request being completed. isolate: {:?}", key);
                 return (ShutdownReason::EarlyDrop, cpu_usage_ms);
             }
 
             // wall clock warning
-            _ = wall_clock_duration_alert.tick(), if !is_wall_clock_expired  => {
+            _ = wall_clock_duration_alert.tick() => {
                 if wall_clock_alerts == 0 {
                     // first tick completes immediately
                     wall_clock_alerts += 1;
@@ -200,27 +197,19 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
                     error!("wall clock duration warning. isolate: {:?}", key);
                     wall_clock_alerts += 1;
                 } else {
-                    // NOTE: Wall clock is also triggered when no more
-                    // pending requests, so we must compare the request
-                    // count here to judge whether we need to terminate the
-                    // isolate.
-                    if req_ack_count == demand.load(Ordering::Acquire) {
-                        interrupt_fn(true);
-                        error!("wall clock duration reached. isolate: {:?}", key);
-                        return (ShutdownReason::WallClockTime, cpu_usage_ms);
-                    } else {
-                        // It looks like there are still items being handled.
-                        // Instead of forcing it to end by the wall clock limit,
-                        // let it terminate by another limit routine.
-                        is_wall_clock_expired = true;
-                        continue;
-                    }
+                    let is_in_flight_req_exists = req_ack_count != demand.load(Ordering::Acquire);
+
+                    terminate_fn();
+
+                    error!("wall clock duration reached. isolate: {:?} (in_flight_req_exists = {})", key, is_in_flight_req_exists);
+
+                    return (ShutdownReason::WallClockTime, cpu_usage_ms);
                 }
             }
 
             // memory usage
             Some(_) = memory_limit_rx.recv() => {
-                interrupt_fn(true);
+                terminate_fn();
                 error!("memory limit reached for the worker. isolate: {:?}", key);
                 return (ShutdownReason::Memory, cpu_usage_ms);
             }

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -6,8 +6,8 @@ use crate::rt_worker::worker_ctx::create_supervisor;
 use crate::utils::send_event_if_event_worker_available;
 use anyhow::{anyhow, Error};
 use event_worker::events::{
-    EventMetadata, ShutdownEvent, ShutdownReason, UncaughtExceptionEvent, WorkerEventWithMetadata,
-    WorkerEvents, WorkerMemoryUsed,
+    EventLoopCompletedEvent, EventMetadata, ShutdownEvent, ShutdownReason, UncaughtExceptionEvent,
+    WorkerEventWithMetadata, WorkerEvents, WorkerMemoryUsed,
 };
 use futures_util::FutureExt;
 use log::{debug, error};
@@ -290,6 +290,10 @@ impl Worker {
                         match event {
                             WorkerEvents::Shutdown(ShutdownEvent { cpu_time_used, .. })
                             | WorkerEvents::UncaughtException(UncaughtExceptionEvent {
+                                cpu_time_used,
+                                ..
+                            })
+                            | WorkerEvents::EventLoopCompleted(EventLoopCompletedEvent {
                                 cpu_time_used,
                                 ..
                             }) => {

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -2,9 +2,6 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PseudoEvent {}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct BootEvent {
     pub boot_time: usize,
 }
@@ -43,6 +40,11 @@ pub struct UncaughtExceptionEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct EventLoopCompletedEvent {
+    pub cpu_time_used: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct LogEvent {
     pub msg: String,
     pub level: LogLevel,
@@ -62,7 +64,7 @@ pub enum WorkerEvents {
     BootFailure(BootFailureEvent),
     UncaughtException(UncaughtExceptionEvent),
     Shutdown(ShutdownEvent),
-    EventLoopCompleted(PseudoEvent),
+    EventLoopCompleted(EventLoopCompletedEvent),
     Log(LogEvent),
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

```typescript
// Inputs below will disable the wall clock limit.
const workerTimeoutMs = -999;
const workerTimeoutMs = -1;
const workerTimeoutMs = 0;
const worker = EdgeRuntime.userWorkers.create({
    ...,
    workerTimeoutMs
});
```

```typescript
// Worker is created and immediately terminated by the wall clock limit. However, if the script
// is lightweight enough to initialize quickly, the request can be processed before the worker exits.
const workerTimeoutMs = 1;
const worker = EdgeRuntime.userWorkers.create({
    ...,
    workerTimeoutMs
});
```

```typescript
// main.ts
const workerTimeoutMs = 2000;
const worker = EdgeRuntime.userWorkers.create({
    ...,
    workerTimeoutMs
});

// serve.ts
async function sleep(ms: number) {
    return new Promise(res => {
        setTimeout(() => {
            res(void 0);
        }, ms)
    });
}

// Wait 3000 ms on purpose. (Top-level await)
await sleep(3000);
Deno.serve((_req) => new Response("Hello, world"));

// Following case is also valid.
// Deno.serve(async () => {
//     await sleep(3000);
//     return new Response("Hello, world");
// });

// This script will be forced to exit after about 2000 ms with no requests processed.
```

Fixes #99 