### PR TITLE
feat: correctly handle import statement with JSR specifier

### DIFF
--- a/crates/base/test_cases/oak-v12-file-upload/index.ts
+++ b/crates/base/test_cases/oak-v12-file-upload/index.ts
@@ -1,0 +1,35 @@
+import { Application, Router } from 'https://deno.land/x/oak@v12.3.0/mod.ts';
+
+const MB = 1024 * 1024;
+
+const router = new Router();
+
+router
+	.post('/file-upload', async (ctx) => {
+		try {
+			const body = ctx.request.body({ type: 'form-data' });
+			const formData = await body.value.read({
+				// Need to set the maxSize so files will be stored in memory.
+				// This is necessary as Edge Functions don't have disk write access.
+				// We are setting the max size as 10MB (an Edge Function has a max memory limit of 150MB)
+				// For more config options, check: https://deno.land/x/oak@v11.1.0/mod.ts?s=FormDataReadOptions
+				maxSize: 1 * MB,
+			});
+			const file = formData.files[0];
+
+			ctx.response.status = 201;
+			ctx.response.body = `file-type: ${file.contentType}`;
+		} catch (e) {
+			console.log('error occurred');
+			console.log(e);
+			ctx.response.status = 500;
+			ctx.response.body = 'Error!';
+		}
+	});
+
+const app = new Application();
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen();

--- a/crates/base/test_cases/oak-with-jsr/index.ts
+++ b/crates/base/test_cases/oak-with-jsr/index.ts
@@ -1,0 +1,17 @@
+import { Application } from "jsr:@oak/oak/application";
+import { Router } from "jsr:@oak/oak/router";
+
+const router = new Router();
+
+router
+	// Note: path will be prefixed with function name
+	.get("/oak-with-jsr", (context) => {
+		context.response.body = "meow";
+	});
+
+const app = new Application();
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen();

--- a/crates/base/test_cases/oak/index.ts
+++ b/crates/base/test_cases/oak/index.ts
@@ -1,48 +1,19 @@
-import { Application, Router } from 'https://deno.land/x/oak@v12.3.0/mod.ts';
-
-const MB = 1024 * 1024;
+import { Application, Router } from 'https://deno.land/x/oak/mod.ts';
 
 const router = new Router();
+
 router
 	// Note: path will be prefixed with function name
 	.get('/oak', (context) => {
 		context.response.body = 'This is an example Oak server running on Edge Functions!';
 	})
-	.post('/oak/greet', async (context) => {
-		// Note: request body will be streamed to the function as chunks, set limit to 0 to fully read it.
-		const result = context.request.body({ type: 'json', limit: 0 });
-		const body = await result.value;
-		const name = body.name || 'you';
-
-		context.response.body = { msg: `Hey ${name}!` };
-	})
 	.get('/oak/redirect', (context) => {
 		context.response.redirect('https://www.example.com');
-	})
-	.post('/file-upload', async (ctx) => {
-		try {
-			const body = ctx.request.body({ type: 'form-data' });
-			const formData = await body.value.read({
-				// Need to set the maxSize so files will be stored in memory.
-				// This is necessary as Edge Functions don't have disk write access.
-				// We are setting the max size as 10MB (an Edge Function has a max memory limit of 150MB)
-				// For more config options, check: https://deno.land/x/oak@v11.1.0/mod.ts?s=FormDataReadOptions
-				maxSize: 1 * MB,
-			});
-			const file = formData.files[0];
-
-			ctx.response.status = 201;
-			ctx.response.body = `file-type: ${file.contentType}`;
-		} catch (e) {
-			console.log('error occurred');
-			console.log(e);
-			ctx.response.status = 500;
-			ctx.response.body = 'Error!';
-		}
 	});
 
 const app = new Application();
+
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-await app.listen({ port: 8000 });
+await app.listen();

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -608,7 +608,7 @@ async fn test_file_upload() {
     let request_builder = Some(original);
 
     integration_test!(
-        "./test_cases/oak",
+        "./test_cases/oak-v12-file-upload",
         NON_SECURE_PORT,
         "",
         None,

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -1279,6 +1279,24 @@ async fn send_partial_payload_into_closed_pipe_should_not_be_affected_worker_sta
     tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
 }
 
+#[tokio::test]
+#[serial]
+async fn oak_with_jsr_specifier() {
+    integration_test!(
+        "./test_cases/main",
+        NON_SECURE_PORT,
+        "oak-with-jsr",
+        None,
+        None,
+        None,
+        None,
+        (|resp| async {
+            assert_eq!(resp.unwrap().text().await.unwrap(), "meow");
+        }),
+        TerminationToken::new()
+    );
+}
+
 trait TlsExt {
     fn client(&self) -> reqwest::Client;
     fn schema(&self) -> &'static str;

--- a/examples/oak-with-jsr/index.ts
+++ b/examples/oak-with-jsr/index.ts
@@ -1,0 +1,17 @@
+import { Application } from "jsr:@oak/oak/application";
+import { Router } from "jsr:@oak/oak/router";
+
+const router = new Router();
+
+router
+	// Note: path will be prefixed with function name
+	.get("/oak-with-jsr", (context) => {
+		context.response.body = "This is an example Oak server running on Edge Functions!";
+	});
+
+const app = new Application();
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Now that Deno has deployed the `jsr:` specifier [globally](https://jsr.io), the edge runtime should also support it.

Previously, this specifier was not properly supported, causing the module resolution phase to be an indefinite pending state.

Fixes #335 