### PR TITLE
feat: support idle timeout for HTTP requests 

### DIFF
--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -227,7 +227,7 @@ async fn relay_upgraded_request_and_response(
 
     match copy_bidirectional(&mut upstream, &mut downstream).await {
         Ok(_) => {}
-        Err(err) if maybe_idle_timeout.is_some() && matches!(err.kind(), ErrorKind::TimedOut) => {}
+        Err(err) if matches!(err.kind(), ErrorKind::TimedOut | ErrorKind::BrokenPipe) => {}
         Err(err) if matches!(err.kind(), ErrorKind::UnexpectedEof) => {
             let Ok(_) = downstream.downcast::<timeout::Stream<TlsStream<TcpStream>>>() else {
                 // TODO(Nyannyacha): It would be better if we send
@@ -240,8 +240,8 @@ async fn relay_upgraded_request_and_response(
             };
         }
 
-        _ => {
-            unreachable!("coping between upgraded connections failed");
+        value => {
+            unreachable!("coping between upgraded connections failed: {:?}", value);
         }
     }
 

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -1,5 +1,6 @@
 use crate::inspector_server::Inspector;
 use crate::rt_worker::worker_ctx::{create_worker, send_user_worker_request};
+use crate::server::ServerFlags;
 use anyhow::{anyhow, bail, Context, Error};
 use enum_as_inner::EnumAsInner;
 use event_worker::events::WorkerEventWithMetadata;
@@ -88,15 +89,15 @@ impl WorkerPoolPolicy {
     pub fn new(
         supervisor: impl Into<Option<SupervisorPolicy>>,
         max_parallelism: impl Into<Option<usize>>,
-        request_wait_timeout_ms: impl Into<Option<u64>>,
+        server_flags: ServerFlags,
     ) -> Self {
         let default = Self::default();
 
         Self {
             supervisor_policy: supervisor.into().unwrap_or(default.supervisor_policy),
             max_parallelism: max_parallelism.into().unwrap_or(default.max_parallelism),
-            request_wait_timeout_ms: request_wait_timeout_ms
-                .into()
+            request_wait_timeout_ms: server_flags
+                .request_wait_timeout_ms
                 .unwrap_or(default.request_wait_timeout_ms),
         }
     }

--- a/crates/base/src/rt_worker/worker_pool.rs
+++ b/crates/base/src/rt_worker/worker_pool.rs
@@ -212,6 +212,7 @@ pub struct WorkerPool {
     pub active_workers: HashMap<String, ActiveWorkerRegistry>,
     pub worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
     pub maybe_inspector: Option<Inspector>,
+    pub maybe_request_idle_timeout: Option<u64>,
 
     // TODO: refactor this out of worker pool
     pub worker_event_sender: Option<mpsc::UnboundedSender<WorkerEventWithMetadata>>,
@@ -224,6 +225,7 @@ impl WorkerPool {
         worker_event_sender: Option<UnboundedSender<WorkerEventWithMetadata>>,
         worker_pool_msgs_tx: mpsc::UnboundedSender<UserWorkerMsgs>,
         inspector: Option<Inspector>,
+        request_idle_timeout: Option<u64>,
     ) -> Self {
         Self {
             policy,
@@ -232,6 +234,7 @@ impl WorkerPool {
             user_workers: HashMap::new(),
             active_workers: HashMap::new(),
             maybe_inspector: inspector,
+            maybe_request_idle_timeout: request_idle_timeout,
             worker_pool_msgs_tx,
         }
     }
@@ -250,6 +253,7 @@ impl WorkerPool {
 
         let is_oneshot_policy = self.policy.supervisor_policy.is_oneshot();
         let inspector = self.maybe_inspector.clone();
+        let request_idle_timeout = self.maybe_request_idle_timeout;
 
         let force_create = worker_options
             .conf
@@ -419,6 +423,7 @@ impl WorkerPool {
             match create_worker(
                 (worker_options, supervisor_policy, termination_token.clone()),
                 inspector,
+                request_idle_timeout,
             )
             .await
             {

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -244,6 +244,8 @@ pub struct ServerFlags {
     pub tcp_nodelay: bool,
     pub graceful_exit_deadline_sec: u64,
     pub graceful_exit_keepalive_deadline_ms: Option<u64>,
+    pub request_wait_timeout_ms: Option<u64>,
+    pub request_idle_timeout_ms: Option<u64>,
     pub request_read_timeout_ms: Option<u64>,
 }
 

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -381,6 +381,7 @@ impl Server {
             Some(termination_tokens.pool.clone()),
             static_patterns,
             inspector.clone(),
+            flags.request_idle_timeout_ms,
         )
         .await?;
 

--- a/crates/base/test_cases/chunked-char-first-6000ms/index.ts
+++ b/crates/base/test_cases/chunked-char-first-6000ms/index.ts
@@ -1,0 +1,32 @@
+async function sleep(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res(void 0);
+        }, ms)
+    });
+}
+
+Deno.serve(() => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+        async start(controller) {
+            const input: [string, number][] = [
+                ["m", 6000],
+                ["e", 100],
+            ];
+
+            for (const [char, wait] of input) {
+                await sleep(wait);
+                controller.enqueue(encoder.encode(char));
+            }
+
+            controller.close();
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/plain"
+        }
+    });
+});

--- a/crates/base/test_cases/chunked-char-variable-delay-max-6000ms/index.ts
+++ b/crates/base/test_cases/chunked-char-variable-delay-max-6000ms/index.ts
@@ -1,0 +1,38 @@
+async function sleep(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res(void 0);
+        }, ms)
+    });
+}
+
+Deno.serve(() => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+        async start(controller) {
+            const input: [string, number][] = [
+                ["m", 500],
+                ["e", 1000],
+                ["o", 1000],
+                ["w", 6000],
+                ["m", 100],
+                ["e", 100],
+                ["o", 100],
+                ["w", 600],
+            ];
+
+            for (const [char, wait] of input) {
+                await sleep(wait);
+                controller.enqueue(encoder.encode(char));
+            }
+
+            controller.close();
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/plain"
+        }
+    });
+});

--- a/crates/base/test_cases/sleep-5000ms/index.ts
+++ b/crates/base/test_cases/sleep-5000ms/index.ts
@@ -1,0 +1,12 @@
+async function sleep(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res(void 0);
+        }, ms)
+    });
+}
+
+Deno.serve(async () => {
+    await sleep(5000);
+    return new Response("meow");
+});

--- a/crates/base/test_cases/websocket-upgrade-no-send-node/index.ts
+++ b/crates/base/test_cases/websocket-upgrade-no-send-node/index.ts
@@ -1,0 +1,19 @@
+import { createServer } from "node:http";
+import { WebSocketServer } from "npm:ws";
+
+const server = createServer();
+const wss = new WebSocketServer({ noServer: true });
+
+wss.on("connection", ws => {
+	ws.on("message", data => {
+		ws.send(data.toString());
+	});
+});
+
+server.on("upgrade", (req, socket, head) => {
+	wss.handleUpgrade(req, socket, head, ws => {
+		wss.emit("connection", ws, req);
+	});
+});
+
+server.listen(8080);

--- a/crates/base/test_cases/websocket-upgrade-no-send/index.ts
+++ b/crates/base/test_cases/websocket-upgrade-no-send/index.ts
@@ -1,0 +1,9 @@
+Deno.serve(async (req: Request) => {
+	const { socket, response } = Deno.upgradeWebSocket(req);
+
+	socket.onmessage = ev => {
+		socket.send(ev.data);
+	};
+
+	return response;
+});

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -190,6 +190,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         Some(pool_termination_token.clone()),
         vec![],
         None,
+        None,
     )
     .await
     .unwrap();
@@ -213,7 +214,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         static_patterns: vec![],
     };
 
-    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()), None)
+    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()), None, None)
         .await
         .unwrap();
 
@@ -346,6 +347,7 @@ async fn test_main_worker_boot_error() {
         Some(pool_termination_token.clone()),
         vec![],
         None,
+        None,
     )
     .await
     .unwrap();
@@ -369,7 +371,7 @@ async fn test_main_worker_boot_error() {
         static_patterns: vec![],
     };
 
-    let result = create_worker((opts, main_termination_token.clone()), None).await;
+    let result = create_worker((opts, main_termination_token.clone()), None, None).await;
 
     assert!(result.is_err());
     assert!(result

--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -141,6 +141,11 @@ fn get_start_command() -> Command {
                 .value_parser(value_parser!(u64)),
         )
         .arg(
+            arg!(--"request-idle-timeout" <MILLISECONDS>)
+                .help("Maximum time in milliseconds that can be waited from when a worker takes over the request")
+                .value_parser(value_parser!(u64)),
+        )
+        .arg(
             arg!(--"request-read-timeout" <MILLISECONDS>)
                 .help("Maximum time in milliseconds that can be waited from when the connection is accepted until the request body is fully read")
                 .value_parser(value_parser!(u64)),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -122,6 +122,8 @@ fn main() -> Result<(), anyhow::Error> {
                     sub_matches.get_one::<usize>("max-parallelism").cloned();
                 let maybe_request_wait_timeout =
                     sub_matches.get_one::<u64>("request-wait-timeout").cloned();
+                let maybe_request_idle_timeout =
+                    sub_matches.get_one::<u64>("request-idle-timeout").cloned();
                 let maybe_request_read_timeout =
                     sub_matches.get_one::<u64>("request-read-timeout").cloned();
                 let static_patterns =
@@ -157,6 +159,16 @@ fn main() -> Result<(), anyhow::Error> {
                 };
 
                 let tcp_nodelay = sub_matches.get_one::<bool>("tcp-nodelay").copied().unwrap();
+                let flags = ServerFlags {
+                    no_module_cache,
+                    allow_main_inspector,
+                    tcp_nodelay,
+                    graceful_exit_deadline_sec,
+                    graceful_exit_keepalive_deadline_ms,
+                    request_wait_timeout_ms: maybe_request_wait_timeout,
+                    request_idle_timeout_ms: maybe_request_idle_timeout,
+                    request_read_timeout_ms: maybe_request_read_timeout,
+                };
 
                 start_server(
                     ip.as_str(),
@@ -187,17 +199,10 @@ fn main() -> Result<(), anyhow::Error> {
                         } else {
                             maybe_max_parallelism
                         },
-                        maybe_request_wait_timeout,
+                        flags,
                     )),
                     import_map_path,
-                    ServerFlags {
-                        no_module_cache,
-                        allow_main_inspector,
-                        tcp_nodelay,
-                        graceful_exit_deadline_sec,
-                        graceful_exit_keepalive_deadline_ms,
-                        request_read_timeout_ms: maybe_request_read_timeout,
-                    },
+                    flags,
                     None,
                     WorkerEntrypoints {
                         main: maybe_main_entrypoint,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

> Note: This PR is behind [PR-337](https://github.com/supabase/edge-runtime/pull/337). (PR will be rebased after PR-337 has been merged into main)

This PR introduces the feature for a user worker to force a response to complete (timeout) if it does not complete the response within a specified amount of time after receiving the request from the pooler.

### List of arguments to be created due to the introduction of this PR
* `--request-idle-timeout` flag specifies maximum time in milliseconds that can be waited from when a worker takes over the request. (disabled by default)

### Timeout behaviors by response types
|Response Type|Behavior|
|---------------|---------|
|`Content-Length` present (ie. not stream response)|Respond with [HTTP 408 Request Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408)|
|No `Content-Length` present (ie. stream response)|Emit an EOF to a stream immediately|
|Upgraded Connection (ie. WebSocket)|Connection Reset|

> Note: Timeout behavior for upgraded connections seems like something that needs to be improved in the future