### PR TITLE
fix: make `EmitterFactory` respect `allow_remote_modules` option when determining `no npm` mode

### DIFF
--- a/crates/sb_graph/emitter.rs
+++ b/crates/sb_graph/emitter.rs
@@ -327,6 +327,7 @@ impl EmitterFactory {
     pub fn cli_graph_resolver_options(&self) -> CliGraphResolverOptions {
         CliGraphResolverOptions {
             maybe_import_map: self.maybe_import_map.clone(),
+            no_npm: !self.file_fetcher_allow_remote,
             ..Default::default()
         }
     }
@@ -339,7 +340,11 @@ impl EmitterFactory {
                     self.package_json_deps_provider().clone(),
                     self.package_json_deps_installer().await.clone(),
                     self.cli_graph_resolver_options(),
-                    Some(self.npm_resolver().await.clone()),
+                    if self.file_fetcher_allow_remote {
+                        Some(self.npm_resolver().await.clone())
+                    } else {
+                        None
+                    },
                 )))
             })
             .await


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR improves EmitterFactory so that it can determine `no npm` mode via the `allowRemoteModules` passed in by the user. (The original option for this is `no_npm`, but this is not exposed in js land).

```typescript
// main service
await EdgeRuntime.userWorkers.create({
      servicePath,
      memoryLimitMb,
      workerTimeoutMs,
      noModuleCache,

      allowRemoteModules: false,
      ...
});

// some user script
import * as jose from 'npm:jose'
...
```

Output
```
...
DEBUG Snapshot already up to date. Skipping pending resolution.
failed to load 'npm:jose': npm specifiers were requested; but --no-npm is specified
An error has occured
InvalidWorkerCreation: worker boot error failed to load 'npm:jose': npm specifiers were requested; but --no-npm is specified
    at async UserWorker.create (ext:sb_user_workers/user_workers.js:155:15)
    at async createWorker (file:///workspaces/edge-runtime/examples/main/index.ts:85:12)
    at async callWorker (file:///workspaces/edge-runtime/examples/main/index.ts:104:22)
    at async respond (ext:sb_core_main_js/js/http.js:162:14) {
  name: "InvalidWorkerCreation"
}
```

Fixes #340 