### PR TITLE
fix: relaxing the condition which can be activated inspector feature

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -161,16 +161,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .or(sub_matches.get_one::<SocketAddr>("inspect-wait")),
                 );
 
-                let maybe_inspector_option = if inspector.is_some()
-                    && !maybe_supervisor_policy
-                        .as_ref()
-                        .map(SupervisorPolicy::is_oneshot)
-                        .unwrap_or(false)
-                {
-                    bail!(
-                        "specifying `oneshot` policy is required to enable the inspector feature"
-                    );
-                } else if let Some((key, addr)) = inspector {
+                let maybe_inspector_option = if let Some((key, addr)) = inspector {
                     Some(get_inspector_option(key.as_str(), addr).unwrap())
                 } else {
                     None


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## Description

The PR relaxes the restriction that inspector feature could only be activated in `oneshot` policy.

> Caveats: This relaxation allows policies other than `oneshot` to create inspector sessions, so the worker will remain until the `wallclock limit` or `cputime limit` is reached. This means that source changes by users will not result in immediate feedback to the worker.