### PR TITLE
fix: change the status code emitted when an idle timeout occurs for a worker

### DIFF
--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -168,8 +168,7 @@ async fn handle_request(
     let res = tokio::select! {
         resp = request_sender.send_request(req) => resp,
         _ = maybe_cancel_fut => {
-            // XXX(Nyannyacha): Should we add a more detailed message?
-            Ok(emit_status_code(http::StatusCode::REQUEST_TIMEOUT, None, true))
+            Ok(emit_status_code(http::StatusCode::GATEWAY_TIMEOUT, None, false))
         }
     };
 

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -1701,7 +1701,7 @@ async fn test_request_idle_timeout_no_streamed_response(maybe_tls: Option<Tls>) 
         request_builder,
         maybe_tls,
         (|resp| async {
-            assert_eq!(resp.unwrap().status().as_u16(), StatusCode::REQUEST_TIMEOUT);
+            assert_eq!(resp.unwrap().status().as_u16(), StatusCode::GATEWAY_TIMEOUT);
         }),
         TerminationToken::new()
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

By default, idle timeout is for connections that have been successfully established, so a 504 status code should be emitted instead of a 408 status code.

cc @laktek 
