### PR TITLE
fix: don't emit `RequestCancelledBySupervisor` when event loop error has been raised

### DIFF
--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -12,7 +12,7 @@ use event_worker::events::{
 use futures_util::FutureExt;
 use log::{debug, error};
 use sb_core::{MetricSource, RuntimeMetricSource, WorkerMetricSource};
-use sb_workers::context::{UserWorkerMsgs, WorkerContextInitOpts};
+use sb_workers::context::{UserWorkerMsgs, WorkerContextInitOpts, WorkerExit, WorkerExitStatus};
 use std::any::Any;
 use std::future::{pending, Future};
 use std::pin::Pin;
@@ -94,6 +94,7 @@ impl Worker {
             UnboundedReceiver<DuplexStreamEntry>,
         ),
         booter_signal: Sender<Result<MetricSource, Error>>,
+        exit: WorkerExit,
         termination_token: Option<TerminationToken>,
         inspector: Option<Inspector>,
     ) {
@@ -269,13 +270,19 @@ impl Worker {
                                 )
                                 .await;
 
-                            let found_unexpected_error = result.is_err()
-                                || matches!(
-                                    result.as_ref(),
-                                    Ok(WorkerEvents::UncaughtException(_))
-                                );
+                            let maybe_uncaught_exception_event = match result.as_ref() {
+                                Ok(WorkerEvents::UncaughtException(ev)) => Some(ev.clone()),
+                                Err(err) => Some(UncaughtExceptionEvent {
+                                    cpu_time_used: 0,
+                                    exception: err.to_string()
+                                }),
 
-                            if found_unexpected_error {
+                                _ => None
+                            };
+
+                            if let Some(ev) = maybe_uncaught_exception_event {
+                                exit.set(WorkerExitStatus::WithUncaughtException(ev)).await;
+
                                 if let Some(token) = supervise_cancel_token.as_ref() {
                                     token.cancel();
                                 }

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -25,7 +25,7 @@ use sb_core::{MetricSource, SharedMetricSource};
 use sb_graph::{DecoratorType, EszipPayloadKind};
 use sb_workers::context::{
     EventWorkerRuntimeOpts, MainWorkerRuntimeOpts, Timing, UserWorkerMsgs, WorkerContextInitOpts,
-    WorkerKind, WorkerRequestMsg, WorkerRuntimeOpts,
+    WorkerExit, WorkerKind, WorkerRequestMsg, WorkerRuntimeOpts,
 };
 use sb_workers::errors::WorkerError;
 use std::future::pending;
@@ -553,11 +553,18 @@ impl CreateWorkerArgs {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct WorkerCtx {
+    pub metric: MetricSource,
+    pub msg_tx: mpsc::UnboundedSender<WorkerRequestMsg>,
+    pub exit: WorkerExit,
+}
+
 pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
     init_opts: Opt,
     inspector: Option<Inspector>,
     maybe_request_idle_timeout: Option<u64>,
-) -> Result<(MetricSource, mpsc::UnboundedSender<WorkerRequestMsg>), Error> {
+) -> Result<WorkerCtx, Error> {
     let (duplex_stream_tx, duplex_stream_rx) = mpsc::unbounded_channel::<DuplexStreamEntry>();
     let (worker_boot_result_tx, worker_boot_result_rx) =
         oneshot::channel::<Result<MetricSource, Error>>();
@@ -566,6 +573,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
         init_opts.into();
 
     let worker_kind = worker_init_opts.conf.to_worker_kind();
+    let exit = WorkerExit::default();
     let mut worker = Worker::new(&worker_init_opts)?;
 
     if worker_kind.is_user_worker() {
@@ -584,6 +592,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
             worker_init_opts,
             (duplex_stream_tx.clone(), duplex_stream_rx),
             worker_boot_result_tx,
+            exit.clone(),
             maybe_termination_token.clone(),
             inspector,
         );
@@ -629,6 +638,7 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
 
                 bail!(err)
             }
+
             Ok(metric) => {
                 let elapsed = worker_struct_ref
                     .worker_boot_start_time
@@ -643,7 +653,11 @@ pub async fn create_worker<Opt: Into<CreateWorkerArgs>>(
                     worker_struct_ref.event_metadata.clone(),
                 );
 
-                Ok((metric, worker_req_tx))
+                Ok(WorkerCtx {
+                    metric,
+                    msg_tx: worker_req_tx,
+                    exit,
+                })
             }
         }
     } else {
@@ -655,6 +669,7 @@ pub async fn send_user_worker_request(
     worker_request_msg_tx: mpsc::UnboundedSender<WorkerRequestMsg>,
     req: Request<Body>,
     cancel: CancellationToken,
+    exit: WorkerExit,
     conn_token: Option<CancellationToken>,
 ) -> Result<Response<Body>, Error> {
     let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
@@ -669,7 +684,13 @@ pub async fn send_user_worker_request(
 
     // wait for the response back from the worker
     let res = tokio::select! {
-        () = cancel.cancelled() => bail!(WorkerError::RequestCancelledBySupervisor),
+        () = cancel.cancelled() => {
+            bail!(exit
+                .error()
+                .await
+                .unwrap_or(anyhow!(WorkerError::RequestCancelledBySupervisor)))
+        }
+
         res = res_rx => res,
     }??;
 
@@ -699,7 +720,7 @@ pub async fn create_main_worker(
         }
     }
 
-    let (_, sender) = create_worker(
+    let ctx = create_worker(
         (
             WorkerContextInitOpts {
                 service_path,
@@ -724,7 +745,7 @@ pub async fn create_main_worker(
     .await
     .map_err(|err| anyhow!("main worker boot error: {}", err))?;
 
-    Ok(sender)
+    Ok(ctx.msg_tx)
 }
 
 pub async fn create_events_worker(
@@ -734,7 +755,7 @@ pub async fn create_events_worker(
     maybe_entrypoint: Option<String>,
     maybe_decorator: Option<DecoratorType>,
     termination_token: Option<TerminationToken>,
-) -> Result<(MetricSource, mpsc::UnboundedSender<WorkerEventWithMetadata>), Error> {
+) -> Result<(WorkerCtx, mpsc::UnboundedSender<WorkerEventWithMetadata>), Error> {
     let (events_tx, events_rx) = mpsc::unbounded_channel::<WorkerEventWithMetadata>();
 
     let mut service_path = events_worker_path.clone();
@@ -748,7 +769,7 @@ pub async fn create_events_worker(
         }
     }
 
-    let (metric, _) = create_worker(
+    let ctx = create_worker(
         (
             WorkerContextInitOpts {
                 service_path,
@@ -773,7 +794,7 @@ pub async fn create_events_worker(
     .await
     .map_err(|err| anyhow!("events worker boot error: {}", err))?;
 
-    Ok((metric, events_tx))
+    Ok((ctx, events_tx))
 }
 
 pub async fn create_user_worker_pool(

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -692,10 +692,22 @@ pub async fn send_user_worker_request(
         }
 
         res = res_rx => res,
-    }??;
+    }?;
 
-    // send the response back to the caller
-    Ok(res)
+    match res {
+        Ok(v) => {
+            // send the response back to the caller
+            Ok(v)
+        }
+
+        Err(err) => {
+            if let Some(actual_error) = exit.error().await {
+                return Err(actual_error);
+            }
+
+            Err(err.into())
+        }
+    }
 }
 
 // Todo: Fix

--- a/crates/base/src/server.rs
+++ b/crates/base/src/server.rs
@@ -362,7 +362,7 @@ impl Server {
             let events_path = Path::new(&events_service_path);
             let events_path_buf = events_path.to_path_buf();
 
-            let (event_worker_metric, sender) = create_events_worker(
+            let (ctx, sender) = create_events_worker(
                 events_path_buf,
                 import_map_path.clone(),
                 flags.no_module_cache,
@@ -373,7 +373,7 @@ impl Server {
             .await?;
 
             worker_events_tx = Some(sender);
-            Some(event_worker_metric)
+            Some(ctx.metric)
         } else {
             None
         };

--- a/crates/base/src/utils/integration_test_helper.rs
+++ b/crates/base/src/utils/integration_test_helper.rs
@@ -246,7 +246,7 @@ impl TestBedBuilder {
         };
 
         let main_termination_token = TerminationToken::new();
-        let (_, main_worker_msg_tx) = create_worker(
+        let ctx = create_worker(
             (main_worker_init_opts, main_termination_token.clone()),
             None,
             None,
@@ -257,7 +257,7 @@ impl TestBedBuilder {
         TestBed {
             pool_termination_token,
             main_termination_token,
-            main_worker_msg_tx,
+            main_worker_msg_tx: ctx.msg_tx,
         }
     }
 }
@@ -327,7 +327,7 @@ pub async fn create_test_user_worker<Opt: Into<CreateTestUserWorkerArgs>>(
     });
 
     Ok({
-        let (_, sender) = create_worker(
+        let ctx = create_worker(
             opts.with_policy(policy)
                 .with_termination_token(termination_token.clone()),
             None,
@@ -336,7 +336,7 @@ pub async fn create_test_user_worker<Opt: Into<CreateTestUserWorkerArgs>>(
         .await?;
 
         (
-            sender,
+            ctx.msg_tx,
             RequestScope {
                 policy,
                 req_start_tx,

--- a/crates/base/test_cases/array-alloc-sync/index.ts
+++ b/crates/base/test_cases/array-alloc-sync/index.ts
@@ -1,0 +1,9 @@
+let arr: Uint8Array[] = [];
+while (true) {
+    arr.push(new Uint8Array(100000));
+}
+
+Deno.serve(async (_req) => {
+    console.log(arr.length);
+    return new Response("meow");
+});

--- a/crates/base/test_cases/array-alloc/index.ts
+++ b/crates/base/test_cases/array-alloc/index.ts
@@ -1,0 +1,10 @@
+Deno.serve(async (_req) => {
+    let arr: Uint8Array[] = [];
+
+    while (true) {
+        arr.push(new Uint8Array(100000));
+    }
+
+    console.log(arr.length);
+    return new Response("meow");
+});

--- a/crates/base/test_cases/boot_err_user_worker/index.ts
+++ b/crates/base/test_cases/boot_err_user_worker/index.ts
@@ -1,3 +1,1 @@
-import { serve } from "https://deno.land/std@0.131.0/http/server.ts";
-
 throw new Error("fail");

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -216,7 +216,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         maybe_jsx_import_source_config: None,
     };
 
-    let (_, worker_req_tx) = create_worker((opts, main_termination_token.clone()), None, None)
+    let ctx = create_worker((opts, main_termination_token.clone()), None, None)
         .await
         .unwrap();
 
@@ -235,7 +235,7 @@ async fn test_not_trigger_pku_sigsegv_due_to_jit_compilation_non_cli() {
         conn_token: Some(conn_token.clone()),
     };
 
-    let _ = worker_req_tx.send(msg);
+    let _ = ctx.msg_tx.send(msg);
 
     let res = res_rx.await.unwrap().unwrap();
     assert!(res.status().as_u16() == 200);
@@ -476,7 +476,7 @@ async fn test_main_worker_with_jsx_function() {
 //            worker_pool_tx: user_worker_msgs_tx,
 //        }),
 //    };
-//    let worker_req_tx = create_worker(opts).await.unwrap();
+//    let ctx = create_worker(opts).await.unwrap();
 //    let (res_tx, res_rx) = oneshot::channel::<Result<Response<Body>, hyper::Error>>();
 //
 //    let req = Request::builder()
@@ -486,7 +486,7 @@ async fn test_main_worker_with_jsx_function() {
 //        .unwrap();
 //
 //    let msg = WorkerRequestMsg { req, res_tx };
-//    let _ = worker_req_tx.send(msg);
+//    let _ = ctx.msg_tx.send(msg);
 //
 //    let res = res_rx.await.unwrap().unwrap();
 //    assert!(res.status().as_u16() == 500);

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -33,7 +33,7 @@ pub struct ShutdownEvent {
     pub memory_used: WorkerMemoryUsed,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UncaughtExceptionEvent {
     pub exception: String,
     pub cpu_time_used: usize,

--- a/crates/sb_workers/context.rs
+++ b/crates/sb_workers/context.rs
@@ -1,8 +1,8 @@
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use deno_config::JsxImportSourceConfig;
 use deno_core::FastString;
 use enum_as_inner::EnumAsInner;
-use event_worker::events::WorkerEventWithMetadata;
+use event_worker::events::{UncaughtExceptionEvent, WorkerEventWithMetadata};
 use hyper::{Body, Request, Response};
 use sb_core::util::sync::AtomicFlag;
 use sb_core::{MetricSource, SharedMetricSource};
@@ -10,11 +10,41 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::unbounded_channel;
-use tokio::sync::{mpsc, oneshot, Notify, OwnedSemaphorePermit};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify, OwnedSemaphorePermit};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use sb_graph::{DecoratorType, EszipPayloadKind};
+
+#[derive(Debug, Clone)]
+pub enum WorkerExitStatus {
+    Normal,
+    WithUncaughtException(UncaughtExceptionEvent),
+}
+
+impl Default for WorkerExitStatus {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkerExit(Arc<Mutex<WorkerExitStatus>>);
+
+impl WorkerExit {
+    pub async fn error(&self) -> Option<anyhow::Error> {
+        match &*self.0.lock().await {
+            WorkerExitStatus::Normal => None,
+            WorkerExitStatus::WithUncaughtException(UncaughtExceptionEvent {
+                exception, ..
+            }) => Some(anyhow!("{exception}")),
+        }
+    }
+
+    pub async fn set(&self, exit_status: WorkerExitStatus) {
+        *self.0.lock().await = exit_status;
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct UserWorkerRuntimeOpts {
@@ -72,6 +102,7 @@ pub struct UserWorkerProfile {
     pub permit: Option<Arc<OwnedSemaphorePermit>>,
     pub cancel: CancellationToken,
     pub status: TimingStatus,
+    pub exit: WorkerExit,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -499,10 +499,7 @@ pub async fn op_user_worker_fetch_send(
                 }
 
                 None => {
-                    return Err(custom_error(
-                        "InvalidWorkerResponse",
-                        "user worker failed to respond",
-                    ));
+                    return Err(custom_error("InvalidWorkerResponse", err.to_string()));
                 }
             }
         }

--- a/examples/event-manager/index.ts
+++ b/examples/event-manager/index.ts
@@ -12,9 +12,6 @@ for await (const data of eventManager) {
 					console.log(data.event.msg);
 				}
 				break;
-			case 'UncaughtException':
-				console.error(data.event.exception);
-				break;
 			default:
 				console.log(data);
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR makes to record `InvalidWorkerResponse` with an event loop error message in the response instead of emitting `RequestCancelledBySupervisor` if an uncaught error is encountered by the user script.

> Note: Error message recorded in the response may be something other than an event loop error message due to race conditions caused by a worker exiting quickly. (but error kind is still fixed to `InvalidWorkerResponse`)

Example
```typescript
// Throw an exception from the top level (will cause an event loop error and a worker will be terminated immediately)
throw new Error("meow");

// Deno.serve((_req) => new Response("meow"));
```

Response (Before this PR)
```jsonc
// 500 Internal Server Error
{
    "msg": "WorkerRequestCancelled: request has been cancelled by supervisor"
}
```

Response (This PR)
```jsonc
// 500 Internal Server Error
{
    "msg": "InvalidWorkerResponse: event loop error: Error: meow!\n    at file:///<location>"
}
```