### PR TITLE
fix: include detailed memory metric in event record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "deno_core",
  "log",
  "serde",
+ "strum",
  "tokio",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ glob = "0.3.1"
 httparse = "1.8"
 http = "0.2"
 faster-hex = "0.9.0"
+strum = "0.25"
 
 # DEBUG
 #[patch.crates-io]

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -32,6 +32,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
@@ -123,6 +124,7 @@ struct MemCheckState {
     limit: Option<usize>,
     waker: Arc<AtomicWaker>,
     notify: Arc<Notify>,
+    current_bytes: Arc<AtomicUsize>,
 
     #[cfg(debug_assertions)]
     exceeded: Arc<AtomicFlag>,
@@ -155,6 +157,8 @@ impl MemCheckState {
         let total_bytes = malloced_bytes
             .saturating_add(used_heap_bytes)
             .saturating_add(external_bytes);
+
+        self.current_bytes.store(total_bytes, Ordering::Release);
 
         if total_bytes >= limit {
             self.notify.notify_waiters();
@@ -816,19 +820,24 @@ impl DenoRuntime {
         self.maybe_inspector.clone()
     }
 
+    pub fn mem_check_captured_bytes(&self) -> Arc<AtomicUsize> {
+        self.mem_check_state.current_bytes.clone()
+    }
+
     pub fn add_memory_limit_callback<C>(&self, mut cb: C)
     where
         // XXX(Nyannyacha): Should we relax bounds a bit more?
-        C: FnMut() -> bool + Send + 'static,
+        C: FnMut(usize) -> bool + Send + 'static,
     {
         let notify = self.mem_check_state.notify.clone();
         let drop_token = self.mem_check_state.drop_token.clone();
+        let current_bytes = self.mem_check_state.current_bytes.clone();
 
         drop(rt::SUPERVISOR_RT.spawn(async move {
             loop {
                 tokio::select! {
                     _ = notify.notified() => {
-                        if cb() {
+                        if cb(current_bytes.load(Ordering::Acquire)) {
                             break;
                         }
                     }
@@ -1586,7 +1595,7 @@ mod test {
         let waker = user_rt.js_runtime.op_state().borrow().waker.clone();
         let handle = user_rt.js_runtime.v8_isolate().thread_safe_handle();
 
-        user_rt.add_memory_limit_callback(move || {
+        user_rt.add_memory_limit_callback(move |_| {
             handle.terminate_execution();
             waker.wake();
             callback_tx.send(()).unwrap();

--- a/crates/base/src/rt_worker/supervisor/mod.rs
+++ b/crates/base/src/rt_worker/supervisor/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use cpu_timer::{CPUAlarmVal, CPUTimer};
 use deno_core::v8::IsolateHandle;
 use enum_as_inner::EnumAsInner;
+use event_worker::events::MemoryLimitDetail;
 use futures_util::task::AtomicWaker;
 use log::error;
 use sb_workers::context::{Timing, UserWorkerMsgs, UserWorkerRuntimeOpts};
@@ -126,7 +127,7 @@ pub struct Arguments {
     pub cpu_timer_param: CPUTimerParam,
     pub supervisor_policy: SupervisorPolicy,
     pub timing: Option<Timing>,
-    pub memory_limit_rx: mpsc::UnboundedReceiver<()>,
+    pub memory_limit_rx: mpsc::UnboundedReceiver<MemoryLimitDetail>,
     pub pool_msg_tx: Option<mpsc::UnboundedSender<UserWorkerMsgs>>,
     pub isolate_memory_usage_tx: oneshot::Sender<IsolateMemoryStats>,
     pub thread_safe_handle: IsolateHandle,

--- a/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
+++ b/crates/base/src/rt_worker/supervisor/strategy_per_request.rs
@@ -116,7 +116,7 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
 
                         if !cpu_timer_param.is_disabled() {
                             if cpu_usage_ms >= hard_limit_ms as i64 {
-                                error!("CPU time limit reached. isolate: {:?}", key);
+                                error!("CPU time limit reached: isolate: {:?}", key);
                                 complete_reason = Some(ShutdownReason::CPUTime);
                             }
 
@@ -130,7 +130,7 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
 
             Some(_) = wait_cpu_alarm(cpu_alarms_rx.as_mut()) => {
                 if is_worker_entered && req_start_ack {
-                    error!("CPU time limit reached. isolate: {:?}", key);
+                    error!("CPU time limit reached: isolate: {:?}", key);
                     complete_reason = Some(ShutdownReason::CPUTime);
                 }
             }
@@ -171,14 +171,14 @@ pub async fn supervise(args: Arguments, oneshot: bool) -> (ShutdownReason, i64) 
 
                     continue;
                 } else {
-                    error!("wall clock duraiton reached. isolate: {:?}", key);
+                    error!("wall clock duraiton reached: isolate: {:?}", key);
                     complete_reason = Some(ShutdownReason::WallClockTime);
                 }
             }
 
-            Some(_) = memory_limit_rx.recv() => {
-                error!("memory limit reached for the worker. isolate: {:?}", key);
-                complete_reason = Some(ShutdownReason::Memory);
+            Some(detail) = memory_limit_rx.recv() => {
+                error!("memory limit reached for the worker: isolate: {:?}", key);
+                complete_reason = Some(ShutdownReason::Memory(detail));
             }
         }
 

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -224,6 +224,7 @@ impl Worker {
                                                 total: 0,
                                                 heap: 0,
                                                 external: 0,
+                                                mem_check_captured: 0,
                                             },
                                         },
                                     ));

--- a/crates/event_worker/Cargo.toml
+++ b/crates/event_worker/Cargo.toml
@@ -17,3 +17,4 @@ serde.workspace = true
 anyhow.workspace = true
 tokio.workspace = true
 log.workspace = true
+strum = { workspace = true, features = ["derive"] }

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use strum::IntoStaticStr;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -15,13 +16,60 @@ pub struct WorkerMemoryUsed {
     pub total: usize,
     pub heap: usize,
     pub external: usize,
+    pub mem_check_captured: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct MemoryLimitDetailMemCheck {
+    pub captured: usize,
+}
+
+impl std::fmt::Display for MemoryLimitDetailMemCheck {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryLimitDetailMemCheck")
+            .field("captured", &self.captured)
+            .finish()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct MemoryLimitDetailV8 {
+    pub current: usize,
+    pub initial: usize,
+}
+
+impl std::fmt::Display for MemoryLimitDetailV8 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryLimitDetailV8")
+            .field("current", &self.current)
+            .field("initial", &self.initial)
+            .finish()
+    }
+}
+
+#[derive(Serialize, Deserialize, IntoStaticStr, Debug, Clone, Copy)]
+#[serde(tag = "limited_by")]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum MemoryLimitDetail {
+    MemCheck(MemoryLimitDetailMemCheck),
+    V8(MemoryLimitDetailV8),
+}
+
+impl std::fmt::Display for MemoryLimitDetail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MemCheck(arg) => std::fmt::Display::fmt(arg, f),
+            Self::V8(arg) => std::fmt::Display::fmt(arg, f),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ShutdownReason {
     WallClockTime,
     CPUTime,
-    Memory,
+    Memory(MemoryLimitDetail),
     EarlyDrop,
     TerminationRequested,
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

Clarify which memory limit kind caused termination to be requested and expose the memory metrics used to decide to terminate into the event record.

Sample (MemCheck / MemCheckState::check)
```
2024-06-04T03:20:14.726849Z DEBUG sb-supervisor base::rt_worker::worker_ctx: memory limit triggered: isolate: 6745b2ae-075e-4a5d-8414-912411de8aaf, detail: MemoryLimitDetailMemCheck { captured: 158894854 }    
2024-06-04T03:20:14.728807Z ERROR sb-supervisor base::rt_worker::supervisor::strategy_per_worker: memory limit reached for the worker: isolate: 6745b2ae-075e-4a5d-8414-912411de8aaf    
2024-06-04T03:20:14.731119Z ERROR          main base::rt_worker::worker_pool: failed to send request to user worker: request has been cancelled by supervisor    
2024-06-04T03:20:14.829827Z TRACE ThreadId(18) base::deno_runtime: name: Some("sb-iso-6745b2ae-075e-4a5d-8414-912411de8aaf"), thread_id: ThreadId(18), accumulated_cpu_time: 4413ms, malloced: 136.59MiB    
WorkerRequestCancelled: request has been cancelled by supervisor
    at async Promise.allSettled (index 1)
    at async UserWorker.fetch (ext:sb_user_workers/user_workers.js:77:21)
    at async callWorker (file:///home/deno/examples/main/index.ts:108:14)
    at async respond (ext:sb_core_main_js/js/http.js:162:14) {
  name: "WorkerRequestCancelled"
}
2024-06-04T03:20:14.846946Z DEBUG ThreadId(18) base::rt_worker::worker: CPU time used: 4413ms    
{
  timestamp: "2024-06-04T03:20:14.852Z",
  event_type: "Shutdown",
  event: [Object: null prototype] {
    reason: [Object: null prototype] {
      Memory: [Object: null prototype] {
        limited_by: "mem_check",
        captured: 158894854
      }
    },
    cpu_time_used: 4413,
    memory_used: [Object: null prototype] {
      total: 142947754,
      heap: 142933184,
      external: 14570,
      mem_check_captured: 143230146
    }
  },
  metadata: [Object: null prototype] {
    service_path: "./examples/serve",
    execution_id: "6745b2ae-075e-4a5d-8414-912411de8aaf"
  }
}
```

Sample (V8 / near_heap_callback)
```
2024-06-04T03:17:18.796863Z DEBUG ThreadId(17) base::rt_worker::worker_ctx: memory limit triggered: isolate: c8a88599-3535-4185-85f4-4efe7d7e1842, detail: MemoryLimitDetailV8 { current: 154140672, initial: 154140672 }    
2024-06-04T03:17:18.797096Z ERROR sb-supervisor base::rt_worker::supervisor::strategy_per_worker: memory limit reached for the worker: isolate: c8a88599-3535-4185-85f4-4efe7d7e1842    
2024-06-04T03:17:18.798519Z ERROR          main base::rt_worker::worker_pool: failed to send request to user worker: request has been cancelled by supervisor    
2024-06-04T03:17:18.803128Z TRACE ThreadId(17) base::deno_runtime: name: Some("sb-iso-c8a88599-3535-4185-85f4-4efe7d7e1842"), thread_id: ThreadId(17), accumulated_cpu_time: 4985ms, malloced: 8.93MiB    
2024-06-04T03:17:18.814446Z DEBUG ThreadId(17) base::rt_worker::worker: CPU time used: 4985ms    
WorkerRequestCancelled: request has been cancelled by supervisor
    at async Promise.allSettled (index 1)
    at async UserWorker.fetch (ext:sb_user_workers/user_workers.js:77:21)
    at async callWorker (file:///home/deno/examples/main/index.ts:108:14)
    at async respond (ext:sb_core_main_js/js/http.js:162:14) {
  name: "WorkerRequestCancelled"
}
{
  timestamp: "2024-06-04T03:17:18.819Z",
  event_type: "Shutdown",
  event: [Object: null prototype] {
    reason: [Object: null prototype] {
      Memory: [Object: null prototype] {
        limited_by: "v8",
        current: 154140672,
        initial: 154140672
      }
    },
    cpu_time_used: 4985,
    memory_used: [Object: null prototype] {
      total: 153479114,
      heap: 153464544,
      external: 14570,
      mem_check_captured: 153763754
    }
  },
  metadata: [Object: null prototype] {
    service_path: "./examples/serve",
    execution_id: "c8a88599-3535-4185-85f4-4efe7d7e1842"
  }
}
```