### PR TITLE
fix: downgrade rust builder image to `rust:1.77.2-bookworm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM rust:1.78-bookworm as builder
+FROM rust:1.77.2-bookworm as builder
 ARG TARGETPLATFORM
 ARG GIT_V_VERSION
 ARG ONNXRUNTIME_VERSION=1.17.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Downgrade the rust builder image due to an upstream issue.

Note: denoland/deno#23778