### PR TITLE
fix: include more detailed memory metric in mem check record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "async-tungstenite",
+ "base_mem_check",
  "bytes",
  "cityhash",
  "cooked-waker",
@@ -481,6 +482,14 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "base_mem_check"
+version = "0.1.0"
+dependencies = [
+ "deno_core",
+ "serde",
+]
 
 [[package]]
 name = "better_scoped_tls"
@@ -2032,6 +2041,7 @@ name = "event_worker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base_mem_check",
  "deno_core",
  "log",
  "serde",
@@ -4825,6 +4835,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
+ "base_mem_check",
  "bytes",
  "cache_control",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "./crates/base",
+  "./crates/base_mem_check",
   "./crates/cli",
   "./crates/sb_workers",
   "./crates/sb_env",

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base_mem_check = { version = "0.1.0", path = "../base_mem_check" }
 http_utils = { version = "0.1.0", path = "../http_utils" }
 async-trait.workspace = true
 thiserror.workspace = true

--- a/crates/base/src/rt_worker/worker.rs
+++ b/crates/base/src/rt_worker/worker.rs
@@ -5,6 +5,7 @@ use crate::rt_worker::utils::{get_event_metadata, parse_worker_conf};
 use crate::rt_worker::worker_ctx::create_supervisor;
 use crate::utils::send_event_if_event_worker_available;
 use anyhow::{anyhow, Error};
+use base_mem_check::MemCheckState;
 use event_worker::events::{
     EventLoopCompletedEvent, EventMetadata, ShutdownEvent, ShutdownReason, UncaughtExceptionEvent,
     WorkerEventWithMetadata, WorkerEvents, WorkerMemoryUsed,
@@ -224,7 +225,7 @@ impl Worker {
                                                 total: 0,
                                                 heap: 0,
                                                 external: 0,
-                                                mem_check_captured: 0,
+                                                mem_check_captured: MemCheckState::default(),
                                             },
                                         },
                                     ));

--- a/crates/base_mem_check/Cargo.toml
+++ b/crates/base_mem_check/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "base_mem_check"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+deno_core.workspace = true
+serde.workspace = true

--- a/crates/base_mem_check/src/lib.rs
+++ b/crates/base_mem_check/src/lib.rs
@@ -1,0 +1,40 @@
+use deno_core::v8;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerHeapStatistics {
+    pub total_heap_size: usize,
+    pub total_heap_size_executable: usize,
+    pub total_physical_size: usize,
+    pub total_available_size: usize,
+    pub total_global_handles_size: usize,
+    pub used_global_handles_size: usize,
+    pub used_heap_size: usize,
+    pub malloced_memory: usize,
+    pub external_memory: usize,
+    pub peak_malloced_memory: usize,
+}
+
+impl From<&'_ v8::HeapStatistics> for WorkerHeapStatistics {
+    fn from(value: &v8::HeapStatistics) -> Self {
+        Self {
+            total_heap_size: value.total_heap_size(),
+            total_heap_size_executable: value.total_heap_size_executable(),
+            total_physical_size: value.total_physical_size(),
+            total_available_size: value.total_available_size(),
+            total_global_handles_size: value.total_global_handles_size(),
+            used_global_handles_size: value.used_global_handles_size(),
+            used_heap_size: value.used_heap_size(),
+            malloced_memory: value.used_heap_size(),
+            external_memory: value.external_memory(),
+            peak_malloced_memory: value.peak_malloced_memory(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+pub struct MemCheckState {
+    pub current: WorkerHeapStatistics,
+    pub exceeded: bool,
+}

--- a/crates/event_worker/Cargo.toml
+++ b/crates/event_worker/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 path = "lib.rs"
 
 [dependencies]
+base_mem_check = { version = "0.1.0", path = "../base_mem_check" }
 deno_core.workspace = true
 uuid.workspace = true
 serde.workspace = true

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -20,50 +20,13 @@ pub struct WorkerMemoryUsed {
     pub mem_check_captured: MemCheckState,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-pub struct MemoryLimitDetailMemCheck {
-    pub captured: MemCheckState,
-}
-
-impl std::fmt::Display for MemoryLimitDetailMemCheck {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryLimitDetailMemCheck")
-            .field("captured", &self.captured)
-            .finish()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-pub struct MemoryLimitDetailV8 {
-    pub current: usize,
-    pub initial: usize,
-}
-
-impl std::fmt::Display for MemoryLimitDetailV8 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryLimitDetailV8")
-            .field("current", &self.current)
-            .field("initial", &self.initial)
-            .finish()
-    }
-}
-
 #[derive(Serialize, Deserialize, IntoStaticStr, Debug, Clone, Copy)]
 #[serde(tag = "limited_by")]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum MemoryLimitDetail {
-    MemCheck(MemoryLimitDetailMemCheck),
-    V8(MemoryLimitDetailV8),
-}
-
-impl std::fmt::Display for MemoryLimitDetail {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MemCheck(arg) => std::fmt::Display::fmt(arg, f),
-            Self::V8(arg) => std::fmt::Display::fmt(arg, f),
-        }
-    }
+    MemCheck,
+    V8,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/event_worker/events.rs
+++ b/crates/event_worker/events.rs
@@ -1,3 +1,4 @@
+use base_mem_check::MemCheckState;
 use serde::{Deserialize, Serialize};
 use strum::IntoStaticStr;
 use uuid::Uuid;
@@ -16,12 +17,12 @@ pub struct WorkerMemoryUsed {
     pub total: usize,
     pub heap: usize,
     pub external: usize,
-    pub mem_check_captured: usize,
+    pub mem_check_captured: MemCheckState,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct MemoryLimitDetailMemCheck {
-    pub captured: usize,
+    pub captured: MemCheckState,
 }
 
 impl std::fmt::Display for MemoryLimitDetailMemCheck {
@@ -145,7 +146,7 @@ pub struct WorkerEventWithMetadata {
 
 #[derive(Serialize, Deserialize)]
 pub enum RawEvent {
-    Event(WorkerEventWithMetadata),
+    Event(Box<WorkerEventWithMetadata>),
     Done,
 }
 

--- a/crates/event_worker/lib.rs
+++ b/crates/event_worker/lib.rs
@@ -27,7 +27,7 @@ async fn op_event_accept(state: Rc<RefCell<OpState>>) -> Result<RawEvent, Error>
     op_state.put::<mpsc::UnboundedReceiver<WorkerEventWithMetadata>>(rx);
 
     match data {
-        Some(event) => Ok(RawEvent::Event(event)),
+        Some(event) => Ok(RawEvent::Event(Box::new(event))),
         None => Ok(RawEvent::Done),
     }
 }

--- a/crates/sb_core/Cargo.toml
+++ b/crates/sb_core/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 bytes.workspace = true
 deno_tls.workspace = true
 thiserror.workspace = true
+base_mem_check = { version = "0.1.0", path = "../base_mem_check" }
 sb_node = { version = "0.1.0", path = "../node" }
 deno_crypto.workspace = true
 fs3.workspace = true

--- a/examples/event-manager/index.ts
+++ b/examples/event-manager/index.ts
@@ -9,11 +9,11 @@ for await (const data of eventManager) {
 				if (data.event.level === 'Error') {
 					console.error(data.event.msg);
 				} else {
-					console.log(data.event.msg);
+					console.dir(data.event.msg, { depth: Infinity });
 				}
 				break;
 			default:
-				console.log(data);
+				console.dir(data, { depth: Infinity });
 		}
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR changes the original v8 memory statistics that were the basis of the memory limitation to be exposed, rather than the arbitrarily calculated memory usage by `MemCheck` (Previously `MemCheckState`).

```
{
  timestamp: "2024-06-14T00:35:08.578Z",
  event_type: "Shutdown",
  event: [Object: null prototype] {
    reason: [Object: null prototype] {
      Memory: [Object: null prototype] { limited_by: "mem_check" }
    },
    cpu_time_used: 74,
    memory_used: [Object: null prototype] {
      total: 67685841,
      heap: 6460736,
      external: 61225105,
      mem_check_captured: [Object: null prototype] {
        current: [Object: null prototype] {
          totalHeapSize: 8626176,
          totalHeapSizeExecutable: 262144,
          totalPhysicalSize: 7131136,
          totalAvailableSize: 61063776,
          totalGlobalHandlesSize: 24576,
          usedGlobalHandlesSize: 18976,
          usedHeapSize: 6460736,
          mallocedMemory: 6460736,
          externalMemory: 61225105,
          peakMallocedMemory: 139480
        },
        exceeded: true
      }
    }
  },
  metadata: [Object: null prototype] {
    service_path: "./examples/serve",
    execution_id: "b033df22-46d2-41cf-990d-ba9389141780"
  }
}
```