### PR TITLE
fix: don’t update mem stat if exceeded the memory limit

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -158,15 +158,15 @@ impl MemCheck {
         let heap_stats = WorkerHeapStatistics::from(&stats);
         let mut state = self.state.write().unwrap();
 
-        state.current = heap_stats;
+        if !state.exceeded {
+            state.current = heap_stats;
 
-        if total_bytes >= limit {
-            if !state.exceeded {
+            if total_bytes >= limit {
                 state.exceeded = true;
-            }
 
-            drop(state);
-            self.notify.notify_waiters();
+                drop(state);
+                self.notify.notify_waiters();
+            }
         }
 
         total_bytes


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

To get accurate memory stats, this PR makes changes `MemCheck` stops updating memory stats when the memory limit is reached.
