### PR TITLE
fix(node): refer the internal rid correctly

### DIFF
--- a/crates/node/polyfills/http.ts
+++ b/crates/node/polyfills/http.ts
@@ -66,6 +66,8 @@ import { clearTimeout as webClearTimeout } from "ext:deno_web/02_timers.js";
 import { resourceForReadableStream } from "ext:deno_web/06_streams.js";
 import { TcpConn } from "ext:deno_net/01_net.js";
 
+const { internalRidSymbol } = core;
+
 enum STATUS_CODES {
   /** RFC 7231, 6.2.1 */
   Continue = 100,
@@ -617,7 +619,7 @@ class ClientRequest extends OutgoingMessage {
         this.method,
         url,
         headers,
-        client.rid,
+        client[internalRidSymbol],
         this._bodyWriteRid,
     );
   }
@@ -803,7 +805,7 @@ class ClientRequest extends OutgoingMessage {
     }
     this.destroyed = true;
 
-    const rid = this._client?.rid;
+    const rid = this._client?.[internalRidSymbol];
     if (rid) {
       core.tryClose(rid);
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

h2 protocol was unintentionally enabled in the context of npm modules due to the rid of the HttpClient not being passed properly. This PR fixes that.

Fixes #369 