### PR TITLE
fix(sb_workers): don't propagate promise rejection on request body streaming failure

### DIFF
--- a/crates/sb_workers/user_workers.js
+++ b/crates/sb_workers/user_workers.js
@@ -83,7 +83,7 @@ class UserWorker {
 			throw responsePromiseResult.reason;
 		}
 
-		const result = responsePromiseResult;
+		const result = responsePromiseResult.value;
 		const response = {
 			headers: result.headers,
 			status: result.status,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

For a promise to a WritableStream that streams the body of an inbound request to a user worker, the promise might be rejected in some cases.

Previously, if this promise was rejected, an exception to this rejection would be propagated to the caller.

```typescript
let [sent, res] = await Promise.allSettled([reqBodyPromise, resPromise]);
```

> The promise `res`, which gets the response from the user worker, and the promise `sent`, which streams the request body to the user worker, are bound by `Promise.allSettled`, so it will not return until all of the passed Promises have performed their actions.

However, propagating exceptions for these `sent` is turns out to be undesirable. 

This is because the user worker may consume the request object abnormally, or `op_user_worker_fetch_send` may drop the channel object in the body under the request object, causing the promise to be rejected.

Therefore, we should always expose only the result for `res` to the caller.

Fixes #366 