### PR TITLE
chore: introduce `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4955,6 +4955,7 @@ dependencies = [
  "sb_npm",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ glob = "0.3.1"
 httparse = "1.8"
 http = "0.2"
 faster-hex = "0.9.0"
+tracing = "0.1"
 
 # DEBUG
 # [patch.crates-io]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,21 +39,27 @@ fn main() -> Result<(), anyhow::Error> {
     let local = tokio::task::LocalSet::new();
     let res: Result<(), Error> = local.block_on(&runtime, async {
         let matches = get_cli().get_matches();
+        let verbose = matches.get_flag("verbose");
 
         if !matches.get_flag("quiet") {
             #[cfg(feature = "tracing")]
             {
+                use tracing_subscriber::fmt::format::FmtSpan;
                 use tracing_subscriber::EnvFilter;
 
                 tracing_subscriber::fmt()
                     .with_env_filter(EnvFilter::from_default_env())
                     .with_thread_names(true)
+                    .with_span_events(if verbose {
+                        FmtSpan::FULL
+                    } else {
+                        FmtSpan::NONE
+                    })
                     .init()
             }
 
             #[cfg(not(feature = "tracing"))]
             {
-                let verbose = matches.get_flag("verbose");
                 let include_source = matches.get_flag("log-source");
                 logger::init(verbose, include_source);
             }

--- a/crates/sb_module_loader/Cargo.toml
+++ b/crates/sb_module_loader/Cargo.toml
@@ -25,6 +25,7 @@ once_cell.workspace = true
 deno_tls.workspace = true
 monch.workspace = true
 base64.workspace = true
+tracing.workspace = true
 sb_core = { version = "0.1.0", path = "../sb_core" }
 sb_node = { version = "0.1.0", path = "../node" }
 sb_npm = { version = "0.1.0", path = "../npm" }

--- a/crates/sb_module_loader/standalone/standalone_module_loader.rs
+++ b/crates/sb_module_loader/standalone/standalone_module_loader.rs
@@ -14,6 +14,7 @@ use deno_core::{ModuleSpecifier, RequestedModuleType};
 use deno_semver::npm::NpmPackageReqReference;
 use eszip::deno_graph;
 use std::sync::Arc;
+use tracing::instrument;
 
 use crate::node::cli_node_resolver::CliNodeResolver;
 use crate::util::arc_u8_to_arc_str;
@@ -33,6 +34,7 @@ pub struct EmbeddedModuleLoader {
 }
 
 impl ModuleLoader for EmbeddedModuleLoader {
+    #[instrument(level = "debug", skip(self))]
     fn resolve(
         &self,
         specifier: &str,
@@ -96,6 +98,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
         Ok(specifier)
     }
 
+    #[instrument(level = "debug", skip_all, fields(specifier = original_specifier.as_str()))]
     fn load(
         &self,
         original_specifier: &ModuleSpecifier,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

Introduces `tracing` crate to improve the edge runtime debugging experience.

In this PR, I'm not trying to apply tracing to all of the codebase, just the `sb_module_loader` crate. (There's nothing special about this 😅)

### Changes
* **cli**: Changed the behavior of the `-v` `--verbose` cli flag in `cli/tracing` feature flag
  When this feature flag is enabled and `-v` or `--verbose` flag is set, detailed tracing span events are output to the console.

  With `-v` or `--verbose` flag
  ```bash
  ...
  2024-06-24T03:07:11.447652Z DEBUG ThreadId(04) load{specifier="https://deno.land/std/http/status.ts"}: sb_module_loader::standalone::standalone_module_loader: new
  2024-06-24T03:07:11.447670Z DEBUG ThreadId(04) load{specifier="https://deno.land/std/http/status.ts"}: sb_module_loader::standalone::standalone_module_loader: enter
  2024-06-24T03:07:11.447727Z DEBUG ThreadId(04) load{specifier="https://deno.land/std/http/status.ts"}: sb_module_loader::standalone::standalone_module_loader: exit
  2024-06-24T03:07:11.447744Z DEBUG ThreadId(04) load{specifier="https://deno.land/std/http/status.ts"}: sb_module_loader::standalone::standalone_module_loader: close time.busy=57.0µs time.idle=35.7µs
  ...
  ```