### PR TITLE
fix: revisit `MemCheck` related logics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-util",
+ "tracing-subscriber",
  "tungstenite",
  "url",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ httparse = "1.8"
 http = "0.2"
 faster-hex = "0.9.0"
 tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [patch.crates-io]
 # TODO(Nyannyacha): Patch below is temporary. Clean the line in the Deno 1.44 update.
@@ -87,6 +88,10 @@ deno_core = { git = "https://github.com/supabase/deno_core", branch = "278-supab
 
 [profile.dind]
 inherits = "dev"
+
+[profile.no-debug-assertions]
+inherits = "dev"
+debug-assertions = false
 
 [profile.release]
 lto = true

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -80,6 +80,7 @@ reqwest = { workspace = true, features = ["multipart"] }
 serial_test = { version = "3.0.0" }
 async-tungstenite = { version = "0.25.0", default-features = false }
 tungstenite = { version = "0.21.0", default-features = false, features = ["handshake"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "tracing-log"] }
 
 [build-dependencies]
 sb_core = { version = "0.1.0", path = "../sb_core" }

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -13,3 +13,6 @@ mod timeout;
 
 pub use inspector_server::InspectorOption;
 pub use sb_graph::DecoratorType;
+
+#[cfg(test)]
+mod tracing;

--- a/crates/base/src/rt_worker/worker_ctx.rs
+++ b/crates/base/src/rt_worker/worker_ctx.rs
@@ -307,7 +307,6 @@ pub fn create_supervisor(
         let send_fn = send_memory_limit_fn.clone();
         move |_| {
             send_fn("mem_check");
-            true
         }
     });
 

--- a/crates/base/src/tracing.rs
+++ b/crates/base/src/tracing.rs
@@ -1,0 +1,14 @@
+use ctor::ctor;
+use tracing_subscriber::{filter::LevelFilter, EnvFilter};
+
+#[ctor]
+fn init_tracing_subscriber() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::OFF.into())
+                .from_env_lossy(),
+        )
+        .with_thread_names(true)
+        .init()
+}

--- a/crates/base_mem_check/src/lib.rs
+++ b/crates/base_mem_check/src/lib.rs
@@ -26,7 +26,7 @@ impl From<&'_ v8::HeapStatistics> for WorkerHeapStatistics {
             total_global_handles_size: value.total_global_handles_size(),
             used_global_handles_size: value.used_global_handles_size(),
             used_heap_size: value.used_heap_size(),
-            malloced_memory: value.used_heap_size(),
+            malloced_memory: value.malloced_memory(),
             external_memory: value.external_memory(),
             peak_malloced_memory: value.peak_malloced_memory(),
         }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ sb_graph = { path = "../sb_graph" }
 tokio.workspace = true
 glob.workspace = true
 once_cell.workspace = true
-tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "tracing-log"] }
+tracing-subscriber = { workspace = true, optional = true, features = ["env-filter", "tracing-log"] }
 
 [build-dependencies]
 dotenv-build = { version = "0.1.1" }

--- a/crates/cli/src/env.rs
+++ b/crates/cli/src/env.rs
@@ -28,4 +28,9 @@ pub(super) fn resolve_deno_runtime_env() {
         "DENO_VERBOSE_WARNINGS",
         &deno_runtime::SHOULD_USE_VERBOSE_DEPRECATED_API_WARNING,
     );
+
+    resolve_boolish_env(
+        "EDGE_RUNTIME_INCLUDE_MALLOCED_MEMORY_ON_MEMCHECK",
+        &deno_runtime::SHOULD_INCLUDE_MALLOCED_MEMORY_ON_MEMCHECK,
+    );
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, Enhancement

## Description

* Makes `malloced_memory` calculation optional (`EDGE_RUNTIME_INCLUDE_MALLOCED_MEMORY_ON_MEMCHECK` env var can be used to restore the old behavior).
* Simplifies memory limit callback trigger logic.
* Fixes a mistake made in a previous `MemCheck` related PR.
* Enables `tracing_subscriber` in the test build (ie. `#[cfg(test)]`)