### PR TITLE
feat: support declarative style fetch handler

### DIFF
--- a/crates/base/test_cases/serve-declarative-style/index.ts
+++ b/crates/base/test_cases/serve-declarative-style/index.ts
@@ -1,0 +1,5 @@
+export default {
+    async fetch(_req: Request) {
+        return new Response("meow");
+    }
+}

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -2250,6 +2250,24 @@ async fn test_fastify_latest_package() {
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn test_declarative_style_fetch_handler() {
+    integration_test!(
+        "./test_cases/main",
+        NON_SECURE_PORT,
+        "serve-declarative-style",
+        None,
+        None,
+        None,
+        None,
+        (|resp| async {
+            assert_eq!(resp.unwrap().text().await.unwrap(), "meow");
+        }),
+        TerminationToken::new()
+    );
+}
+
 trait AsyncReadWrite: AsyncRead + AsyncWrite + Send + Unpin {}
 
 impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite + Send + Unpin {}

--- a/crates/sb_core/js/00_serve.js
+++ b/crates/sb_core/js/00_serve.js
@@ -1,0 +1,22 @@
+import { primordials } from "ext:core/mod.js";
+
+const { ObjectHasOwn } = primordials;
+
+function registerDeclarativeServer(exports) {
+    if (ObjectHasOwn(exports, "fetch")) {
+        if (typeof exports.fetch !== "function") {
+            throw new TypeError(
+                "Invalid type for fetch: must be a function with a single or no parameter",
+            );
+        }
+        Deno.serve({
+            handler: (req) => {
+                return exports.fetch(req);
+            },
+        });
+    }
+}
+
+export {
+    registerDeclarativeServer
+}

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -43,6 +43,7 @@ import {
 
 import { promiseRejectMacrotaskCallback } from 'ext:sb_core_main_js/js/promises.js';
 import { denoOverrides, fsVars } from 'ext:sb_core_main_js/js/denoOverrides.js';
+import { registerDeclarativeServer } from 'ext:sb_core_main_js/js/00_serve.js';
 import * as performance from 'ext:deno_web/15_performance.js';
 import * as messagePort from 'ext:deno_web/13_message_port.js';
 import { SupabaseEventListener } from 'ext:sb_user_event_worker/event_worker.js';
@@ -66,6 +67,7 @@ const {
 	ObjectDefineProperty,
 	ObjectDefineProperties,
 	ObjectSetPrototypeOf,
+	ObjectHasOwn,
 	SafeSet,
 	StringPrototypeIncludes,
 	StringPrototypeSplit,
@@ -547,6 +549,13 @@ globalThis.bootstrapSBEdge = (opts, extraCtx) => {
 				Deno[name] = value;
 			}
 		}
+
+		// find declarative fetch handler
+		core.addMainModuleHandler(main => {
+			if (ObjectHasOwn(main, 'default')) {
+				registerDeclarativeServer(main.default);
+			}
+		});
 	}
 
 	if (isEventsWorker) {

--- a/crates/sb_core/lib.rs
+++ b/crates/sb_core/lib.rs
@@ -374,6 +374,7 @@ deno_core::extension!(
         "js/navigator.js",
         "js/bootstrap.js",
         "js/main_worker.js",
+        "js/00_serve.js",
         "js/01_http.js"
     ]
 );

--- a/examples/serve-declarative-style/index.ts
+++ b/examples/serve-declarative-style/index.ts
@@ -1,0 +1,5 @@
+export default {
+    async fetch(_req: Request) {
+        return new Response("Hello, world");
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Description

This PR allows declarative-style fetch handlers like the one below.

```typescript
export default {
  async fetch(_req) {
    return new Response("Hello world!");
  },
}
```

## Additional Context
https://docs.deno.com/runtime/manual/tools/serve/

