### PR TITLE
fix: inspector causes panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,8 +1301,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.293.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4618658ef613af8978a4bada32231c6c31aeeb9a02b6c58a5df17168a082be"
+source = "git+https://github.com/supabase/deno_core?branch=293-supabase#d73dc1e1845d00cc2e8d2a32caf5859cc300386b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1577,8 +1576,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.169.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f2d01d8999f283f6c94cfcabe206a599a1471969e8974fc19eb523d8a7b91f"
+source = "git+https://github.com/supabase/deno_core?branch=293-supabase#d73dc1e1845d00cc2e8d2a32caf5859cc300386b"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5452,8 +5450,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.202.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d179230030f377d5a788e4adc979262d586d7da286462f98b70da7f8b8a9d0b7"
+source = "git+https://github.com/supabase/deno_core?branch=293-supabase#d73dc1e1845d00cc2e8d2a32caf5859cc300386b"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,8 @@ rkyv = "0.7"
 tempfile = "3"
 
 [patch.crates-io]
+# If the PR is merged upstream, remove the line below.
+deno_core = { git = "https://github.com/supabase/deno_core", branch = "293-supabase" }
 eszip = { git = "https://github.com/supabase/eszip", branch = "fix-pub-vis-0-72-2" }
 
 [profile.dind]

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -396,12 +396,13 @@ where
             });
         }
 
+        let has_inspector = maybe_inspector.is_some();
         let rt_provider = create_module_loader_for_standalone_from_eszip_kind(
             eszip,
             base_dir_path.clone(),
             maybe_import_map,
             import_map_path,
-            maybe_inspector.is_some(),
+            has_inspector,
         )
         .await?;
 
@@ -701,11 +702,11 @@ where
         let current_thread_id = std::thread::current().id();
         let mut accumulated_cpu_time_ns = 0i64;
 
-        let inspector = self.inspector();
+        let has_inspector = self.inspector().is_some();
         let mut mod_result_rx = unsafe {
             self.js_runtime.v8_isolate().enter();
 
-            if inspector.is_some() {
+            if has_inspector {
                 let is_terminated = self.is_terminated.clone();
                 let mut this = scopeguard::guard_on_unwind(&mut *self, |this| {
                     this.js_runtime.v8_isolate().exit();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

It seems that the path to calling `thread::unpark` was enabled when eszip content became possible to load asynchronously.

The current inspector implementation upstream doesn't like it when `park` is called at a certain stage of `poll_session` and then immediately unparked. This results in reaching `unreachable!`, which causes panic.

### Related Links
* https://github.com/supabase/cli/issues/2646
* https://github.com/supabase/deno_core/commit/d73dc1e1845d00cc2e8d2a32caf5859cc300386b

Reported-by: @daniel-sc