### PR TITLE
chore(build): adjust release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,5 +148,5 @@ inherits = "dev"
 debug-assertions = false
 
 [profile.release]
-debug = "line-tables-only"
-lto = true
+debug = true
+lto = "thin"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

This PR adjusts the release profile.

* For lto, I've changed from fat to thin.
  * The main reason for changing this is that FullLTO (Traditional LTO) only works on a single thread and consumes a very large amount of memory. Previously we were seeing a moderate impact on build times with this option enabled because we didn't enable debug symbols in our release profile, but now I am seeing unacceptable build times and memory consumption.
  * No performance change was detected on the local machine due to this change.
* Increase the debug symbol level to maximum.
  * In Dockerfile, the debug symbol is separated into a file by the objcopy, so no significant size increase was found for the edge runtime binary itself.
  * The size of the debug symbol is almost 2x(63M -> 114M) and the size of edge runtime on thinLTO has increased by about 2M (111M -> 114M).