### PR TITLE
chore(devcontainer): remove `cargo-make` feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/jungaretti/features/make:1": {},
-    "ghcr.io/lee-orr/rusty-dev-containers/cargo-make:0": {}
+    "ghcr.io/jungaretti/features/make:1": {}
   },
   "runArgs": [
     "--rm",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

Removes an unused feature from devcontainer.json.
In particular, this feature had a problem with changing the ownership of subdirectories under /usr/local/cargo during enable, so rust-analyzer and cargo would not work properly without typing `chown -R vscode:vscode /usr/local/cargo` command manually.