### PR TITLE
fix(sb_graph): checksum size is not a constant

### DIFF
--- a/crates/sb_graph/lib.rs
+++ b/crates/sb_graph/lib.rs
@@ -483,7 +483,7 @@ impl EszipDataSection {
             if !need_load {
                 read += length + checksum_size;
 
-                io.seek(SeekFrom::Current((length + 32) as i64))
+                io.seek(SeekFrom::Current((length + checksum_size) as i64))
                     .await
                     .unwrap();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Fixes an issue where reading sources from the eszip binary causes an unexpected EOF due to reading the checksum size assuming as a constant (32 bytes).