### PR TITLE
fix(sb_workers): allow extra context to be passed in from js land

### DIFF
--- a/crates/base/src/utils/json.rs
+++ b/crates/base/src/utils/json.rs
@@ -1,0 +1,12 @@
+use deno_core::serde_json::Value;
+
+pub fn merge_object(a: &mut Value, b: &Value) {
+    match (a, b) {
+        (Value::Object(a), Value::Object(b)) => {
+            for (k, v) in b {
+                merge_object(a.entry(k.clone()).or_insert(Value::Null), v);
+            }
+        }
+        (a, b) => *a = b.clone(),
+    }
+}

--- a/crates/base/src/utils/mod.rs
+++ b/crates/base/src/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod json;
 pub mod path;
 pub mod units;

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -545,7 +545,7 @@ globalThis.bootstrapSBEdge = (opts, extraCtx) => {
 			'memoryUsage': () => ops.op_runtime_memory_usage(),
 		};
 
-		if (extraCtx?.useSyncFileAPI) {
+		if (extraCtx?.useReadSyncFileAPI) {
 			apisToBeOverridden['readFileSync'] = true;
 			apisToBeOverridden['readTextFileSync'] = true;
 		}

--- a/crates/sb_workers/context.rs
+++ b/crates/sb_workers/context.rs
@@ -70,6 +70,8 @@ pub struct UserWorkerRuntimeOpts {
     pub allow_net: Option<Vec<String>>,
     pub allow_remote_modules: bool,
     pub custom_module_root: Option<String>,
+
+    pub context: Option<crate::JsonMap>,
 }
 
 impl Default for UserWorkerRuntimeOpts {
@@ -94,6 +96,8 @@ impl Default for UserWorkerRuntimeOpts {
             allow_remote_modules: true,
             custom_module_root: None,
             service_path: None,
+
+            context: None,
         }
     }
 }

--- a/crates/sb_workers/lib.rs
+++ b/crates/sb_workers/lib.rs
@@ -11,7 +11,7 @@ use deno_config::JsxImportSourceConfig;
 use deno_core::error::{custom_error, type_error, AnyError};
 use deno_core::futures::stream::Peekable;
 use deno_core::futures::{FutureExt, Stream, StreamExt};
-use deno_core::{op2, ModuleSpecifier};
+use deno_core::{op2, serde_json, ModuleSpecifier};
 use deno_core::{
     AsyncRefCell, AsyncResult, BufView, ByteString, CancelFuture, CancelHandle, CancelTryFuture,
     JsBuffer, OpState, RcRef, Resource, ResourceId, WriteOutcome,
@@ -58,6 +58,8 @@ pub struct JsxImportBaseConfig {
     base_url: String,
 }
 
+pub type JsonMap = serde_json::Map<String, serde_json::Value>;
+
 #[derive(Deserialize, Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UserWorkerCreateOptions {
@@ -87,6 +89,8 @@ pub struct UserWorkerCreateOptions {
 
     s3_fs_config: Option<S3FsConfig>,
     tmp_fs_config: Option<TmpFsConfig>,
+
+    context: Option<JsonMap>,
 }
 
 #[op2(async)]
@@ -125,6 +129,8 @@ pub async fn op_user_worker_create(
 
             s3_fs_config: maybe_s3_fs_config,
             tmp_fs_config: maybe_tmp_fs_config,
+
+            context,
         } = opts;
 
         let user_worker_options = WorkerContextInitOpts {
@@ -152,6 +158,8 @@ pub async fn op_user_worker_create(
                     allow_net,
                     allow_remote_modules,
                     custom_module_root,
+
+                    context,
 
                     ..Default::default()
                 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

The purpose of this is to allow bootstrapping to be more granular, by allowing extra context to be passed in from js land.

We've observed instances of using the Deno.readFileSync API in prod, but because bootstrap.js is hardcoded to block these APIs, it was difficult to react quickly to unblock them.

```typescript
await EdgeRuntime.userWorkers.create({
    ..
    context: {
        useReadSyncFileAPI: true
    }
});
```