### PR TITLE
fix(sb_ai): Sessions are dropped while still in use

### DIFF
--- a/crates/sb_ai/onnxruntime/mod.rs
+++ b/crates/sb_ai/onnxruntime/mod.rs
@@ -21,7 +21,7 @@ pub fn op_sb_ai_ort_init_session(
     let mut state = state.borrow_mut();
     let model_info = ModelSession::from_bytes(model_bytes)?;
 
-    let mut sessions = { state.try_take::<Vec<Arc<Session>>>().unwrap_or(Vec::new()) };
+    let mut sessions = { state.try_take::<Vec<Arc<Session>>>().unwrap_or_default() };
 
     sessions.push(model_info.inner());
     state.put(sessions);

--- a/crates/sb_ai/onnxruntime/session.rs
+++ b/crates/sb_ai/onnxruntime/session.rs
@@ -145,6 +145,8 @@ pub fn cleanup() -> Result<usize, AnyError> {
         let mut to_be_removed = vec![];
 
         for (key, session) in &mut *guard {
+            // Since we're currently referencing the session at this point
+            // It also will increments the counter, so we need to check: counter > 1
             if Arc::strong_count(session) > 1 {
                 continue;
             }

--- a/examples/k6-ort-rust-backend/index.ts
+++ b/examples/k6-ort-rust-backend/index.ts
@@ -1,0 +1,19 @@
+import { env, pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.1';
+
+// Ensure we do not use browser cache
+env.useBrowserCache = false;
+env.allowLocalModels = false;
+
+const pipe = await pipeline('feature-extraction', 'supabase/gte-small', { device: 'auto' });
+
+Deno.serve(async (req) => {
+  const payload = await req.json();
+  const text_for_embedding = payload.text_for_embedding;
+
+  // Generate embedding
+  const embedding = await pipe(text_for_embedding, { pooling: 'mean', normalize: true });
+
+  return Response.json({
+    length: embedding.ort_tensor.size,
+  });
+});

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -10,13 +10,6 @@ console.log('main function started');
 
 // cleanup unused sessions every 30s
 // setInterval(async () => {
-//     const { activeUserWorkersCount } = await EdgeRuntime.getRuntimeMetrics();
-//
-//     /* Since cleanup logic will look into active consumer workers we can avoid this check
-//     if (activeUserWorkersCount > 0) {
-//         return;
-//     }
-//     */
 //     try {
 //         const cleanupCount = await EdgeRuntime.ai.tryCleanupUnusedSession();
 //         if (cleanupCount == 0) {
@@ -29,173 +22,173 @@ console.log('main function started');
 // }, 30 * 1000);
 
 Deno.serve(async (req: Request) => {
-  const headers = new Headers({
-    'Content-Type': 'application/json',
-  });
+    const headers = new Headers({
+        'Content-Type': 'application/json',
+    });
 
-  const url = new URL(req.url);
-  const { pathname } = url;
+    const url = new URL(req.url);
+    const { pathname } = url;
 
-  // handle health checks
-  if (pathname === '/_internal/health') {
-    return new Response(
-      JSON.stringify({ 'message': 'ok' }),
-      {
-        status: STATUS_CODE.OK,
-        headers,
-      },
-    );
-  }
+    // handle health checks
+    if (pathname === '/_internal/health') {
+        return new Response(
+            JSON.stringify({ 'message': 'ok' }),
+            {
+                status: STATUS_CODE.OK,
+                headers,
+            },
+        );
+    }
 
-  // if (pathname === '/_internal/segfault') {
-  // 	EdgeRuntime.raiseSegfault();
-  // 	return new Response(
-  // 		JSON.stringify({ 'message': 'ok' }),
-  // 		{
-  // 			status: STATUS_CODE.OK,
-  // 			headers,
-  // 		},
-  // 	);
-  // }
-
-  if (pathname === '/_internal/metric') {
-    const metric = await EdgeRuntime.getRuntimeMetrics();
-    return Response.json(metric);
-  }
-
-  // NOTE: You can test WebSocket in the main worker by uncommenting below.
-  // if (pathname === '/_internal/ws') {
-  // 	const upgrade = req.headers.get("upgrade") || "";
-
-  // 	if (upgrade.toLowerCase() != "websocket") {
-  // 		return new Response("request isn't trying to upgrade to websocket.");
-  // 	}
-
-  // 	const { socket, response } = Deno.upgradeWebSocket(req);
-
-  // 	socket.onopen = () => console.log("socket opened");
-  // 	socket.onmessage = (e) => {
-  // 		console.log("socket message:", e.data);
-  // 		socket.send(new Date().toString());
-  // 	};
-
-  // 	socket.onerror = e => console.log("socket errored:", e.message);
-  // 	socket.onclose = () => console.log("socket closed");
-
-  // 	return response; // 101 (Switching Protocols)
-  // }
-
-  const REGISTRY_PREFIX = '/_internal/registry';
-  if (pathname.startsWith(REGISTRY_PREFIX)) {
-    return await handleRegistryRequest(REGISTRY_PREFIX, req);
-  }
-
-  const path_parts = pathname.split('/');
-  const service_name = path_parts[1];
-
-  if (!service_name || service_name === '') {
-    const error = { msg: 'missing function name in request' };
-    return new Response(
-      JSON.stringify(error),
-      { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
-    );
-  }
-
-  const servicePath = `./examples/${service_name}`;
-  // console.error(`serving the request with ${servicePath}`);
-
-  const createWorker = async () => {
-    const memoryLimitMb = 150;
-    const workerTimeoutMs = 5 * 60 * 1000;
-    const noModuleCache = false;
-
-    // you can provide an import map inline
-    // const inlineImportMap = {
-    //   imports: {
-    //     "std/": "https://deno.land/std@0.131.0/",
-    //     "cors": "./examples/_shared/cors.ts"
-    //   }
+    // if (pathname === '/_internal/segfault') {
+    // 	EdgeRuntime.raiseSegfault();
+    // 	return new Response(
+    // 		JSON.stringify({ 'message': 'ok' }),
+    // 		{
+    // 			status: STATUS_CODE.OK,
+    // 			headers,
+    // 		},
+    // 	);
     // }
 
-    // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
-    const importMapPath = null;
-    const envVarsObj = Deno.env.toObject();
-    const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
-    const forceCreate = false;
-    const netAccessDisabled = false;
-
-    // load source from an eszip
-    //const maybeEszip = await Deno.readFile('./bin.eszip');
-    //const maybeEntrypoint = 'file:///src/index.ts';
-
-    // const maybeEntrypoint = 'file:///src/index.ts';
-    // or load module source from an inline module
-    // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
-    //
-    const cpuTimeSoftLimitMs = 10000;
-    const cpuTimeHardLimitMs = 20000;
-
-    return await EdgeRuntime.userWorkers.create({
-      servicePath,
-      memoryLimitMb,
-      workerTimeoutMs,
-      noModuleCache,
-      importMapPath,
-      envVars,
-      forceCreate,
-      netAccessDisabled,
-      cpuTimeSoftLimitMs,
-      cpuTimeHardLimitMs,
-      // maybeEszip,
-      // maybeEntrypoint,
-      // maybeModuleCode,
-    });
-  };
-
-  const callWorker = async () => {
-    try {
-      // If a worker for the given service path already exists,
-      // it will be reused by default.
-      // Update forceCreate option in createWorker to force create a new worker for each request.
-      const worker = await createWorker();
-      const controller = new AbortController();
-
-      const signal = controller.signal;
-      // Optional: abort the request after a timeout
-      //setTimeout(() => controller.abort(), 2 * 60 * 1000);
-
-      return await worker.fetch(req, { signal });
-    } catch (e) {
-      console.error(e);
-
-      if (e instanceof Deno.errors.WorkerRequestCancelled) {
-        headers.append('Connection', 'close');
-
-        // XXX(Nyannyacha): I can't think right now how to re-poll
-        // inside the worker pool without exposing the error to the
-        // surface.
-
-        // It is satisfied when the supervisor that handled the original
-        // request terminated due to reaches such as CPU time limit or
-        // Wall-clock limit.
-        //
-        // The current request to the worker has been canceled due to
-        // some internal reasons. We should repoll the worker and call
-        // `fetch` again.
-
-        // return await callWorker();
-      }
-
-      const error = { msg: e.toString() };
-      return new Response(
-        JSON.stringify(error),
-        {
-          status: STATUS_CODE.InternalServerError,
-          headers,
-        },
-      );
+    if (pathname === '/_internal/metric') {
+        const metric = await EdgeRuntime.getRuntimeMetrics();
+        return Response.json(metric);
     }
-  };
 
-  return callWorker();
+    // NOTE: You can test WebSocket in the main worker by uncommenting below.
+    // if (pathname === '/_internal/ws') {
+    // 	const upgrade = req.headers.get("upgrade") || "";
+
+    // 	if (upgrade.toLowerCase() != "websocket") {
+    // 		return new Response("request isn't trying to upgrade to websocket.");
+    // 	}
+
+    // 	const { socket, response } = Deno.upgradeWebSocket(req);
+
+    // 	socket.onopen = () => console.log("socket opened");
+    // 	socket.onmessage = (e) => {
+    // 		console.log("socket message:", e.data);
+    // 		socket.send(new Date().toString());
+    // 	};
+
+    // 	socket.onerror = e => console.log("socket errored:", e.message);
+    // 	socket.onclose = () => console.log("socket closed");
+
+    // 	return response; // 101 (Switching Protocols)
+    // }
+
+    const REGISTRY_PREFIX = '/_internal/registry';
+    if (pathname.startsWith(REGISTRY_PREFIX)) {
+        return await handleRegistryRequest(REGISTRY_PREFIX, req);
+    }
+
+    const path_parts = pathname.split('/');
+    const service_name = path_parts[1];
+
+    if (!service_name || service_name === '') {
+        const error = { msg: 'missing function name in request' };
+        return new Response(
+            JSON.stringify(error),
+            { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
+        );
+    }
+
+    const servicePath = `./examples/${service_name}`;
+    // console.error(`serving the request with ${servicePath}`);
+
+    const createWorker = async () => {
+        const memoryLimitMb = 150;
+        const workerTimeoutMs = 5 * 60 * 1000;
+        const noModuleCache = false;
+
+        // you can provide an import map inline
+        // const inlineImportMap = {
+        //   imports: {
+        //     "std/": "https://deno.land/std@0.131.0/",
+        //     "cors": "./examples/_shared/cors.ts"
+        //   }
+        // }
+
+        // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
+        const importMapPath = null;
+        const envVarsObj = Deno.env.toObject();
+        const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
+        const forceCreate = false;
+        const netAccessDisabled = false;
+
+        // load source from an eszip
+        //const maybeEszip = await Deno.readFile('./bin.eszip');
+        //const maybeEntrypoint = 'file:///src/index.ts';
+
+        // const maybeEntrypoint = 'file:///src/index.ts';
+        // or load module source from an inline module
+        // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
+        //
+        const cpuTimeSoftLimitMs = 10000;
+        const cpuTimeHardLimitMs = 20000;
+
+        return await EdgeRuntime.userWorkers.create({
+            servicePath,
+            memoryLimitMb,
+            workerTimeoutMs,
+            noModuleCache,
+            importMapPath,
+            envVars,
+            forceCreate,
+            netAccessDisabled,
+            cpuTimeSoftLimitMs,
+            cpuTimeHardLimitMs,
+            // maybeEszip,
+            // maybeEntrypoint,
+            // maybeModuleCode,
+        });
+    };
+
+    const callWorker = async () => {
+        try {
+            // If a worker for the given service path already exists,
+            // it will be reused by default.
+            // Update forceCreate option in createWorker to force create a new worker for each request.
+            const worker = await createWorker();
+            const controller = new AbortController();
+
+            const signal = controller.signal;
+            // Optional: abort the request after a timeout
+            //setTimeout(() => controller.abort(), 2 * 60 * 1000);
+
+            return await worker.fetch(req, { signal });
+        } catch (e) {
+            console.error(e);
+
+            if (e instanceof Deno.errors.WorkerRequestCancelled) {
+                headers.append('Connection', 'close');
+
+                // XXX(Nyannyacha): I can't think right now how to re-poll
+                // inside the worker pool without exposing the error to the
+                // surface.
+
+                // It is satisfied when the supervisor that handled the original
+                // request terminated due to reaches such as CPU time limit or
+                // Wall-clock limit.
+                //
+                // The current request to the worker has been canceled due to
+                // some internal reasons. We should repoll the worker and call
+                // `fetch` again.
+
+                // return await callWorker();
+            }
+
+            const error = { msg: e.toString() };
+            return new Response(
+                JSON.stringify(error),
+                {
+                    status: STATUS_CODE.InternalServerError,
+                    headers,
+                },
+            );
+        }
+    };
+
+    return callWorker();
 });

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -11,9 +11,12 @@ console.log('main function started');
 // cleanup unused sessions every 30s
 // setInterval(async () => {
 //     const { activeUserWorkersCount } = await EdgeRuntime.getRuntimeMetrics();
+//
+//     /* Since cleanup logic will look into active consumer workers we can avoid this check
 //     if (activeUserWorkersCount > 0) {
 //         return;
 //     }
+//     */
 //     try {
 //         const cleanupCount = await EdgeRuntime.ai.tryCleanupUnusedSession();
 //         if (cleanupCount == 0) {
@@ -26,173 +29,173 @@ console.log('main function started');
 // }, 30 * 1000);
 
 Deno.serve(async (req: Request) => {
-    const headers = new Headers({
-        'Content-Type': 'application/json',
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+  });
+
+  const url = new URL(req.url);
+  const { pathname } = url;
+
+  // handle health checks
+  if (pathname === '/_internal/health') {
+    return new Response(
+      JSON.stringify({ 'message': 'ok' }),
+      {
+        status: STATUS_CODE.OK,
+        headers,
+      },
+    );
+  }
+
+  // if (pathname === '/_internal/segfault') {
+  // 	EdgeRuntime.raiseSegfault();
+  // 	return new Response(
+  // 		JSON.stringify({ 'message': 'ok' }),
+  // 		{
+  // 			status: STATUS_CODE.OK,
+  // 			headers,
+  // 		},
+  // 	);
+  // }
+
+  if (pathname === '/_internal/metric') {
+    const metric = await EdgeRuntime.getRuntimeMetrics();
+    return Response.json(metric);
+  }
+
+  // NOTE: You can test WebSocket in the main worker by uncommenting below.
+  // if (pathname === '/_internal/ws') {
+  // 	const upgrade = req.headers.get("upgrade") || "";
+
+  // 	if (upgrade.toLowerCase() != "websocket") {
+  // 		return new Response("request isn't trying to upgrade to websocket.");
+  // 	}
+
+  // 	const { socket, response } = Deno.upgradeWebSocket(req);
+
+  // 	socket.onopen = () => console.log("socket opened");
+  // 	socket.onmessage = (e) => {
+  // 		console.log("socket message:", e.data);
+  // 		socket.send(new Date().toString());
+  // 	};
+
+  // 	socket.onerror = e => console.log("socket errored:", e.message);
+  // 	socket.onclose = () => console.log("socket closed");
+
+  // 	return response; // 101 (Switching Protocols)
+  // }
+
+  const REGISTRY_PREFIX = '/_internal/registry';
+  if (pathname.startsWith(REGISTRY_PREFIX)) {
+    return await handleRegistryRequest(REGISTRY_PREFIX, req);
+  }
+
+  const path_parts = pathname.split('/');
+  const service_name = path_parts[1];
+
+  if (!service_name || service_name === '') {
+    const error = { msg: 'missing function name in request' };
+    return new Response(
+      JSON.stringify(error),
+      { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const servicePath = `./examples/${service_name}`;
+  // console.error(`serving the request with ${servicePath}`);
+
+  const createWorker = async () => {
+    const memoryLimitMb = 150;
+    const workerTimeoutMs = 5 * 60 * 1000;
+    const noModuleCache = false;
+
+    // you can provide an import map inline
+    // const inlineImportMap = {
+    //   imports: {
+    //     "std/": "https://deno.land/std@0.131.0/",
+    //     "cors": "./examples/_shared/cors.ts"
+    //   }
+    // }
+
+    // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
+    const importMapPath = null;
+    const envVarsObj = Deno.env.toObject();
+    const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
+    const forceCreate = false;
+    const netAccessDisabled = false;
+
+    // load source from an eszip
+    //const maybeEszip = await Deno.readFile('./bin.eszip');
+    //const maybeEntrypoint = 'file:///src/index.ts';
+
+    // const maybeEntrypoint = 'file:///src/index.ts';
+    // or load module source from an inline module
+    // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
+    //
+    const cpuTimeSoftLimitMs = 10000;
+    const cpuTimeHardLimitMs = 20000;
+
+    return await EdgeRuntime.userWorkers.create({
+      servicePath,
+      memoryLimitMb,
+      workerTimeoutMs,
+      noModuleCache,
+      importMapPath,
+      envVars,
+      forceCreate,
+      netAccessDisabled,
+      cpuTimeSoftLimitMs,
+      cpuTimeHardLimitMs,
+      // maybeEszip,
+      // maybeEntrypoint,
+      // maybeModuleCode,
     });
+  };
 
-    const url = new URL(req.url);
-    const { pathname } = url;
+  const callWorker = async () => {
+    try {
+      // If a worker for the given service path already exists,
+      // it will be reused by default.
+      // Update forceCreate option in createWorker to force create a new worker for each request.
+      const worker = await createWorker();
+      const controller = new AbortController();
 
-    // handle health checks
-    if (pathname === '/_internal/health') {
-        return new Response(
-            JSON.stringify({ 'message': 'ok' }),
-            {
-                status: STATUS_CODE.OK,
-                headers,
-            },
-        );
-    }
+      const signal = controller.signal;
+      // Optional: abort the request after a timeout
+      //setTimeout(() => controller.abort(), 2 * 60 * 1000);
 
-    // if (pathname === '/_internal/segfault') {
-    // 	EdgeRuntime.raiseSegfault();
-    // 	return new Response(
-    // 		JSON.stringify({ 'message': 'ok' }),
-    // 		{
-    // 			status: STATUS_CODE.OK,
-    // 			headers,
-    // 		},
-    // 	);
-    // }
+      return await worker.fetch(req, { signal });
+    } catch (e) {
+      console.error(e);
 
-    if (pathname === '/_internal/metric') {
-        const metric = await EdgeRuntime.getRuntimeMetrics();
-        return Response.json(metric);
-    }
+      if (e instanceof Deno.errors.WorkerRequestCancelled) {
+        headers.append('Connection', 'close');
 
-    // NOTE: You can test WebSocket in the main worker by uncommenting below.
-    // if (pathname === '/_internal/ws') {
-    // 	const upgrade = req.headers.get("upgrade") || "";
+        // XXX(Nyannyacha): I can't think right now how to re-poll
+        // inside the worker pool without exposing the error to the
+        // surface.
 
-    // 	if (upgrade.toLowerCase() != "websocket") {
-    // 		return new Response("request isn't trying to upgrade to websocket.");
-    // 	}
-
-    // 	const { socket, response } = Deno.upgradeWebSocket(req);
-
-    // 	socket.onopen = () => console.log("socket opened");
-    // 	socket.onmessage = (e) => {
-    // 		console.log("socket message:", e.data);
-    // 		socket.send(new Date().toString());
-    // 	};
-
-    // 	socket.onerror = e => console.log("socket errored:", e.message);
-    // 	socket.onclose = () => console.log("socket closed");
-
-    // 	return response; // 101 (Switching Protocols)
-    // }
-
-    const REGISTRY_PREFIX = '/_internal/registry';
-    if (pathname.startsWith(REGISTRY_PREFIX)) {
-        return await handleRegistryRequest(REGISTRY_PREFIX, req);
-    }
-
-    const path_parts = pathname.split('/');
-    const service_name = path_parts[1];
-
-    if (!service_name || service_name === '') {
-        const error = { msg: 'missing function name in request' };
-        return new Response(
-            JSON.stringify(error),
-            { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
-        );
-    }
-
-    const servicePath = `./examples/${service_name}`;
-    // console.error(`serving the request with ${servicePath}`);
-
-    const createWorker = async () => {
-        const memoryLimitMb = 150;
-        const workerTimeoutMs = 5 * 60 * 1000;
-        const noModuleCache = false;
-
-        // you can provide an import map inline
-        // const inlineImportMap = {
-        //   imports: {
-        //     "std/": "https://deno.land/std@0.131.0/",
-        //     "cors": "./examples/_shared/cors.ts"
-        //   }
-        // }
-
-        // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
-        const importMapPath = null;
-        const envVarsObj = Deno.env.toObject();
-        const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
-        const forceCreate = false;
-        const netAccessDisabled = false;
-
-        // load source from an eszip
-        //const maybeEszip = await Deno.readFile('./bin.eszip');
-        //const maybeEntrypoint = 'file:///src/index.ts';
-
-        // const maybeEntrypoint = 'file:///src/index.ts';
-        // or load module source from an inline module
-        // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
+        // It is satisfied when the supervisor that handled the original
+        // request terminated due to reaches such as CPU time limit or
+        // Wall-clock limit.
         //
-        const cpuTimeSoftLimitMs = 10000;
-        const cpuTimeHardLimitMs = 20000;
+        // The current request to the worker has been canceled due to
+        // some internal reasons. We should repoll the worker and call
+        // `fetch` again.
 
-        return await EdgeRuntime.userWorkers.create({
-            servicePath,
-            memoryLimitMb,
-            workerTimeoutMs,
-            noModuleCache,
-            importMapPath,
-            envVars,
-            forceCreate,
-            netAccessDisabled,
-            cpuTimeSoftLimitMs,
-            cpuTimeHardLimitMs,
-            // maybeEszip,
-            // maybeEntrypoint,
-            // maybeModuleCode,
-        });
-    };
+        // return await callWorker();
+      }
 
-    const callWorker = async () => {
-        try {
-            // If a worker for the given service path already exists,
-            // it will be reused by default.
-            // Update forceCreate option in createWorker to force create a new worker for each request.
-            const worker = await createWorker();
-            const controller = new AbortController();
+      const error = { msg: e.toString() };
+      return new Response(
+        JSON.stringify(error),
+        {
+          status: STATUS_CODE.InternalServerError,
+          headers,
+        },
+      );
+    }
+  };
 
-            const signal = controller.signal;
-            // Optional: abort the request after a timeout
-            //setTimeout(() => controller.abort(), 2 * 60 * 1000);
-
-            return await worker.fetch(req, { signal });
-        } catch (e) {
-            console.error(e);
-
-            if (e instanceof Deno.errors.WorkerRequestCancelled) {
-                headers.append('Connection', 'close');
-
-                // XXX(Nyannyacha): I can't think right now how to re-poll
-                // inside the worker pool without exposing the error to the
-                // surface.
-
-                // It is satisfied when the supervisor that handled the original
-                // request terminated due to reaches such as CPU time limit or
-                // Wall-clock limit.
-                //
-                // The current request to the worker has been canceled due to
-                // some internal reasons. We should repoll the worker and call
-                // `fetch` again.
-
-                // return await callWorker();
-            }
-
-            const error = { msg: e.toString() };
-            return new Response(
-                JSON.stringify(error),
-                {
-                    status: STATUS_CODE.InternalServerError,
-                    headers,
-                },
-            );
-        }
-    };
-
-    return callWorker();
+  return callWorker();
 });

--- a/k6/specs/ort-rust-backend.ts
+++ b/k6/specs/ort-rust-backend.ts
@@ -1,0 +1,70 @@
+/*
+./scripts/run.sh
+
+#!/usr/bin/env bash
+
+GIT_V_TAG=0.1.1 cargo build --features cli/tracing && \
+EDGE_RUNTIME_WORKER_POOL_SIZE=8 \
+EDGE_RUNTIME_PORT=9998 RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start \
+    --main-service ./examples/main \
+    --event-worker ./examples/event-manager
+
+*/
+
+import http from "k6/http";
+
+import { check, fail } from "k6";
+import { Options } from "k6/options";
+
+import { target } from "../config";
+
+/** @ts-ignore */
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { MSG_CANCELED } from "../constants";
+
+export const options: Options = {
+    scenarios: {
+        simple: {
+            executor: "constant-vus",
+            vus: 12,
+            duration: "3m",
+        }
+    }
+};
+
+const GENERATORS = import("../generators");
+
+export async function setup() {
+    const pkg = await GENERATORS;
+    return {
+        words: pkg.makeText(1000)
+    }
+}
+
+export default function ort_rust_backend(data: { words: string[] }) {
+    const wordIdx = randomIntBetween(0, data.words.length - 1);
+
+    console.debug(`WORD[${wordIdx}]: ${data.words[wordIdx]}`);
+    const res = http.post(
+        `${target}/k6-ort-rust-backend`,
+        JSON.stringify({
+            "text_for_embedding": data.words[wordIdx]
+        })
+    );
+
+    const isOk = check(res, {
+        "status is 200": r => r.status === 200
+    });
+
+    const isRequestCancelled = check(res, {
+        "request cancelled": r => {
+            const msg = r.json("msg");
+            return r.status === 500 && msg === MSG_CANCELED;
+        }
+    });
+
+    if (!isOk && !isRequestCancelled) {
+        console.log(res.body);
+        fail("unexpected response");
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `cleanup` method can't verify if sessions created via `op_sb_ai_ort_init_session()` are still in use.

## What is the new behavior?

This PR fixes this issue, by ensure that sessions created from `op_sb_ai_ort_init_session()` will have its reference stored in Worker's `OpState`. This guarantees that `cleanup` method will don't drop `Sessions` attached to an active worker.

Also was introduced a better error handling when it can't found a session.

## Additional context

**Solved:**
![image](https://github.com/user-attachments/assets/85d28a91-9848-4602-9336-7075a9ead437)
> *Trying to retrieve a session that was dropped while the worker was still consuming it*
