### PR TITLE
chore(ci): only PRs submitted from the origin repo can be tested for s3 fs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         run: ./scripts/install_onnx.sh ${{ env.ONNXRUNTIME_VERSION }} x64 /tmp/onnxruntime
 
       - name: Install S3 credentials for testing
+        if: github.repository == github.event.repository.full_name
         run: |
           cd crates/sb_fs/tests
           echo "S3FS_TEST_SUPABASE_STORAGE=true" >> .env


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

It adjusts the actions runner to skip the s3 fs tests if the PR is submitted from the fork repository.