### PR TITLE
fix(sb_fs): make s3 fs proxy capability to unsafe feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]

--- a/crates/sb_fs/Cargo.toml
+++ b/crates/sb_fs/Cargo.toml
@@ -41,10 +41,10 @@ either.workspace = true
 tracing.workspace = true
 rkyv = { workspace = true, features = ["validation"] }
 
-rustls = "0.21"
-hyper-proxy = { version = "0.9", default-features = false, features = ["rustls"] }
-hyper-rustls = "0.24"
-headers = "0.3"
+rustls = { version = "0.21", optional = true }
+hyper-proxy = { version = "0.9", optional = true, default-features = false, features = ["rustls"] }
+hyper-rustls = { version = "0.24", optional = true }
+headers = { version = "0.3", optional = true }
 normalize-path = "0.2"
 memmap2 = "0.9"
 aws-sdk-s3 = "1.2"
@@ -64,3 +64,11 @@ serial_test.workspace = true
 dotenvy = "0.15"
 aws-smithy-runtime = { version = "1.7", features = ["test-util"] }
 aws-smithy-runtime-api = { version = "1.7", features = ["test-util"] }
+
+[features]
+unsafe-proxy = [
+    "dep:rustls",
+    "dep:hyper-proxy",
+    "dep:hyper-rustls",
+    "dep:headers"
+]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

According to dependabot, <= `webpki@0.22.1` is vulnerable to CPU denial of service attacks.
However, this version is only used for debugging and development purposes by hyper-proxy, so it can be tolerated.

Ultimately, this is a problem because aws-rust-sdk does not currently provide an appropriate hyper v1 connector, and if the issue is resolved (which does not seem likely to be resolved in the short term), the vulnerability can be completely resolved by upgrading the connector version.

The proxy feature is used very limitedly, so I am adding a feature gate to make it available only through the cargo feature to clarify its meaning.

```
│   ├── hyper-proxy v0.9.1
│   │   ├── bytes v1.6.1
│   │   ├── futures v0.3.30 (*)
│   │   ├── headers v0.3.9 (*)
│   │   ├── http v0.2.11 (*)
│   │   ├── hyper v0.14.28 (*)
│   │   ├── hyper-rustls v0.22.1
│   │   │   ├── ct-logs v0.8.0
│   │   │   │   └── sct v0.6.1
│   │   │   │       ├── ring v0.16.20
│   │   │   │       │   ├── libc v0.2.153
│   │   │   │       │   ├── once_cell v1.19.0
│   │   │   │       │   ├── spin v0.5.2
│   │   │   │       │   └── untrusted v0.7.1
│   │   │   │       │   [build-dependencies]
│   │   │   │       │   └── cc v1.2.1 (*)
│   │   │   │       └── untrusted v0.7.1
│   │   │   ├── futures-util v0.3.30 (*)
│   │   │   ├── hyper v0.14.28 (*)
│   │   │   ├── log v0.4.20
│   │   │   ├── rustls v0.19.1
│   │   │   │   ├── base64 v0.13.1
│   │   │   │   ├── log v0.4.20
│   │   │   │   ├── ring v0.16.20 (*)
│   │   │   │   ├── sct v0.6.1 (*)
│   │   │   │   └── webpki v0.21.4 👈
│   │   │   │       ├── ring v0.16.20 (*)
│   │   │   │       └── untrusted v0.7.1
│   │   │   ├── rustls-native-certs v0.5.0
│   │   │   │   ├── openssl-probe v0.1.5
│   │   │   │   └── rustls v0.19.1 (*)
│   │   │   ├── tokio v1.36.0 (*)
│   │   │   ├── tokio-rustls v0.22.0
│   │   │   │   ├── rustls v0.19.1 (*)
│   │   │   │   ├── tokio v1.36.0 (*)
│   │   │   │   └── webpki v0.21.4 (*) 👈
│   │   │   └── webpki v0.21.4 (*) 👈
│   │   ├── rustls-native-certs v0.5.0 (*)
│   │   ├── tokio v1.36.0 (*)
│   │   ├── tokio-rustls v0.22.0 (*)
│   │   ├── tower-service v0.3.2
│   │   └── webpki v0.21.4 (*) 👈
```

Refs:

1: https://github.com/supabase/edge-runtime/security/dependabot/18
2: https://github.com/awslabs/aws-sdk-rust/issues/169
3: https://github.com/tafia/hyper-proxy/pull/38