### PR TITLE
chore(ci): s3 cred install step didn't gate correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: ./scripts/install_onnx.sh ${{ env.ONNXRUNTIME_VERSION }} x64 /tmp/onnxruntime
 
       - name: Install S3 credentials for testing
-        if: github.repository == github.event.repository.full_name
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           cd crates/sb_fs/tests
           echo "S3FS_TEST_SUPABASE_STORAGE=true" >> .env


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the current behavior?

(cherry picked from commit 5ef1122703466517b4fc88e73cea1773bc5122ff)

in case opening a PR using a branch: https://github.com/supabase/edge-runtime/actions/runs/11982000952/job/33409254971

in case opening a PR using a branch of the fork repository: https://github.com/supabase/edge-runtime/actions/runs/11981885370/job/33408929366

