### PR TITLE
fix: move `markAsBackground` to `EdgeRuntime.waitUntil`

### DIFF
--- a/crates/base/test_cases/mark-background-task/index.ts
+++ b/crates/base/test_cases/mark-background-task/index.ts
@@ -37,7 +37,7 @@ export default {
         mySlowFunction(10);
         // make a promise that waits for 5s, and at the same time, notify the runtime that it should
         // wait for this promise.
-        dispatchEvent(new MyBackgroundTaskEvent(markAsBackgroundTask(sleep(5000))));
+        dispatchEvent(new MyBackgroundTaskEvent(EdgeRuntime.waitUntil(sleep(5000))));
         return new Response();
     }
 }

--- a/crates/sb_core/js/async_hook.js
+++ b/crates/sb_core/js/async_hook.js
@@ -8,7 +8,7 @@ const {
 let COUNTER = 0;
 const PROMISES = new Map();
 
-function markAsBackgroundTask(maybePromise) {
+function waitUntil(maybePromise) {
     if (maybePromise instanceof Promise) {
         ops.op_tap_promise_metrics("init");
         PROMISES.set(maybePromise, ++COUNTER);
@@ -31,6 +31,6 @@ function installPromiseHook() {
 }
 
 export {
-    markAsBackgroundTask,
+    waitUntil,
     installPromiseHook
 }

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -594,7 +594,10 @@ globalThis.bootstrapSBEdge = (opts, extraCtx) => {
 	if (isUserWorker) {
 		ObjectDefineProperties(globalThis, {
 			EdgeRuntime: {
-				waitUntil: nonEnumerable(waitUntil),
+				value: {
+					waitUntil,
+				},
+				configurable: true,
 			},
 			console: nonEnumerable(
 				new console.Console((msg, level) => {

--- a/crates/sb_core/js/bootstrap.js
+++ b/crates/sb_core/js/bootstrap.js
@@ -24,7 +24,7 @@ import * as globalInterfaces from 'ext:deno_web/04_global_interfaces.js';
 import { SUPABASE_ENV } from 'ext:sb_env/env.js';
 import { USER_WORKER_API as ai } from 'ext:sb_ai/js/ai.js';
 import 'ext:sb_ai/js/onnxruntime/cache_adapter.js';
-import { markAsBackgroundTask, installPromiseHook } from 'ext:sb_core_main_js/js/async_hook.js';
+import { waitUntil, installPromiseHook } from 'ext:sb_core_main_js/js/async_hook.js';
 import { registerErrors } from 'ext:sb_core_main_js/js/errors.js';
 import {
 	formatException,
@@ -592,10 +592,10 @@ globalThis.bootstrapSBEdge = (opts, extraCtx) => {
 	/// DISABLE SHARED MEMORY INSTALL MEM CHECK TIMING
 
 	if (isUserWorker) {
-		delete globalThis.EdgeRuntime;
-
 		ObjectDefineProperties(globalThis, {
-			markAsBackgroundTask: nonEnumerable(markAsBackgroundTask),
+			EdgeRuntime: {
+				waitUntil: nonEnumerable(waitUntil),
+			},
 			console: nonEnumerable(
 				new console.Console((msg, level) => {
 					return ops.op_user_worker_log(msg, level > 1);

--- a/crates/sb_core/js/main_worker.js
+++ b/crates/sb_core/js/main_worker.js
@@ -1,11 +1,13 @@
+import { core, primordials } from 'ext:core/mod.js';
+
 import { MAIN_WORKER_API as ai } from 'ext:sb_ai/js/ai.js';
 import { SUPABASE_USER_WORKERS } from 'ext:sb_user_workers/user_workers.js';
 import { applySupabaseTag } from 'ext:sb_core_main_js/js/http.js';
-import { core } from 'ext:core/mod.js';
 
 const ops = core.ops;
+const { ObjectDefineProperty } = primordials;
 
-Object.defineProperty(globalThis, 'EdgeRuntime', {
+ObjectDefineProperty(globalThis, 'EdgeRuntime', {
 	get() {
 		return {
 			ai,

--- a/examples/mark-background-task/index.ts
+++ b/examples/mark-background-task/index.ts
@@ -37,7 +37,7 @@ export default {
         mySlowFunction(10);
         // make a promise that waits for 5s, and at the same time, notify the runtime that it should
         // wait for this promise.
-        dispatchEvent(new MyBackgroundTaskEvent(markAsBackgroundTask(sleep(5000))));
+        dispatchEvent(new MyBackgroundTaskEvent(EdgeRuntime.waitUntil(sleep(5000))));
         return new Response();
     }
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,1 +1,105 @@
-declare function markAsBackgroundTask<T>(promise: Promise<T>): Promise<T>;
+type DecoratorType = "tc39" | "typescript" | "typescript_with_metadata";
+
+interface JsxImportBaseConfig {
+    defaultSpecifier?: string | null;
+    module?: string | null;
+    baseUrl?: string | null;
+}
+
+// TODO(Nyannyacha): These two type defs will be provided later.
+
+// deno-lint-ignore no-explicit-any
+type S3FsConfig = any;
+
+// deno-lint-ignore no-explicit-any
+type TmpFsConfig = any;
+
+interface UserWorkerFetchOptions {
+    signal?: AbortSignal;
+}
+
+interface UserWorkerCreateOptions {
+    servicePath?: string | null;
+    envVars?: string[][] | [string, string][] | null;
+    noModuleCache?: boolean | null;
+    importMapPath?: string | null;
+
+    forceCreate?: boolean | null;
+    netAccessDisabled?: boolean | null;
+    allowNet?: string[] | null;
+    allowRemoteModules?: boolean | null;
+    customModuleRoot?: string | null;
+
+    maybeEszip?: Uint8Array | null;
+    maybeEntrypoint?: string | null;
+    maybeModuleCode?: string | null;
+
+    memoryLimitMb?: number | null;
+    lowMemoryMultiplier?: number | null;
+    workerTimeoutMs?: number | null;
+    cpuTimeSoftLimitMs?: number | null;
+    cpuTimeHardLimitMs?: number | null;
+
+    decoratorType?: DecoratorType | null;
+    jsxImportSourceConfig?: JsxImportBaseConfig | null;
+
+    s3FsConfig?: S3FsConfig | null;
+    tmpFsConfig?: TmpFsConfig | null;
+
+    context?: { [key: string]: unknown } | null;
+}
+
+interface HeapStatistics {
+    totalHeapSize: number;
+    totalHeapSizeExecutable: number;
+    totalPhysicalSize: number;
+    totalAvailableSize: number;
+    totalGlobalHandlesSize: number;
+    usedGlobalHandlesSize: number;
+    usedHeapSize: number;
+    mallocedMemory: number;
+    externalMemory: number;
+    peakMallocedMemory: number;
+}
+
+interface RuntimeMetrics {
+    mainWorkerHeapStats: HeapStatistics;
+    eventWorkerHeapStats?: HeapStatistics;
+}
+
+interface MemInfo {
+    total: number;
+    free: number;
+    available: number;
+    buffers: number;
+    cached: number;
+    swapTotal: number;
+    swapFree: number;
+}
+
+declare namespace EdgeRuntime {
+    export namespace ai {
+        function tryCleanupUnusedSession(): Promise<void>;
+    }
+
+    class UserWorker {
+        constructor(key: string);
+
+        fetch(request: Request, options?: UserWorkerFetchOptions): Promise<Response>;
+        static create(opts: UserWorkerCreateOptions): Promise<UserWorker>;
+    }
+
+    export function waitUntil<T>(promise: Promise<T>): Promise<T>;
+    export function getRuntimeMetrics(): Promise<RuntimeMetrics>;
+    export function applySupabaseTag(src: Request, dest: Request): void;
+    export function systemMemoryInfo(): MemInfo;
+    export function raiseSegfault(): void;
+
+    export { UserWorker as userWorkers };
+}
+
+declare namespace Deno {
+    export namespace errors {
+        class WorkerRequestCancelled extends Error { }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor, Enhancement

## Description

* Move `markAsBackground` to `EdgeRuntime.waitUntil`
* Fill global definitions in `global.d.ts` as far as possible (We haven't had proper type definitions until now, so now is the time.)