### PR TITLE
fix(sb_fs): update `build.rs`

### DIFF
--- a/crates/sb_fs/build.rs
+++ b/crates/sb_fs/build.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 fn main() {
-    dbg!(Path::new("./tests/.env").exists());
+    println!("cargo::rerun-if-changed=tests/.env");
     if Path::new("./tests/.env").exists() {
         println!("cargo:rustc-cfg=dotenv")
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

It just appends the `cargo::return-if-changed` instruction to the build script. 
Because it could not detect changes `.env` before.
