### PR TITLE
feat(base): make able to trigger early drop with other resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   ORT_DYLIB_PATH: /tmp/onnxruntime/lib/libonnxruntime.so
-  RUST_LOG: event_worker=trace
+  RUST_LOG: sb_event_worker=trace
 
 jobs:
   cargo-fmt:

--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -279,6 +279,7 @@ pub struct RuntimeState {
     pub event_loop_completed: Arc<AtomicFlag>,
     pub terminated: Arc<AtomicFlag>,
     pub found_inspector_session: Arc<AtomicFlag>,
+    pub mem_reached_half: Arc<AtomicFlag>,
 }
 
 impl RuntimeState {
@@ -1321,6 +1322,14 @@ where
                         {
                             return Poll::Ready(Err(err));
                         }
+                    }
+                }
+
+                if let Some(limit) = mem_state.limit {
+                    if total_malloced_bytes >= limit / 2 {
+                        state.mem_reached_half.raise();
+                    } else {
+                        state.mem_reached_half.lower();
                     }
                 }
 

--- a/crates/base/test_cases/early-drop-mem/index.ts
+++ b/crates/base/test_cases/early-drop-mem/index.ts
@@ -1,0 +1,26 @@
+function sleep(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res(void 0);
+        }, ms)
+    });
+}
+
+addEventListener("beforeunload", ev => {
+    console.log(ev.detail);
+});
+
+const mem = [];
+
+export default {
+    async fetch() {
+        for (const _ of [...Array(12).keys()]) {
+            const buf = new Uint8Array(1024 * 1024);
+            buf.fill(1, 0);
+            mem.push(buf);
+            await sleep(300);
+        }
+
+        return new Response();
+    }
+}

--- a/crates/base/test_cases/early-drop-wall-clock/index.ts
+++ b/crates/base/test_cases/early-drop-wall-clock/index.ts
@@ -1,0 +1,18 @@
+function sleep(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res(void 0);
+        }, ms)
+    });
+}
+
+addEventListener("beforeunload", ev => {
+    console.log(ev.detail);
+});
+
+export default {
+    async fetch() {
+        await sleep(2000);
+        return new Response();
+    }
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,10 +1,9 @@
 declare type BeforeunloadReason = "cpu" | "memory" | "wall_clock" | "early_drop" | "termination";
-declare interface BeforeunloadEvent extends CustomEvent<BeforeunloadReason> { }
 
 declare interface WindowEventMap {
     "load": Event;
     "unload": Event;
-    "beforeunload": BeforeunloadEvent;
+    "beforeunload": CustomEvent<BeforeunloadReason>;
     "drain": Event;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, Enhancement

## Description

This PR makes the early drop be performed even under other resource limits.

* wallclock limit
  * It may be triggered when half of its limit specified by the main worker has elapsed.
* worker memory limit
  * It may be triggered when half of its limit specified by the main worker has been reached.

Nevertheless, the fact that if there are remaining requests or background tasks, the runtime will not trigger the early drop is unchanged.

~Blocked-by: #462~