### PR TITLE
fix(ext/event_worker): don't use `tracing` as the log backend if `cli/tracing` feature flag is not enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ dependencies = [
  "graph",
  "log",
  "once_cell",
+ "sb_event_worker",
  "tokio",
  "tracing-subscriber",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,8 @@ base.workspace = true
 deno_manifest.workspace = true
 graph.workspace = true
 
+sb_event_worker = { workspace = true, optional = true, features = ["tracing"] }
+
 anyhow.workspace = true
 log.workspace = true
 tokio.workspace = true
@@ -26,4 +28,4 @@ tracing-subscriber = { workspace = true, optional = true }
 env_logger = "0.10.0"
 
 [features]
-tracing = ["dep:tracing-subscriber"]
+tracing = ["dep:tracing-subscriber", "dep:sb_event_worker"]

--- a/ext/event_worker/Cargo.toml
+++ b/ext/event_worker/Cargo.toml
@@ -20,3 +20,6 @@ tokio.workspace = true
 log.workspace = true
 tracing.workspace = true
 enum-as-inner.workspace = true
+
+[features]
+tracing = []


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

`CliLogger` does not trace the log entries emitted by tracing, so if the user does not explicitly set the event worker, the edge runtime does not render these logs to stdout or stderr.
