### PR TITLE
fix: allow setting static patterns when creating a user worker

### DIFF
--- a/crates/base/src/worker/pool.rs
+++ b/crates/base/src/worker/pool.rs
@@ -365,6 +365,7 @@ impl WorkerPool {
                         maybe_jsx_import_source_config,
                         maybe_s3_fs_config,
                         maybe_tmp_fs_config,
+                        static_patterns,
                         ..
                     } = worker_options;
 
@@ -381,7 +382,7 @@ impl WorkerPool {
                                 maybe_module_code,
                                 maybe_entrypoint,
                                 maybe_decorator,
-                                static_patterns: vec![],
+                                static_patterns,
 
                                 maybe_jsx_import_source_config,
                                 maybe_s3_fs_config,
@@ -714,7 +715,7 @@ pub async fn create_user_worker_pool(
                             None => break,
                             Some(UserWorkerMsgs::Create(worker_options, tx)) => {
                                 worker_pool.create_user_worker(WorkerContextInitOpts {
-                                    static_patterns: static_patterns.clone(),
+                                    static_patterns: vec![worker_options.static_patterns, static_patterns.clone()].concat(),
                                     maybe_jsx_import_source_config: {
                                         if worker_options.maybe_jsx_import_source_config.is_some() {
                                             worker_options.maybe_jsx_import_source_config

--- a/crates/base/src/worker/pool.rs
+++ b/crates/base/src/worker/pool.rs
@@ -715,7 +715,7 @@ pub async fn create_user_worker_pool(
                             None => break,
                             Some(UserWorkerMsgs::Create(worker_options, tx)) => {
                                 worker_pool.create_user_worker(WorkerContextInitOpts {
-                                    static_patterns: vec![worker_options.static_patterns, static_patterns.clone()].concat(),
+                                    static_patterns: [worker_options.static_patterns, static_patterns.clone()].concat(),
                                     maybe_jsx_import_source_config: {
                                         if worker_options.maybe_jsx_import_source_config.is_some() {
                                             worker_options.maybe_jsx_import_source_config

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "./crates/base/test_cases"
   ],
   "fmt": {
-    "useTabs": true,
+    "useTabs": false,
     "lineWidth": 100,
     "indentWidth": 4,
     "singleQuote": true,

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -6,7 +6,7 @@ import { handleRegistryRequest } from './registry/mod.ts';
 console.log('main function started');
 
 addEventListener('beforeunload', () => {
-    console.log('main worker exiting');
+	console.log('main worker exiting');
 });
 
 // log system memory usage every 30s
@@ -26,173 +26,177 @@ addEventListener('beforeunload', () => {
 // }, 30 * 1000);
 
 Deno.serve(async (req: Request) => {
-    const headers = new Headers({
-        'Content-Type': 'application/json',
-    });
+	const headers = new Headers({
+		'Content-Type': 'application/json',
+	});
 
-    const url = new URL(req.url);
-    const { pathname } = url;
+	const url = new URL(req.url);
+	const { pathname } = url;
 
-    // handle health checks
-    if (pathname === '/_internal/health') {
-        return new Response(
-            JSON.stringify({ 'message': 'ok' }),
-            {
-                status: STATUS_CODE.OK,
-                headers,
-            },
-        );
-    }
+	// handle health checks
+	if (pathname === '/_internal/health') {
+		return new Response(
+			JSON.stringify({ 'message': 'ok' }),
+			{
+				status: STATUS_CODE.OK,
+				headers,
+			},
+		);
+	}
 
-    // if (pathname === '/_internal/segfault') {
-    // 	EdgeRuntime.raiseSegfault();
-    // 	return new Response(
-    // 		JSON.stringify({ 'message': 'ok' }),
-    // 		{
-    // 			status: STATUS_CODE.OK,
-    // 			headers,
-    // 		},
-    // 	);
-    // }
+	// if (pathname === '/_internal/segfault') {
+	// 	EdgeRuntime.raiseSegfault();
+	// 	return new Response(
+	// 		JSON.stringify({ 'message': 'ok' }),
+	// 		{
+	// 			status: STATUS_CODE.OK,
+	// 			headers,
+	// 		},
+	// 	);
+	// }
 
-    if (pathname === '/_internal/metric') {
-        const metric = await EdgeRuntime.getRuntimeMetrics();
-        return Response.json(metric);
-    }
+	if (pathname === '/_internal/metric') {
+		const metric = await EdgeRuntime.getRuntimeMetrics();
+		return Response.json(metric);
+	}
 
-    // NOTE: You can test WebSocket in the main worker by uncommenting below.
-    // if (pathname === '/_internal/ws') {
-    // 	const upgrade = req.headers.get("upgrade") || "";
+	// NOTE: You can test WebSocket in the main worker by uncommenting below.
+	// if (pathname === '/_internal/ws') {
+	// 	const upgrade = req.headers.get("upgrade") || "";
 
-    // 	if (upgrade.toLowerCase() != "websocket") {
-    // 		return new Response("request isn't trying to upgrade to websocket.");
-    // 	}
+	// 	if (upgrade.toLowerCase() != "websocket") {
+	// 		return new Response("request isn't trying to upgrade to websocket.");
+	// 	}
 
-    // 	const { socket, response } = Deno.upgradeWebSocket(req);
+	// 	const { socket, response } = Deno.upgradeWebSocket(req);
 
-    // 	socket.onopen = () => console.log("socket opened");
-    // 	socket.onmessage = (e) => {
-    // 		console.log("socket message:", e.data);
-    // 		socket.send(new Date().toString());
-    // 	};
+	// 	socket.onopen = () => console.log("socket opened");
+	// 	socket.onmessage = (e) => {
+	// 		console.log("socket message:", e.data);
+	// 		socket.send(new Date().toString());
+	// 	};
 
-    // 	socket.onerror = e => console.log("socket errored:", e.message);
-    // 	socket.onclose = () => console.log("socket closed");
+	// 	socket.onerror = e => console.log("socket errored:", e.message);
+	// 	socket.onclose = () => console.log("socket closed");
 
-    // 	return response; // 101 (Switching Protocols)
-    // }
+	// 	return response; // 101 (Switching Protocols)
+	// }
 
-    const REGISTRY_PREFIX = '/_internal/registry';
-    if (pathname.startsWith(REGISTRY_PREFIX)) {
-        return await handleRegistryRequest(REGISTRY_PREFIX, req);
-    }
+	const REGISTRY_PREFIX = '/_internal/registry';
+	if (pathname.startsWith(REGISTRY_PREFIX)) {
+		return await handleRegistryRequest(REGISTRY_PREFIX, req);
+	}
 
-    const path_parts = pathname.split('/');
-    const service_name = path_parts[1];
+	const path_parts = pathname.split('/');
+	const service_name = path_parts[1];
 
-    if (!service_name || service_name === '') {
-        const error = { msg: 'missing function name in request' };
-        return new Response(
-            JSON.stringify(error),
-            { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
-        );
-    }
+	if (!service_name || service_name === '') {
+		const error = { msg: 'missing function name in request' };
+		return new Response(
+			JSON.stringify(error),
+			{ status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
+		);
+	}
 
-    const servicePath = `./examples/${service_name}`;
-    // console.error(`serving the request with ${servicePath}`);
+	const servicePath = `./examples/${service_name}`;
+	// console.error(`serving the request with ${servicePath}`);
 
-    const createWorker = async () => {
-        const memoryLimitMb = 150;
-        const workerTimeoutMs = 5 * 60 * 1000;
-        const noModuleCache = false;
+	const createWorker = async () => {
+		const memoryLimitMb = 150;
+		const workerTimeoutMs = 5 * 60 * 1000;
+		const noModuleCache = false;
 
-        // you can provide an import map inline
-        // const inlineImportMap = {
-        //   imports: {
-        //     "std/": "https://deno.land/std@0.131.0/",
-        //     "cors": "./examples/_shared/cors.ts"
-        //   }
-        // }
+		// you can provide an import map inline
+		// const inlineImportMap = {
+		//   imports: {
+		//     "std/": "https://deno.land/std@0.131.0/",
+		//     "cors": "./examples/_shared/cors.ts"
+		//   }
+		// }
 
-        // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
-        const importMapPath = null;
-        const envVarsObj = Deno.env.toObject();
-        const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
-        const forceCreate = false;
-        const netAccessDisabled = false;
+		// const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
+		const importMapPath = null;
+		const envVarsObj = Deno.env.toObject();
+		const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
+		const forceCreate = false;
+		const netAccessDisabled = false;
 
-        // load source from an eszip
-        //const maybeEszip = await Deno.readFile('./bin.eszip');
-        //const maybeEntrypoint = 'file:///src/index.ts';
+		// load source from an eszip
+		//const maybeEszip = await Deno.readFile('./bin.eszip');
+		//const maybeEntrypoint = 'file:///src/index.ts';
 
-        // const maybeEntrypoint = 'file:///src/index.ts';
-        // or load module source from an inline module
-        // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
-        //
-        const cpuTimeSoftLimitMs = 10000;
-        const cpuTimeHardLimitMs = 20000;
+		// const maybeEntrypoint = 'file:///src/index.ts';
+		// or load module source from an inline module
+		// const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
+		//
+		const cpuTimeSoftLimitMs = 10000;
+		const cpuTimeHardLimitMs = 20000;
+		const staticPatterns = [
+			'./examples/**/*.html',
+		];
 
-        return await EdgeRuntime.userWorkers.create({
-            servicePath,
-            memoryLimitMb,
-            workerTimeoutMs,
-            noModuleCache,
-            importMapPath,
-            envVars,
-            forceCreate,
-            netAccessDisabled,
-            cpuTimeSoftLimitMs,
-            cpuTimeHardLimitMs,
-            // maybeEszip,
-            // maybeEntrypoint,
-            // maybeModuleCode,
-        });
-    };
+		return await EdgeRuntime.userWorkers.create({
+			servicePath,
+			memoryLimitMb,
+			workerTimeoutMs,
+			noModuleCache,
+			importMapPath,
+			envVars,
+			forceCreate,
+			netAccessDisabled,
+			cpuTimeSoftLimitMs,
+			cpuTimeHardLimitMs,
+			staticPatterns,
+			// maybeEszip,
+			// maybeEntrypoint,
+			// maybeModuleCode,
+		});
+	};
 
-    const callWorker = async () => {
-        try {
-            // If a worker for the given service path already exists,
-            // it will be reused by default.
-            // Update forceCreate option in createWorker to force create a new worker for each request.
-            const worker = await createWorker();
-            const controller = new AbortController();
+	const callWorker = async () => {
+		try {
+			// If a worker for the given service path already exists,
+			// it will be reused by default.
+			// Update forceCreate option in createWorker to force create a new worker for each request.
+			const worker = await createWorker();
+			const controller = new AbortController();
 
-            const signal = controller.signal;
-            // Optional: abort the request after a timeout
-            //setTimeout(() => controller.abort(), 2 * 60 * 1000);
+			const signal = controller.signal;
+			// Optional: abort the request after a timeout
+			//setTimeout(() => controller.abort(), 2 * 60 * 1000);
 
-            return await worker.fetch(req, { signal });
-        } catch (e) {
-            console.error(e);
+			return await worker.fetch(req, { signal });
+		} catch (e) {
+			console.error(e);
 
-            if (e instanceof Deno.errors.WorkerRequestCancelled) {
-                headers.append('Connection', 'close');
+			if (e instanceof Deno.errors.WorkerRequestCancelled) {
+				headers.append('Connection', 'close');
 
-                // XXX(Nyannyacha): I can't think right now how to re-poll
-                // inside the worker pool without exposing the error to the
-                // surface.
+				// XXX(Nyannyacha): I can't think right now how to re-poll
+				// inside the worker pool without exposing the error to the
+				// surface.
 
-                // It is satisfied when the supervisor that handled the original
-                // request terminated due to reaches such as CPU time limit or
-                // Wall-clock limit.
-                //
-                // The current request to the worker has been canceled due to
-                // some internal reasons. We should repoll the worker and call
-                // `fetch` again.
+				// It is satisfied when the supervisor that handled the original
+				// request terminated due to reaches such as CPU time limit or
+				// Wall-clock limit.
+				//
+				// The current request to the worker has been canceled due to
+				// some internal reasons. We should repoll the worker and call
+				// `fetch` again.
 
-                // return await callWorker();
-            }
+				// return await callWorker();
+			}
 
-            const error = { msg: e.toString() };
-            return new Response(
-                JSON.stringify(error),
-                {
-                    status: STATUS_CODE.InternalServerError,
-                    headers,
-                },
-            );
-        }
-    };
+			const error = { msg: e.toString() };
+			return new Response(
+				JSON.stringify(error),
+				{
+					status: STATUS_CODE.InternalServerError,
+					headers,
+				},
+			);
+		}
+	};
 
-    return callWorker();
+	return callWorker();
 });

--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -6,7 +6,7 @@ import { handleRegistryRequest } from './registry/mod.ts';
 console.log('main function started');
 
 addEventListener('beforeunload', () => {
-	console.log('main worker exiting');
+    console.log('main worker exiting');
 });
 
 // log system memory usage every 30s
@@ -26,177 +26,177 @@ addEventListener('beforeunload', () => {
 // }, 30 * 1000);
 
 Deno.serve(async (req: Request) => {
-	const headers = new Headers({
-		'Content-Type': 'application/json',
-	});
+    const headers = new Headers({
+        'Content-Type': 'application/json',
+    });
 
-	const url = new URL(req.url);
-	const { pathname } = url;
+    const url = new URL(req.url);
+    const { pathname } = url;
 
-	// handle health checks
-	if (pathname === '/_internal/health') {
-		return new Response(
-			JSON.stringify({ 'message': 'ok' }),
-			{
-				status: STATUS_CODE.OK,
-				headers,
-			},
-		);
-	}
+    // handle health checks
+    if (pathname === '/_internal/health') {
+        return new Response(
+            JSON.stringify({ 'message': 'ok' }),
+            {
+                status: STATUS_CODE.OK,
+                headers,
+            },
+        );
+    }
 
-	// if (pathname === '/_internal/segfault') {
-	// 	EdgeRuntime.raiseSegfault();
-	// 	return new Response(
-	// 		JSON.stringify({ 'message': 'ok' }),
-	// 		{
-	// 			status: STATUS_CODE.OK,
-	// 			headers,
-	// 		},
-	// 	);
-	// }
+    // if (pathname === '/_internal/segfault') {
+    // 	EdgeRuntime.raiseSegfault();
+    // 	return new Response(
+    // 		JSON.stringify({ 'message': 'ok' }),
+    // 		{
+    // 			status: STATUS_CODE.OK,
+    // 			headers,
+    // 		},
+    // 	);
+    // }
 
-	if (pathname === '/_internal/metric') {
-		const metric = await EdgeRuntime.getRuntimeMetrics();
-		return Response.json(metric);
-	}
+    if (pathname === '/_internal/metric') {
+        const metric = await EdgeRuntime.getRuntimeMetrics();
+        return Response.json(metric);
+    }
 
-	// NOTE: You can test WebSocket in the main worker by uncommenting below.
-	// if (pathname === '/_internal/ws') {
-	// 	const upgrade = req.headers.get("upgrade") || "";
+    // NOTE: You can test WebSocket in the main worker by uncommenting below.
+    // if (pathname === '/_internal/ws') {
+    // 	const upgrade = req.headers.get("upgrade") || "";
 
-	// 	if (upgrade.toLowerCase() != "websocket") {
-	// 		return new Response("request isn't trying to upgrade to websocket.");
-	// 	}
+    // 	if (upgrade.toLowerCase() != "websocket") {
+    // 		return new Response("request isn't trying to upgrade to websocket.");
+    // 	}
 
-	// 	const { socket, response } = Deno.upgradeWebSocket(req);
+    // 	const { socket, response } = Deno.upgradeWebSocket(req);
 
-	// 	socket.onopen = () => console.log("socket opened");
-	// 	socket.onmessage = (e) => {
-	// 		console.log("socket message:", e.data);
-	// 		socket.send(new Date().toString());
-	// 	};
+    // 	socket.onopen = () => console.log("socket opened");
+    // 	socket.onmessage = (e) => {
+    // 		console.log("socket message:", e.data);
+    // 		socket.send(new Date().toString());
+    // 	};
 
-	// 	socket.onerror = e => console.log("socket errored:", e.message);
-	// 	socket.onclose = () => console.log("socket closed");
+    // 	socket.onerror = e => console.log("socket errored:", e.message);
+    // 	socket.onclose = () => console.log("socket closed");
 
-	// 	return response; // 101 (Switching Protocols)
-	// }
+    // 	return response; // 101 (Switching Protocols)
+    // }
 
-	const REGISTRY_PREFIX = '/_internal/registry';
-	if (pathname.startsWith(REGISTRY_PREFIX)) {
-		return await handleRegistryRequest(REGISTRY_PREFIX, req);
-	}
+    const REGISTRY_PREFIX = '/_internal/registry';
+    if (pathname.startsWith(REGISTRY_PREFIX)) {
+        return await handleRegistryRequest(REGISTRY_PREFIX, req);
+    }
 
-	const path_parts = pathname.split('/');
-	const service_name = path_parts[1];
+    const path_parts = pathname.split('/');
+    const service_name = path_parts[1];
 
-	if (!service_name || service_name === '') {
-		const error = { msg: 'missing function name in request' };
-		return new Response(
-			JSON.stringify(error),
-			{ status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
-		);
-	}
+    if (!service_name || service_name === '') {
+        const error = { msg: 'missing function name in request' };
+        return new Response(
+            JSON.stringify(error),
+            { status: STATUS_CODE.BadRequest, headers: { 'Content-Type': 'application/json' } },
+        );
+    }
 
-	const servicePath = `./examples/${service_name}`;
-	// console.error(`serving the request with ${servicePath}`);
+    const servicePath = `./examples/${service_name}`;
+    // console.error(`serving the request with ${servicePath}`);
 
-	const createWorker = async () => {
-		const memoryLimitMb = 150;
-		const workerTimeoutMs = 5 * 60 * 1000;
-		const noModuleCache = false;
+    const createWorker = async () => {
+        const memoryLimitMb = 150;
+        const workerTimeoutMs = 5 * 60 * 1000;
+        const noModuleCache = false;
 
-		// you can provide an import map inline
-		// const inlineImportMap = {
-		//   imports: {
-		//     "std/": "https://deno.land/std@0.131.0/",
-		//     "cors": "./examples/_shared/cors.ts"
-		//   }
-		// }
+        // you can provide an import map inline
+        // const inlineImportMap = {
+        //   imports: {
+        //     "std/": "https://deno.land/std@0.131.0/",
+        //     "cors": "./examples/_shared/cors.ts"
+        //   }
+        // }
 
-		// const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
-		const importMapPath = null;
-		const envVarsObj = Deno.env.toObject();
-		const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
-		const forceCreate = false;
-		const netAccessDisabled = false;
+        // const importMapPath = `data:${encodeURIComponent(JSON.stringify(importMap))}?${encodeURIComponent('/home/deno/functions/test')}`;
+        const importMapPath = null;
+        const envVarsObj = Deno.env.toObject();
+        const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
+        const forceCreate = false;
+        const netAccessDisabled = false;
 
-		// load source from an eszip
-		//const maybeEszip = await Deno.readFile('./bin.eszip');
-		//const maybeEntrypoint = 'file:///src/index.ts';
+        // load source from an eszip
+        //const maybeEszip = await Deno.readFile('./bin.eszip');
+        //const maybeEntrypoint = 'file:///src/index.ts';
 
-		// const maybeEntrypoint = 'file:///src/index.ts';
-		// or load module source from an inline module
-		// const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
-		//
-		const cpuTimeSoftLimitMs = 10000;
-		const cpuTimeHardLimitMs = 20000;
-		const staticPatterns = [
-			'./examples/**/*.html',
-		];
+        // const maybeEntrypoint = 'file:///src/index.ts';
+        // or load module source from an inline module
+        // const maybeModuleCode = 'Deno.serve((req) => new Response("Hello from Module Code"));';
+        //
+        const cpuTimeSoftLimitMs = 10000;
+        const cpuTimeHardLimitMs = 20000;
+        const staticPatterns = [
+            './examples/**/*.html',
+        ];
 
-		return await EdgeRuntime.userWorkers.create({
-			servicePath,
-			memoryLimitMb,
-			workerTimeoutMs,
-			noModuleCache,
-			importMapPath,
-			envVars,
-			forceCreate,
-			netAccessDisabled,
-			cpuTimeSoftLimitMs,
-			cpuTimeHardLimitMs,
-			staticPatterns,
-			// maybeEszip,
-			// maybeEntrypoint,
-			// maybeModuleCode,
-		});
-	};
+        return await EdgeRuntime.userWorkers.create({
+            servicePath,
+            memoryLimitMb,
+            workerTimeoutMs,
+            noModuleCache,
+            importMapPath,
+            envVars,
+            forceCreate,
+            netAccessDisabled,
+            cpuTimeSoftLimitMs,
+            cpuTimeHardLimitMs,
+            staticPatterns,
+            // maybeEszip,
+            // maybeEntrypoint,
+            // maybeModuleCode,
+        });
+    };
 
-	const callWorker = async () => {
-		try {
-			// If a worker for the given service path already exists,
-			// it will be reused by default.
-			// Update forceCreate option in createWorker to force create a new worker for each request.
-			const worker = await createWorker();
-			const controller = new AbortController();
+    const callWorker = async () => {
+        try {
+            // If a worker for the given service path already exists,
+            // it will be reused by default.
+            // Update forceCreate option in createWorker to force create a new worker for each request.
+            const worker = await createWorker();
+            const controller = new AbortController();
 
-			const signal = controller.signal;
-			// Optional: abort the request after a timeout
-			//setTimeout(() => controller.abort(), 2 * 60 * 1000);
+            const signal = controller.signal;
+            // Optional: abort the request after a timeout
+            //setTimeout(() => controller.abort(), 2 * 60 * 1000);
 
-			return await worker.fetch(req, { signal });
-		} catch (e) {
-			console.error(e);
+            return await worker.fetch(req, { signal });
+        } catch (e) {
+            console.error(e);
 
-			if (e instanceof Deno.errors.WorkerRequestCancelled) {
-				headers.append('Connection', 'close');
+            if (e instanceof Deno.errors.WorkerRequestCancelled) {
+                headers.append('Connection', 'close');
 
-				// XXX(Nyannyacha): I can't think right now how to re-poll
-				// inside the worker pool without exposing the error to the
-				// surface.
+                // XXX(Nyannyacha): I can't think right now how to re-poll
+                // inside the worker pool without exposing the error to the
+                // surface.
 
-				// It is satisfied when the supervisor that handled the original
-				// request terminated due to reaches such as CPU time limit or
-				// Wall-clock limit.
-				//
-				// The current request to the worker has been canceled due to
-				// some internal reasons. We should repoll the worker and call
-				// `fetch` again.
+                // It is satisfied when the supervisor that handled the original
+                // request terminated due to reaches such as CPU time limit or
+                // Wall-clock limit.
+                //
+                // The current request to the worker has been canceled due to
+                // some internal reasons. We should repoll the worker and call
+                // `fetch` again.
 
-				// return await callWorker();
-			}
+                // return await callWorker();
+            }
 
-			const error = { msg: e.toString() };
-			return new Response(
-				JSON.stringify(error),
-				{
-					status: STATUS_CODE.InternalServerError,
-					headers,
-				},
-			);
-		}
-	};
+            const error = { msg: e.toString() };
+            return new Response(
+                JSON.stringify(error),
+                {
+                    status: STATUS_CODE.InternalServerError,
+                    headers,
+                },
+            );
+        }
+    };
 
-	return callWorker();
+    return callWorker();
 });

--- a/examples/serve-html/bar.html
+++ b/examples/serve-html/bar.html
@@ -1,0 +1,3 @@
+<html>
+  <h1>Bar</h1>
+</html>

--- a/examples/serve-html/foo.html
+++ b/examples/serve-html/foo.html
@@ -1,0 +1,3 @@
+<html>
+  <h1>Foo</h1>
+</html>

--- a/examples/serve-html/index.ts
+++ b/examples/serve-html/index.ts
@@ -1,0 +1,9 @@
+import { join } from 'https://deno.land/std/path/mod.ts';
+
+Deno.serve(async (req) => {
+	if (req.url.endsWith('/foo')) {
+		return new Response(await Deno.readTextFile(join(import.meta.dirname, 'foo.html')));
+	} else {
+		return new Response(await Deno.readTextFile(join(import.meta.dirname, 'bar.html')));
+	}
+});

--- a/ext/workers/lib.rs
+++ b/ext/workers/lib.rs
@@ -91,6 +91,7 @@ pub struct UserWorkerCreateOptions {
     tmp_fs_config: Option<TmpFsConfig>,
 
     context: Option<JsonMap>,
+    #[serde(default)]
     static_patterns: Vec<String>,
 }
 

--- a/ext/workers/lib.rs
+++ b/ext/workers/lib.rs
@@ -91,6 +91,7 @@ pub struct UserWorkerCreateOptions {
     tmp_fs_config: Option<TmpFsConfig>,
 
     context: Option<JsonMap>,
+    static_patterns: Vec<String>,
 }
 
 #[op2(async)]
@@ -131,6 +132,7 @@ pub async fn op_user_worker_create(
             tmp_fs_config: maybe_tmp_fs_config,
 
             context,
+            static_patterns,
         } = opts;
 
         let user_worker_options = WorkerContextInitOpts {
@@ -165,7 +167,7 @@ pub async fn op_user_worker_create(
                 }
             }),
 
-            static_patterns: vec![],
+            static_patterns,
             import_map_path,
             timing: None,
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, static file patterns (ie. static files that can be added to the eszip bundles) can be specified only via CLI flag `--static`. This PR modifies create options for user worker to support providing static patterns.