### PR TITLE
fix(ext/ai): Invalid tensor length causing Segmentation Fault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6042,6 +6042,7 @@ dependencies = [
  "ort-sys",
  "rand",
  "reqwest 0.12.4",
+ "sb_ai_v8_utilities",
  "scopeguard",
  "serde",
  "tokenizers",
@@ -6050,6 +6051,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xxhash-rust",
+]
+
+[[package]]
+name = "sb_ai_v8_utilities"
+version = "0.1.0"
+dependencies = [
+ "deno_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ members = [
   "ext/env",
   "ext/core",
   "ext/os",
-  "ext/ai"
+  "ext/ai",
+  "ext/ai/utilities"
 ]
 
 [workspace.dependencies]
@@ -75,6 +76,7 @@ sb_env = { version = "0.1.0", path = "./ext/env"}
 sb_core = { version = "0.1.0", path = "./ext/core" }
 sb_os = { version = "0.1.0", path = "./ext/os" }
 sb_ai = { version = "0.1.0", path = "./ext/ai" }
+sb_ai_v8_utilities = { version = "0.1.0", path = "./ext/ai/utilities" }
 
 # crypto
 hkdf = "0.12.3"

--- a/ext/ai/Cargo.toml
+++ b/ext/ai/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 deno_core.workspace = true
 
 base_rt.workspace = true
+sb_ai_v8_utilities.workspace = true
 
 anyhow.workspace = true
 log.workspace = true

--- a/ext/ai/utilities/Cargo.toml
+++ b/ext/ai/utilities/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sb_ai_v8_utilities"
+version = "0.1.0"
+authors = ["Supabase <team@supabase.com>"]
+edition = "2021"
+license = "MIT"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+deno_core.workspace = true

--- a/ext/ai/utilities/lib.rs
+++ b/ext/ai/utilities/lib.rs
@@ -1,0 +1,26 @@
+use std::sync::Once;
+
+use deno_core::v8;
+
+pub fn v8_init() {
+    let platform = v8::new_unprotected_default_platform(0, false).make_shared();
+    v8::V8::initialize_platform(platform);
+    v8::V8::initialize();
+}
+
+pub fn v8_shutdown() {
+    // SAFETY: this is safe, because all isolates have been shut down already.
+    unsafe {
+        v8::V8::dispose();
+    }
+    v8::V8::dispose_platform();
+}
+
+pub fn v8_do(f: impl FnOnce()) {
+    static V8_INIT: Once = Once::new();
+    V8_INIT.call_once(|| {
+        v8_init();
+    });
+    f();
+    // v8_shutdown();
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, CRITICAL

## What is the current behavior?

If a `Tensor` received from JS land haves `data.length` not compatible with the `dims`  then when feeding the `Session` a **Segmentation Fault: 11** error will be panic!.

### How to reproduce it:
The tensors is successfully handled by `rust` as well `JsTensor::extract_ort_input` but error will be panic when feed this values into the `Session`.
```js
const t1 = new Tensor("float32", [], [1] ); // This one always will result in panic!
const t2 = new Tensor("float32", [0.1, 0.2, 0.3], [1, 2] ); // Session may safely throws while validating inputs
// ...
await core.ops.op_sb_ai_ort_run_session("123", { t1, t2 });
```
```bash
./scripts/run.sh: line 13: 12963 Segmentation fault: 11  RUST_BACKTRACE=full ./target/debug/edge-runtime "$@" start --main-service ./examples/main --event-worker ./examples/event-manager
```

## What is the new behavior?

Following the [ort api reference](https://docs.rs/ort/2.0.0-rc.2/ort/type.TensorRefMut.html#method.from_raw):  *The 'N' of elements 'T' must be equal to the Tensor's 'dims product'*.
So we must prevent it by checking if the `Tensor` length reflects in its `dim shape`

