### PR TITLE
fix: missing `libopenblas.so.0` 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/devcontainers/rust:dev-1-bookworm
 ARG TARGETPLATFORM
 
 RUN apt-get update && apt-get install -y build-essential cmake libclang-dev lldb \
-    nodejs npm hyperfine
+    nodejs npm hyperfine \
+    libblas-dev liblapack-dev libopenblas-dev
 
 COPY .env /tmp/.env
 COPY .devcontainer/install.sh /tmp/install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ARG GIT_V_TAG
 ARG PROFILE=release
 ARG FEATURES
 
-RUN apt-get update && apt-get install -y llvm-dev libclang-dev clang cmake binutils
+RUN apt-get update && apt-get install -y llvm-dev libclang-dev clang cmake binutils \
+    libblas-dev liblapack-dev libopenblas-dev
 
 WORKDIR /usr/src/edge-runtime
 
@@ -30,7 +31,10 @@ RUN objcopy --strip-debug \
 # Application runtime without ONNX
 FROM debian:bookworm-slim as edge-runtime-base
 
-RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl-dev \
+    libblas-dev liblapack-dev libopenblas-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get remove -y perl && apt-get autoremove -y
 
 COPY --from=builder /root/edge-runtime /usr/local/bin/edge-runtime


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`libopenblas` was introduced on #486 but was not added to container deps.

<details>
<summary>error log</summary>

```bash
$ ./scripts/run_dind.sh
edge-runtime: error while loading shared libraries: libopenblas.so.0: cannot open shared object file: No such file or directory
```

</details>

## What is the new behavior?

Install `libopenblas` to Devcontainer as well the Docker image.

---
*Question: Do we really need this `blas` lib?*