### PR TITLE
chore: skip s3 cred install step if the action is triggered by dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
         run: ./scripts/install_onnx.sh ${{ env.ONNXRUNTIME_VERSION }} linux x64 /tmp/onnxruntime
 
       - name: Install S3 credentials for testing
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: | 
+          github.actor != 'dependabot[bot]' &&
+          (
+            github.event_name != 'pull_request'
+            || github.event.pull_request.head.repo.full_name == github.repository
+          )
         run: |
           cd crates/fs/tests
           echo "S3FS_TEST_SUPABASE_STORAGE=true" >> .env


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

dependabot does not have access to the secrets in the repository.