### PR TITLE
fix: unblock `Deno.realPathSync`

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -653,8 +653,10 @@ where
         let build_file_system_fn =
             |base_fs: Arc<dyn deno_fs::FileSystem>| -> Result<Arc<dyn deno_fs::FileSystem>, AnyError> {
                 let tmp_fs = TmpFs::try_from(maybe_tmp_fs_config.unwrap_or_default())?;
-                let fs = PrefixFs::new("/tmp", tmp_fs, Some(base_fs))
-                    .tmp_dir("/tmp");
+                let tmp_fs_actual_path = tmp_fs.actual_path().to_path_buf();
+                let fs = PrefixFs::new("/tmp", tmp_fs.clone(), Some(base_fs))
+                    .tmp_dir("/tmp")
+                    .add_fs(tmp_fs_actual_path, tmp_fs);
 
                 Ok(if let Some(s3_fs) = maybe_s3_fs_config.map(S3Fs::new).transpose()? {
                     maybe_s3_fs = Some(s3_fs.clone());

--- a/crates/base/test_cases/use-tmp-fs-3/index.ts
+++ b/crates/base/test_cases/use-tmp-fs-3/index.ts
@@ -1,0 +1,15 @@
+const meowFile = await Deno.create('/tmp/meow');
+const meow = new TextEncoder().encode('meowmeow');
+await meowFile.write(meow);
+
+const meowRealPath = Deno.realPathSync('/tmp/meow');
+const meowFileContent = await Deno.readTextFile(meowRealPath);
+const isValid = meowFileContent == 'meowmeow';
+
+export default {
+    fetch() {
+        return new Response(null, {
+            status: isValid ? 200 : 500,
+        });
+    },
+};

--- a/crates/base/test_cases/user-worker-san-check/.blocklisted
+++ b/crates/base/test_cases/user-worker-san-check/.blocklisted
@@ -31,7 +31,6 @@ openSync
 readDirSync
 readLink
 readLinkSync
-realPathSync
 removeSync
 rename
 renameSync

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -2826,6 +2826,23 @@ async fn test_tmp_fs_usage() {
             TerminationToken::new()
         );
     }
+
+    {
+        integration_test!(
+            "./test_cases/main",
+            NON_SECURE_PORT,
+            "use-tmp-fs-3",
+            None,
+            None,
+            None,
+            None,
+            (|resp| async {
+                let resp = resp.unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }),
+            TerminationToken::new()
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/fs/impl/tmp_fs.rs
+++ b/crates/fs/impl/tmp_fs.rs
@@ -227,6 +227,12 @@ pub struct TmpFs {
     quota: Arc<Quota>,
 }
 
+impl TmpFs {
+    pub fn actual_path(&self) -> &Path {
+        self.root.path()
+    }
+}
+
 #[async_trait::async_trait(?Send)]
 impl deno_fs::FileSystem for TmpFs {
     fn cwd(&self) -> FsResult<PathBuf> {

--- a/ext/core/js/bootstrap.js
+++ b/ext/core/js/bootstrap.js
@@ -641,6 +641,7 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
 			'open': true,
 			'stat': true,
 			'realPath': true,
+			'realPathSync': true,
 			'create': true,
 			'remove': true,
 			'writeFile': true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Remove realPathSync from the blocklist.

Deno.realPath(Sync) returns a path on the actual filesystem (e.g. /tmp/.tmpe8EebZ/meow), so we need to add extra steps to ensure that prefixfs can route these paths to tmpfs.

closes FUNC-191