### PR TITLE
fix: update github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 jobs:

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,10 @@
 {
   "branches": [
-    "main"
+    "main",
+    {
+      "name": "develop",
+      "prerelease": true
+    }
   ],
   "plugins": [
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description
Now we have `develop` branch.
Any release that is published from this branch should be marked as `Pre-release`.