### PR TITLE
chore: add an integration test for byonm feature

### DIFF
--- a/crates/base/test_cases/byonm-typescript/meow.ts
+++ b/crates/base/test_cases/byonm-typescript/meow.ts
@@ -1,0 +1,25 @@
+import isodd from "is-odd";
+import { createServer } from "node:http";
+
+class Meow {
+  private meow: boolean;
+
+  constructor(odd: number) {
+    this.meow = isodd(odd);
+  }
+
+  getMeow() {
+    return this.meow;
+  }
+}
+
+const server = createServer((_, resp) => {
+  const meow = new Meow(33);
+  resp.writeHead(200, {
+    "content-type": "text-plain",
+  });
+  resp.write(meow.getMeow() ? "meow" : "meow!!");
+  resp.end();
+});
+
+server.listen(8080);

--- a/crates/base/test_cases/byonm-typescript/package.json
+++ b/crates/base/test_cases/byonm-typescript/package.json
@@ -1,0 +1,7 @@
+{
+  "workspaces": [],
+  "main": "meow.ts",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -3014,6 +3014,26 @@ async fn test_commonjs_express_websocket() {
 
 #[tokio::test]
 #[serial]
+async fn test_byonm_typescript() {
+  ensure_npm_package_installed("./test_cases/byonm-typescript").await;
+  integration_test!(
+    "./test_cases/main",
+    NON_SECURE_PORT,
+    "byonm-typescript",
+    None,
+    None,
+    None,
+    (|resp| async {
+      let resp = resp.unwrap();
+      assert_eq!(resp.status().as_u16(), 200);
+      assert_eq!(resp.text().await.unwrap().as_str(), "meow");
+    }),
+    TerminationToken::new()
+  );
+}
+
+#[tokio::test]
+#[serial]
 async fn test_supabase_ai_gte() {
   let tb = TestBedBuilder::new("./test_cases/main")
     .with_per_worker_policy(None)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## Description

This PR adds an integration test that loads typescript with byonm feature.

Note that the `npm:` prefix is not added in an import statement for `is-odd` package in meow.ts:
https://github.com/supabase/edge-runtime/blob/5bd4e8c2a2fa7f399664ff8abb45a5ce72659c31/crates/base/test_cases/byonm-typescript/meow.ts#L1-L2