### PR TITLE
fix: do not mention about unstable sloppy import flag

### DIFF
--- a/deno/graph_util.rs
+++ b/deno/graph_util.rs
@@ -813,7 +813,8 @@ fn enhanced_sloppy_imports_error_message(
         .resolve(specifier, SloppyImportsResolutionKind::Execution)?
         .as_suggestion_message();
       Some(format!(
-        "{} {} or run with --unstable-sloppy-imports",
+        // "{} {} or run with --unstable-sloppy-imports",
+        "{} {}",
         error,
         additional_message,
       ))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

edge runtime does not allow specifying Deno flags, so it is recommended not to make such an error message to avoid confusion for users.

Ref: https://supabase.slack.com/archives/C02KMRX22NR/p1740553071388899?thread_ts=1740552521.862859&cid=C02KMRX22NR