### PR TITLE
build(deps): bump ring from 0.17.7 to 0.17.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.11",
- "ring 0.17.7",
+ "ring 0.17.12",
  "time",
  "tokio",
  "tracing",
@@ -567,7 +567,7 @@ dependencies = [
  "once_cell",
  "p256 0.11.1",
  "percent-encoding",
- "ring 0.17.7",
+ "ring 0.17.12",
  "sha2",
  "subtle",
  "time",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -1870,7 +1870,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest 0.12.7",
- "ring 0.17.7",
+ "ring 0.17.12",
  "serde",
  "tar",
  "thiserror 2.0.8",
@@ -2083,7 +2083,7 @@ dependencies = [
  "p384",
  "p521",
  "rand",
- "ring 0.17.7",
+ "ring 0.17.12",
  "rsa",
  "sec1 0.7.3",
  "serde",
@@ -2280,7 +2280,7 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project",
- "ring 0.17.7",
+ "ring 0.17.12",
  "scopeguard",
  "serde",
  "smallvec",
@@ -2409,7 +2409,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "rand",
- "ring 0.17.7",
+ "ring 0.17.12",
  "serde_json",
  "tar",
  "tempfile",
@@ -3264,7 +3264,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand",
  "regex",
- "ring 0.17.7",
+ "ring 0.17.12",
  "ripemd",
  "rsa",
  "scrypt",
@@ -6285,7 +6285,7 @@ dependencies = [
  "bytes",
  "getrandom",
  "rand",
- "ring 0.17.7",
+ "ring 0.17.12",
  "rustc-hash 2.1.0",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -6662,16 +6662,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6845,7 +6845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.7",
+ "ring 0.17.12",
  "rustls-webpki 0.101.7",
  "sct 0.7.1",
 ]
@@ -6857,7 +6857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.7",
+ "ring 0.17.12",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -6872,7 +6872,7 @@ checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.7",
+ "ring 0.17.12",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -6962,7 +6962,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.12",
  "untrusted 0.9.0",
 ]
 
@@ -6972,7 +6972,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.12",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -7062,7 +7062,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.12",
  "untrusted 0.9.0",
 ]
 


### PR DESCRIPTION
## Description

bump ring from 0.17.7 to 0.17.12
ring 0.16.20 is tolerable as it is a dependency of `unsafe-proxy` feature.

https://github.com/supabase/edge-runtime/security/dependabot/53