### PR TITLE
fix(deno_facade): implement `get_host_defined_options` member on `EmbeddedModuleLoader`

### DIFF
--- a/crates/base/test_cases/issue-513/deno.json
+++ b/crates/base/test_cases/issue-513/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": [],
+  "imports": {
+    "postgres": "npm:postgres@^3.4.5"
+  }
+}

--- a/crates/base/test_cases/issue-513/index.ts
+++ b/crates/base/test_cases/issue-513/index.ts
@@ -1,0 +1,10 @@
+import postgres from "postgres";
+
+const sql = postgres({/* options */});
+console.log(sql);
+
+export default {
+  fetch() {
+    return new Response(null);
+  },
+};

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -2351,6 +2351,23 @@ async fn test_issue_456() {
 
 #[tokio::test]
 #[serial]
+async fn test_issue_513() {
+  let tb = TestBedBuilder::new("./test_cases/main").build().await;
+  let resp = tb
+    .request(|b| {
+      b.uri("/issue-513")
+        .body(Body::empty())
+        .context("can't make request")
+    })
+    .await
+    .unwrap();
+
+  assert_eq!(resp.status().as_u16(), StatusCode::OK);
+  tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
+}
+
+#[tokio::test]
+#[serial]
 async fn test_supabase_issue_29583() {
   integration_test!(
     "./test_cases/main",

--- a/crates/deno_facade/module_loader/standalone.rs
+++ b/crates/deno_facade/module_loader/standalone.rs
@@ -69,6 +69,7 @@ use eszip::deno_graph;
 use eszip::EszipRelativeFileBaseUrl;
 use eszip::ModuleKind;
 use eszip_trait::AsyncEszipDataRead;
+use ext_node::create_host_defined_options;
 use ext_node::DenoFsNodeResolverEnv;
 use ext_node::NodeExtInitServices;
 use ext_node::NodeRequireLoader;
@@ -299,6 +300,19 @@ impl ModuleLoader for EmbeddedModuleLoader {
         Err(err.into())
       }
       Err(err) => Err(err.into()),
+    }
+  }
+
+  fn get_host_defined_options<'s>(
+    &self,
+    scope: &mut deno_core::v8::HandleScope<'s>,
+    name: &str,
+  ) -> Option<deno_core::v8::Local<'s, deno_core::v8::Data>> {
+    let name = deno_core::ModuleSpecifier::parse(name).ok()?;
+    if self.shared.node_resolver.in_npm_package(&name) {
+      Some(create_host_defined_options(scope))
+    } else {
+      None
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Deno now uses a v8 API-based callback approach instead of a heuristic based on stack traces to distinguish the current execution context.
This callback is defined in the ModuleLoader trait and should have been implemented in EmbeddedModuleLoader, but was not. As a result, the current execution context was locked to Deno, which caused it to be unable to get some special keys (global, Buffer, etc...) that only exist on Node.

Fixes #513 