### PR TITLE
fix(ext/runtime): expose `Deno.createHttpClient`

### DIFF
--- a/crates/base/test_cases/issue-208/index.ts
+++ b/crates/base/test_cases/issue-208/index.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from 'jsr:@std/assert';
+
+export default {
+  async fetch(req: Request) {
+    const port = parseInt(req.headers.get('x-port') ?? '');
+    if (isNaN(port)) {
+      return new Response(null, {
+        status: 500,
+      });
+    }
+
+    const caCerts = [];
+
+    if (req.method === 'POST') {
+      const arr = await req.arrayBuffer();
+      const dec = new TextDecoder();
+      const ca = dec.decode(arr);
+      caCerts.push(ca);
+    }
+
+    const client = Deno.createHttpClient({
+      caCerts,
+    });
+
+    try {
+      const resp = await fetch(`https://localhost:${port}`, { client });
+      assertEquals(resp.status, 200);
+      return new Response(await resp.text());
+    } catch (ex) {
+      if (ex instanceof TypeError) {
+        return new Response(ex.toString(), {
+          status: 500,
+        });
+      }
+
+      return new Response(null, {
+        status: 500,
+      });
+    }
+  },
+};

--- a/crates/base/test_cases/issue-208/index.ts
+++ b/crates/base/test_cases/issue-208/index.ts
@@ -1,8 +1,8 @@
-import { assertEquals } from 'jsr:@std/assert';
+import { assertEquals } from "jsr:@std/assert";
 
 export default {
   async fetch(req: Request) {
-    const port = parseInt(req.headers.get('x-port') ?? '');
+    const port = parseInt(req.headers.get("x-port") ?? "");
     if (isNaN(port)) {
       return new Response(null, {
         status: 500,
@@ -11,7 +11,7 @@ export default {
 
     const caCerts = [];
 
-    if (req.method === 'POST') {
+    if (req.method === "POST") {
       const arr = await req.arrayBuffer();
       const dec = new TextDecoder();
       const ca = dec.decode(arr);

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -3905,7 +3905,6 @@ impl TlsExt for Option<Tls> {
     assert!(self.is_some());
     let certs =
       rustls_pemfile::certs(&mut std::io::BufReader::new(TLS_LOCALHOST_CERT))
-        .into_iter()
         .flatten()
         .collect();
     let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(

--- a/ext/runtime/js/denoOverrides.js
+++ b/ext/runtime/js/denoOverrides.js
@@ -2,6 +2,7 @@ import * as net from "ext:deno_net/01_net.js";
 import * as tls from "ext:deno_net/02_tls.js";
 import * as timers from "ext:deno_web/02_timers.js";
 import * as fs from "ext:deno_fs/30_fs.js";
+import { createHttpClient } from "ext:deno_fetch/22_http_client.js";
 import { osCalls } from "ext:os/os.js";
 import * as io from "ext:deno_io/12_io.js";
 import * as permissions from "ext:runtime/permissions.js";
@@ -95,6 +96,7 @@ const ioVars = {
 };
 
 const denoOverrides = {
+  createHttpClient,
   serve,
   serveHttp,
   upgradeWebSocket,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Exposing `Deno.createHttpClient` since it's stable on Deno 2.x.

Closes #208 
