### PR TITLE
feat: allow enabling the unstable sloppy imports

### DIFF
--- a/deno/lib.rs
+++ b/deno/lib.rs
@@ -115,6 +115,10 @@ impl DenoOptions {
     self.builder.unstable_detect_cjs.unwrap_or_default()
   }
 
+  pub fn unstable_sloppy_imports(&self) -> bool {
+    self.workspace().has_unstable("sloppy-imports")
+  }
+
   fn byonm_enabled(&self) -> bool {
     self.node_modules_dir().ok().flatten() == Some(NodeModulesDirMode::Manual)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

Allow enabling unstable sloppy imports to fix the issue mentioned in https://github.com/denoland/deno/issues/28930.
You can enable it by specifying `sloppy-imports` in the unstable section of deno.json.
```json
{
}
```