### PR TITLE
fix: allow to specify the file API to expose directly

### DIFF
--- a/ext/runtime/js/bootstrap.js
+++ b/ext/runtime/js/bootstrap.js
@@ -684,6 +684,12 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
       apisToBeOverridden["readTextFileSync"] = true;
     }
 
+    if (ctx?.fileAPIs && ctx.fileAPIs instanceof Array) {
+      for (const api of ctx.fileAPIs) {
+        apisToBeOverridden[api] = true;
+      }
+    }
+
     const apiNames = ObjectKeys(apisToBeOverridden);
 
     for (const name of apiNames) {

--- a/ext/runtime/js/denoOverrides.js
+++ b/ext/runtime/js/denoOverrides.js
@@ -93,6 +93,7 @@ const ioVars = {
   stdout: io.stdout,
   stderr: io.stderr,
   stdin: io.stdin,
+  SeekMode: io.SeekMode,
 };
 
 const denoOverrides = {
@@ -111,6 +112,7 @@ const denoOverrides = {
   errors: errors,
   refTimer: timers.refTimer,
   unrefTimer: timers.unrefTimer,
+
   isatty: (_arg) => false,
   ...ioVars,
   ...fsVars,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

* Allows the main script to directly pass in the File API to be exposed.
```typescript
return await EdgeRuntime.userWorkers.create({
  ...
  context: {
    ...
    fileAPIs: [
      "openSync",
      "removeSync",
      "readSync",
      "writeSync",
      "seekSync",
      "truncateSync",
      "syncDataSync",
      "statSync",
      "lockSync",
      "unlockSync",
    ],
  },
});
```

* `Deno.SeekMode` has been exposed
