### PR TITLE
fix: bring back decorator flag in bundle command

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -305,6 +305,14 @@ fn get_bundle_command() -> Command {
       arg!(--"import-map" <Path>).help("(DEPRECATED) Path to import map file"),
     )
     .arg(
+      arg!(--"decorator" <TYPE>)
+        .help(concat!(
+          "(DEPRECATED) Type of decorator to use on the main worker and event worker. ",
+          "If not specified, the decorator feature is disabled."
+        ))
+        .value_parser(["tc39", "typescript", "typescript_with_metadata"]),
+    )
+    .arg(
       arg!(--"checksum" <KIND>)
         .env("EDGE_RUNTIME_BUNDLE_CHECKSUM")
         .help("Hash function to use when checksum the contents")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -272,12 +272,26 @@ fn main() -> Result<ExitCode, anyhow::Error> {
           sub_matches.get_one::<String>("output").cloned().unwrap();
         let import_map_path =
           sub_matches.get_one::<String>("import-map").cloned();
+        let decorator = sub_matches.get_one::<String>("decorator").cloned();
         let static_patterns =
           if let Some(val_ref) = sub_matches.get_many::<String>("static") {
             val_ref.map(|s| s.as_str()).collect::<Vec<&str>>()
           } else {
             vec![]
           };
+
+        if import_map_path.is_some() {
+          warn!(concat!(
+            "Specifying import_map through flags is no longer supported. ",
+            "Please use deno.json instead."
+          ))
+        }
+        if decorator.is_some() {
+          warn!(concat!(
+            "Specifying decorator through flags is no longer supported. ",
+            "Please use deno.json instead."
+          ))
+        }
 
         let entrypoint_script_path = sub_matches
           .get_one::<String>("entrypoint")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

It is easier to mark it as deprecated than to handle it directly in supabase/cli.

Context: https://github.com/supabase/cli/pull/3537