### PR TITLE
fix: emit warn when using some sync apis in async callback

### DIFF
--- a/ext/runtime/js/bootstrap.js
+++ b/ext/runtime/js/bootstrap.js
@@ -408,7 +408,9 @@ const MAKE_HARD_ERR_FN = (msg) => {
 const DENIED_DENO_FS_API_LIST = ObjectKeys(fsVars)
   .reduce(
     (acc, it) => {
-      acc[it] = MAKE_HARD_ERR_FN(`Deno.${it} is blocklisted`);
+      if (acc[it] !== void 0) {
+        acc[it] = MAKE_HARD_ERR_FN(`Deno.${it} is blocklisted`);
+      }
       return acc;
     },
     {},
@@ -685,9 +687,8 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
     };
 
     if (ctx?.useReadSyncFileAPI) {
-      apisToBeOverridden["readFileSync"] = true;
-      apisToBeOverridden["readTextFileSync"] = true;
-      apisToBeOverridden["openSync"] = true;
+      apisToBeOverridden["readFileSync"] = "warnIfRuntimeIsAlreadyInit";
+      apisToBeOverridden["readTextFileSync"] = "warnIfRuntimeIsAlreadyInit";
     }
 
     const apiNames = ObjectKeys(apisToBeOverridden);
@@ -719,6 +720,20 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
                 return originalFn(...args);
               } else {
                 return blocklistedFn();
+              }
+            };
+            break;
+          }
+          case "warnIfRuntimeIsAlreadyInit": {
+            const originalFn = Deno[name];
+            Deno[name] = (...args) => {
+              if (ops.op_is_runtime_init()) {
+                return originalFn(...args);
+              } else {
+                globalThis.console.error(
+                  `WARNING: Do not use Deno.${name} inside the async callback. This will be disallowed in the future.\nUse the async version instead.`,
+                );
+                return originalFn(...args);
               }
             };
             break;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR makes a warning message be emitted when the following sync APIs are used in the async callback:
* Deno.readFileSync
* Deno.readTextFileSync
