### PR TITLE
fix: allow call sync file apis in `/s3` prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "base",
+ "base_rt",
  "ctor",
  "deno",
  "deno_ast",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -20,6 +20,7 @@ deno_semver.workspace = true
 
 eszip_trait.workspace = true
 
+base_rt.workspace = true
 ext_node.workspace = true
 
 anyhow.workspace = true

--- a/crates/fs/tests/fixture/get/index.ts
+++ b/crates/fs/tests/fixture/get/index.ts
@@ -1,10 +1,22 @@
 export default {
   async fetch(req: Request) {
     const url = new URL(req.url);
+    const sync = url.searchParams.get("sync") == "true";
     const bucketName = Deno.env.get("S3FS_TEST_BUCKET_NAME")!;
     const key = url.pathname.split("/").slice(2).join("/");
-    const f = await Deno.open(`/s3/${bucketName}/${key}`);
 
-    return new Response(f.readable, { status: 200 });
+    if (sync) {
+      try {
+        return new Response(Deno.readFileSync(`/s3/${bucketName}/${key}`), {
+          status: 200,
+        });
+      } catch (err) {
+        console.error(err);
+        return new Response(null, { status: 500 });
+      }
+    } else {
+      const f = await Deno.open(`/s3/${bucketName}/${key}`);
+      return new Response(f.readable, { status: 200 });
+    }
   },
 };

--- a/crates/fs/tests/fixture/main_with_s3fs/index.ts
+++ b/crates/fs/tests/fixture/main_with_s3fs/index.ts
@@ -66,6 +66,9 @@ export default {
         noModuleCache,
         envVars,
         s3FsConfig,
+        context: {
+          useReadSyncFileAPI: true,
+        },
       });
     };
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR allows calling the sync file API using the path with the `/s3` prefix.
Note that the invocation will fail if sync apis are called from inside an async callback.