### PR TITLE
fix: make initial/max heap size configurable for main/event worker

### DIFF
--- a/crates/base/src/deno_runtime.rs
+++ b/crates/base/src/deno_runtime.rs
@@ -814,7 +814,7 @@ where
                 let initial_heap_size = initial_heap_size.get().cloned().unwrap_or_default();
                 let max_heap_size = max_heap_size.get().cloned().unwrap_or_default();
 
-                if initial_heap_size > 0 && max_heap_size > 0 {
+                if max_heap_size > 0 {
                     create_params = Some(v8::CreateParams::default().heap_limits(
                         mib_to_bytes(initial_heap_size) as usize,
                         mib_to_bytes(max_heap_size) as usize,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR makes it possible to configure the initial/max heap size of main/event worker through environment variables.

* EDGE_RUNTIME_MAIN_WORKER_INITIAL_HEAP_SIZE_MIB
* EDGE_RUNTIME_MAIN_WORKER_MAX_HEAP_SIZE_MIB
* EDGE_RUNTIME_EVENT_WORKER_INITIAL_HEAP_SIZE_MIB
* EDGE_RUNTIME_EVENT_WORKER_MAX_HEAP_SIZE_MIB

To set the heap, you must set both `EDGE_RUNTIME_*_WORKER_INITIAL_HEAP_SIZE_MIB` and `EDGE_RUNTIME_*_WORKER_MAX_HEAP_SIZE_MIB`.

Please note that these values must be set in megabytes.