### PR TITLE
fix: promise returned by `getRuntimeMetrics` never resolved

### DIFF
--- a/crates/base_rt/src/lib.rs
+++ b/crates/base_rt/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use cpu_timer::get_thread_time;
 use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
+use deno_core::futures::task::AtomicWaker;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::V8CrossThreadTaskSpawner;
@@ -194,3 +195,6 @@ impl BlockingScopeCPUUsageMetricExt for &mut OpState {
     })
   }
 }
+
+#[derive(Debug, Clone)]
+pub struct RuntimeWaker(pub Arc<AtomicWaker>);

--- a/ext/runtime/lib.rs
+++ b/ext/runtime/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use base_mem_check::WorkerHeapStatistics;
 use base_rt::DropToken;
 use base_rt::RuntimeState;
+use base_rt::RuntimeWaker;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
@@ -126,7 +127,7 @@ impl WorkerMetricSource {
       let state = runtime.op_state();
       let state_mut = state.borrow_mut();
 
-      state_mut.waker.clone()
+      state_mut.borrow::<RuntimeWaker>().0.clone()
     };
 
     Self { handle, waker }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

v8 Isolate has a flag internally to check if a pending interruption request exists, but this flag is recorded as thread-local state, and if Isolate is executed in another thread by a locker, this state does not carry over.

Therefore, in edge-runtime, lines existed to force the interruption flag to be set by calling a dummy interruption request under certain conditions, but when interruptions were requested via op_runtime_metrics, this flag was not set due to a subtle issue.
As a result, the interruption callback was never called and the promise never transitioned to the resolved state.
This PR fixes these issues.
