### PR TITLE
fix: disable pointer compression

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [env]
+RUSTY_V8_MIRROR = "https://github.com/supabase/rusty_v8/releases/download"
 # https://supabase.com/docs/guides/functions/limits
 SUPABASE_RESOURCE_LIMIT_MEM_MB = "256"
 SUPABASE_RESOURCE_LIMIT_LOW_MEM_MULTIPLIER = "5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8201,8 +8201,7 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "0.97.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb417c2cd20684f18b185085c876d379318893461c17d319948a0a5f221f0b50"
+source = "git+https://github.com/supabase/rusty_v8?tag=v0.97.1#3bd1448f9d44081cc88b5ad3f22b916efc667a8f"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ serial_test = "3.0.0"
 [patch.crates-io]
 # If the PR is merged upstream, remove the line below.
 deno_core = { git = "https://github.com/supabase/deno_core", branch = "293-supabase" }
+v8 = { git = "https://github.com/supabase/rusty_v8", tag = "v0.97.1" }
 eszip = { git = "https://github.com/supabase/eszip", branch = "fix-pub-vis-0-72-2" }
 
 [profile.dind]

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -3429,7 +3429,7 @@ async fn test_should_be_able_to_trigger_early_drop_with_mem() {
     let resp = tb
         .request(|b| {
             b.uri("/early-drop-mem")
-                .header("x-memory-limit-mb", HeaderValue::from_static("20"))
+                .header("x-memory-limit-mb", HeaderValue::from_static("22"))
                 .body(Body::empty())
                 .context("can't make request")
         })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

The combination of `v8_enable_pointer_compression` and `v8_enable_pointer_compression_shared_cage` limits the total heap size to 4 GiB per process, so it is best to disable them.

Ref: https://github.com/denoland/rusty_v8/pull/1593
Ref 2: https://v8.dev/blog/v8-release-92#shared-pointer-compression-cage
