### PR TITLE
fix: if runtime is created with old eszip, emit warning message

### DIFF
--- a/crates/deno_facade/eszip/migrate.rs
+++ b/crates/deno_facade/eszip/migrate.rs
@@ -60,7 +60,10 @@ pub async fn try_migrate_if_needed(
           }
         };
 
-        result
+        result.map(|mut it| {
+          it.set_migrated(true);
+          it
+        })
       }
 
       None => Err(anyhow!("failed to migrate (found unexpected error)")),

--- a/crates/deno_facade/eszip/mod.rs
+++ b/crates/deno_facade/eszip/mod.rs
@@ -97,6 +97,7 @@ async fn read_u32<R: futures::io::AsyncRead + Unpin>(
 pub struct LazyLoadableEszip {
   eszip: EszipV2,
   maybe_data_section: Option<Arc<EszipDataSection>>,
+  migrated: bool,
 }
 
 impl std::ops::Deref for LazyLoadableEszip {
@@ -122,6 +123,7 @@ impl Clone for LazyLoadableEszip {
         options: self.eszip.options,
       },
       maybe_data_section: self.maybe_data_section.clone(),
+      migrated: false,
     }
   }
 }
@@ -156,6 +158,7 @@ impl LazyLoadableEszip {
     Self {
       eszip,
       maybe_data_section,
+      migrated: false,
     }
   }
 
@@ -214,6 +217,15 @@ impl LazyLoadableEszip {
     }
 
     Ok(())
+  }
+
+  pub fn migrated(&self) -> bool {
+    self.migrated
+  }
+
+  pub fn set_migrated(&mut self, value: bool) -> &mut Self {
+    self.migrated = value;
+    self
   }
 }
 

--- a/crates/deno_facade/module_loader/mod.rs
+++ b/crates/deno_facade/module_loader/mod.rs
@@ -16,6 +16,7 @@ pub mod standalone;
 pub mod util;
 
 pub struct RuntimeProviders {
+  pub migrated: bool,
   pub module_loader: Rc<dyn ModuleLoader>,
   pub node_services: NodeExtInitServices,
   pub npm_snapshot: Option<ValidSerializedNpmResolutionSnapshot>,

--- a/crates/deno_facade/module_loader/standalone.rs
+++ b/crates/deno_facade/module_loader/standalone.rs
@@ -552,6 +552,7 @@ pub async fn create_module_loader_for_eszip(
   permissions_options: PermissionsOptions,
   include_source_map: bool,
 ) -> Result<RuntimeProviders, AnyError> {
+  let migrated = eszip.migrated();
   let current_exe_path = std::env::current_exe().unwrap();
   let current_exe_name =
     current_exe_path.file_name().unwrap().to_string_lossy();
@@ -810,6 +811,7 @@ pub async fn create_module_loader_for_eszip(
   });
 
   Ok(RuntimeProviders {
+    migrated,
     module_loader: module_loader.clone(),
     node_services: NodeExtInitServices {
       node_require_loader: module_loader.clone(),

--- a/ext/runtime/js/bootstrap.js
+++ b/ext/runtime/js/bootstrap.js
@@ -592,8 +592,8 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
   core.addMainModuleHandler((main) => {
     if (migrated) {
       globalThis.console.warn(
-        "It appears that the function is bundled from the old version of cli.\n",
-        "Compatibility issues may arise, so it is recommended to re-bundle using the latest version of cli.",
+        "It appears this function was deployed using an older version of Supabase CLI.\n",
+        "For best performance and compatibility we recommend re-deploying the function using the latest version of the CLI.",
       );
     }
 

--- a/ext/runtime/js/bootstrap.js
+++ b/ext/runtime/js/bootstrap.js
@@ -520,6 +520,7 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
    * target: string,
    * kind: 'user' | 'main' | 'event',
    * inspector: boolean,
+   * migrated: boolean,
    * debug: boolean,
    * version: {
    * 	runtime: string,
@@ -532,6 +533,7 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
    * }}
    */
   const {
+    migrated,
     target,
     kind,
     version,
@@ -588,6 +590,13 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
   setLanguage("en");
 
   core.addMainModuleHandler((main) => {
+    if (migrated) {
+      globalThis.console.warn(
+        "It appears that the function is bundled from the old version of cli.\n",
+        "Compatibility issues may arise, so it is recommended to re-bundle using the latest version of cli.",
+      );
+    }
+
     // Find declarative fetch handler
     if (ObjectHasOwn(main, "default")) {
       registerDeclarativeServer(main.default);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

If the user created the runtime using old eszip, then print a warning message that they are using an older version.