### PR TITLE
fix: add an option that suppresses eszip migration warning

### DIFF
--- a/ext/runtime/js/bootstrap.js
+++ b/ext/runtime/js/bootstrap.js
@@ -590,7 +590,7 @@ globalThis.bootstrapSBEdge = (opts, ctx) => {
   setLanguage("en");
 
   core.addMainModuleHandler((main) => {
-    if (migrated) {
+    if (migrated && !ctx?.suppressEszipMigrationWarning) {
       globalThis.console.warn(
         "It appears this function was deployed using an older version of Supabase CLI.\n",
         "For best performance and compatibility we recommend re-deploying the function using the latest version of the CLI.",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -43,6 +43,14 @@ interface PermissionsOptions {
   allow_import?: string[] | null;
 }
 
+interface UserWorkerCreateContext {
+  sourceMap?: boolean | null;
+  importMapPath?: string | null;
+  shouldBootstrapMockFnThrowError?: boolean | null;
+  suppressEszipMigrationWarning?: boolean | null;
+  useReadSyncFileAPI?: boolean | null;
+}
+
 interface UserWorkerCreateOptions {
   servicePath?: string | null;
   envVars?: string[][] | [string, string][] | null;
@@ -67,7 +75,7 @@ interface UserWorkerCreateOptions {
   s3FsConfig?: S3FsConfig | null;
   tmpFsConfig?: TmpFsConfig | null;
 
-  context?: { [key: string]: unknown } | null;
+  context?: UserWorkerCreateContext | null;
 }
 
 interface HeapStatistics {
@@ -178,5 +186,6 @@ declare namespace Supabase {
 declare namespace Deno {
   export namespace errors {
     class WorkerRequestCancelled extends Error {}
+    class WorkerAlreadyRetired extends Error {}
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

Adds an option to suppress the warning added in #581.

Usage:
```typescript
await EdgeRuntime.userWorkers.create({
  servicePath,
  // ..snip..
  context: {
    suppressEszipMigrationWarning: true // 👈
  }
});
```