### PR TITLE
chore: add `fail-on-error: false` to coverall upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Coveralls upload
         uses: coverallsapp/github-action@v2
         with:
+          fail-on-error: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
           debug: true


### PR DESCRIPTION
Context: https://supabase.slack.com/archives/C02KMRX22NR/p1755159305940969