### PR TITLE
fix: Otel symbol may not be exposed in some cases

### DIFF
--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -7,8 +7,10 @@ import { context, propagation } from "npm:@opentelemetry/api";
 import { W3CBaggagePropagator } from "npm:@opentelemetry/core@1";
 
 // @ts-ignore See https://github.com/denoland/deno/issues/28082
-globalThis[Symbol.for("opentelemetry.js.api.1")].propagation =
-  new W3CBaggagePropagator();
+if (globalThis[Symbol.for("opentelemetry.js.api.1")]) {
+  globalThis[Symbol.for("opentelemetry.js.api.1")].propagation =
+    new W3CBaggagePropagator();
+}
 
 console.log("main function started");
 console.log(Deno.version);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

The main script example explicitly finds the Otel symbol and assigns W3CBaggagePropagator to its propagator key, but if Otel related environment variables are not specified, the Otel symbol may not exist, which could cause TypeError in this line.