### PR TITLE
chore: introduce a new action that closes stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: >
+            🔕 This issue is stale because it has been open 60 days with no activity.
+            Remove stale label or comment or this will be closed in 7 days.
+          stale-pr-message: >
+            🔕 This PR is stale because it has been open 60 days with no activity.
+            Remove stale label or comment or this will be closed in 7 days.
+          days-before-stale: 60
+          days-before-close: 7


### PR DESCRIPTION
## What kind of change does this PR introduce?

Github Workflow

## Description

Mark an issue/PR as stale after 60 days without activity and close the issue/PR if there is no activity for 7 days after that.