### PR TITLE
fix(byonm): Deno.readFile* fails to recognize paths correctly when called from a node package

### DIFF
--- a/crates/base/src/runtime/mod.rs
+++ b/crates/base/src/runtime/mod.rs
@@ -658,6 +658,10 @@ where
           base_url,
         } = rt_provider;
 
+        let node_modules = metadata
+          .node_modules()
+          .ok()
+          .flatten();
         let entrypoint = metadata.entrypoint.clone();
         let main_module_url = match entrypoint.as_ref() {
           Some(Entrypoint::Key(key)) => base_url.join(key)?,
@@ -717,6 +721,7 @@ where
 
         let (fs, s3_fs) = build_file_system_fn(if is_user_worker {
           Arc::new(StaticFs::new(
+            node_modules,
             static_files,
             if matches!(entrypoint, Some(Entrypoint::ModuleCode(_)) | None)
               && is_some_entry_point

--- a/deno/standalone/binary.rs
+++ b/deno/standalone/binary.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum NodeModules {
   Managed {
     /// Relative path for the node_modules directory in the vfs.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description
Node dependencies used in byonm mode may internally attempt to read other files within their own package via the file system API.
This PR enables such attempts.