### PR TITLE
fix: add `otel_attributes` to event metadata

### DIFF
--- a/ext/event_worker/events.rs
+++ b/ext/event_worker/events.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 
 use base_mem_check::MemCheckState;
@@ -106,6 +107,7 @@ impl WorkerEvents {
 pub struct EventMetadata {
   pub service_path: Option<String>,
   pub execution_id: Option<Uuid>,
+  pub otel_attributes: Option<HashMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR allows the event worker to get the otel attribute of the user worker that sent the event.

Related to FUNC-289