### PR TITLE
fix(cli): introduce timeout flag for the bundle command

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -364,6 +364,11 @@ fn get_bundle_command() -> Command {
         .default_value("false")
         .value_parser(FalseyValueParser::new()),
     )
+    .arg(
+      arg!(--"timeout" <SECONDS>)
+        .help("Maximum time in seconds that can be waited for the bundle to complete.")
+        .value_parser(value_parser!(u64).range(..u64::MAX))
+    )
 }
 
 fn get_unbundle_command() -> Command {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

This PR introduces a timeout flag to the bundle command to prevent the process from getting stuck in an infinite wait state.
If this flag is not specified, it will wait indefinitely until the bundle is complete as before.

### Usage

`<executable> bundle --timeout <seconds> ...`
