### PR TITLE
fix(supervisor): do not try to divide 0 by 2

### DIFF
--- a/crates/base/src/worker/supervisor/strategy_per_worker.rs
+++ b/crates/base/src/worker/supervisor/strategy_per_worker.rs
@@ -188,7 +188,7 @@ pub async fn supervise(args: Arguments) -> (ShutdownReason, i64) {
     worker_timeout_ms
   };
 
-  let wall_clock_duration = Duration::from_millis(worker_timeout_ms);
+  let wall_clock_duration = Duration::from_millis(wall_clock_limit_ms);
 
   // Split wall clock duration into 2 intervals.
   // At the first interval, we will send a msg to retire the worker.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

When the inspect-mode flag is enabled in the cli, `worker_timeout_ms` becomes 0 ([link](https://github.com/supabase/cli/blob/baeae4730442af35f0d91ca9654bf4f123c30206/internal/functions/serve/serve.go#L141)), but we've assigned this directly to `wall_clock_duration`.

Context: https://discord.com/channels/839993398554656828/1414639461291135048
