### PR TITLE
feat: Add configurable functions path via SUPABASE_FUNCTIONS_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The edge runtime can be divided into two runtimes with different purposes.
   - Limits are required to be set such as: Memory and Timeouts.
   - Has access to environment variables explictly allowed by the main runtime.
 
+## Configuration
+
+### Environment Variables
+
+- `SUPABASE_FUNCTIONS_PATH` - Custom path for function compilation directory. 
+  - Default: `/var/tmp/sb-compile-<executable-name>` on Unix/Linux, `%TEMP%\sb-compile-<executable-name>` on Windows
+  - Example: `SUPABASE_FUNCTIONS_PATH=/home/deno/functions` (useful for Kubernetes deployments)
+
 ## Developers
 
 To learn how to build / test Edge Runtime, visit [DEVELOPERS.md](DEVELOPERS.md)

--- a/crates/deno_facade/module_loader/standalone.rs
+++ b/crates/deno_facade/module_loader/standalone.rs
@@ -579,12 +579,18 @@ pub async fn create_module_loader_for_eszip(
   .transpose()?
   .unwrap_or_default();
 
-  let root_path = if cfg!(target_family = "unix") {
-    PathBuf::from("/var/tmp")
-  } else {
-    std::env::temp_dir()
-  }
-  .join(format!("sb-compile-{}", current_exe_name));
+  let root_path = match std::env::var("SUPABASE_FUNCTIONS_PATH") {
+    Ok(custom_path) => PathBuf::from(custom_path),
+    Err(_) => {
+      // Default behavior: use platform-specific temp directory
+      if cfg!(target_family = "unix") {
+        PathBuf::from("/var/tmp")
+      } else {
+        std::env::temp_dir()
+      }
+      .join(format!("sb-compile-{}", current_exe_name))
+    }
+  };
 
   let node_modules = metadata.node_modules()?;
   let root_dir_url =


### PR DESCRIPTION
## Problem

Currently, the edge-runtime has a hardcoded path for function compilation at `/var/tmp/sb-compile-<executable-name>`. This creates compatibility issues with deployment scenarios that require custom paths, particularly:

1. **Kubernetes deployments** using community Helm charts that mount functions at different paths (e.g., `/home/deno/functions`)  
2. **Restricted environments** where `/var/tmp` may not be writable or available
3. **Custom Docker deployments** that prefer different directory structures

## Solution

This PR adds a configurable `SUPABASE_FUNCTIONS_PATH` environment variable that allows users to override the default function compilation path while maintaining full backward compatibility.

### Changes Made:

1. **Modified `standalone.rs`**: Added environment variable check for `SUPABASE_FUNCTIONS_PATH` with fallback to existing behavior
2. **Updated `README.md`**: Added documentation for the new environment variable
3. **Maintained backward compatibility**: Existing deployments continue to work unchanged

### Code Changes:

```rust
let root_path = match std::env::var("SUPABASE_FUNCTIONS_PATH") {
  Ok(custom_path) => PathBuf::from(custom_path),
  Err(_) => {
    // Default behavior: use platform-specific temp directory
    if cfg!(target_family = "unix") {
      PathBuf::from("/var/tmp")
    } else {
      std::env::temp_dir()
    }
    .join(format!("sb-compile-{}", current_exe_name))
  }
};
```

## Usage

### Default behavior (unchanged):
- Unix/Linux: `/var/tmp/sb-compile-edge-runtime`
- Windows: `%TEMP%\sb-compile-edge-runtime`

### Custom path:
```bash
export SUPABASE_FUNCTIONS_PATH=/home/deno/functions
./edge-runtime start --main-service /path/to/function
```

### Kubernetes example:
```yaml
env:
  - name: SUPABASE_FUNCTIONS_PATH
    value: "/home/deno/functions"
```

## Testing

- ✅ Maintains backward compatibility (no environment variable set)
- ✅ Respects custom path when `SUPABASE_FUNCTIONS_PATH` is set
- ✅ Documentation updated

## Benefits

1. **Kubernetes compatibility**: Enables edge functions to work with community Helm charts
2. **Deployment flexibility**: Allows custom paths for different deployment scenarios  
3. **Zero breaking changes**: Existing deployments continue working without modification
4. **Security**: Enables deployment in environments with restricted `/var/tmp` access

## Related Issues

- Addresses hardcoded path incompatibility reported in supabase-community/supabase-kubernetes#117
- Enables edge functions support for community Kubernetes deployments

---

**Reported-by**: kshivang  
**Tested with**: edge-runtime v1.69.6+