### PR TITLE
fix: CPUTimer wrong `new()` definition for 'non linux' os

### DIFF
--- a/crates/cpu_timer/src/lib.rs
+++ b/crates/cpu_timer/src/lib.rs
@@ -81,7 +81,7 @@ pub struct CPUTimer {}
 
 impl CPUTimer {
   #[cfg(not(target_os = "linux"))]
-  pub fn new(_: u64) -> Result<Self, Error> {
+  pub fn new() -> Result<Self, Error> {
     log::error!("CPU timer: not enabled (need Linux)");
     Ok(Self {})
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently the non linux version of `CPUTimer::new` has a required parameter while the other version don't

## What is the new behavior?

Remove the `i64` parameter
