### PR TITLE
fix(v1/cli): reflect exit code correctly when running unbundle command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -363,9 +363,10 @@ fn main() -> Result<ExitCode, anyhow::Error> {
                         "Eszip extracted successfully inside path {}",
                         output_path.to_str().unwrap()
                     );
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::FAILURE
                 }
-
-                ExitCode::SUCCESS
             }
 
             _ => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Returning an exit code of 0 when unbundling stops due to an error is inappropriate.

Context: https://supabase.slack.com/archives/C02KMRX22NR/p1759302556828059?thread_ts=1759231651.657819&cid=C02KMRX22NR