### PR TITLE
docs: remove instructions for orb

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -40,18 +40,6 @@ docker build -t supabase/edge-runtime .
 docker run -it --rm -p 9000:9000 -v ./examples/:/examples supabase/edge-runtime start --main-service /examples/main
 ```
 
-Another option would be to install [Orb](https://docs.orbstack.dev/install) and
-use an [Orbstack Machine](https://docs.orbstack.dev/machines/) to run a Linux
-Machine.
-
-First create a machine:
-
-```
-orb create ubuntu new-ubuntu
-```
-
-and run `orb` in the base directory to enter the virtual machine.
-
 ## How to run tests
 
 ```sh


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs

## What is the current content?

- we include brief instructions on using `orb` in `DEVELOPERS.md` but they are lacking detail

## What is the new behavior?

- removed section on `orb`

alternatively we could improve the instructions to include:

- `sudo apt update && sudo apt install -y wget libopenblas-dev nodejs npm`
- `source .env`
- `TARGETPLATFORM=linux/arm64; ./scripts/install_onnx.sh "$ONNXRUNTIME_VERSION" linux "$TARGETPLATFORM" /tmp/onnxruntime`
- `sudo cp /tmp/onnxruntime/lib/libonnxruntime.so* /usr/lib/`
- more steps I haven't yet figured out to solve `4` remaining ort related tests

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
