### PR TITLE
fix(docs): discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We welcome contributions to Supabase Edge Runtime!
 
 To get started either open an issue on
 [GitHub](https://github.com/supabase/edge-runtime/issues) or drop us a message
-on [Discord](https://discord.com/invite/R7bSpeBSJE)
+on [Discord](https://discord.supabase.com)
 
 Edge Runtime follows Supabase's
 [Code of Conduct](https://github.com/supabase/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Updated Discord link to the new invite URL.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
