### PR TITLE
fix: request idle timeout should be applied differently for worker kind

### DIFF
--- a/cli/src/flags.rs
+++ b/cli/src/flags.rs
@@ -208,7 +208,15 @@ fn get_start_command() -> Command {
         .value_parser(value_parser!(u64)),
     )
     .arg(
-      arg!(--"request-idle-timeout" <MILLISECONDS>)
+      arg!(--"main-worker-request-idle-timeout" <MILLISECONDS>)
+        .help(concat!(
+          "Maximum time in milliseconds that can be waited from when a ",
+          "worker takes over the request (disabled by default)"
+        ))
+        .value_parser(value_parser!(u64)),
+    )
+    .arg(
+      arg!(--"user-worker-request-idle-timeout" <MILLISECONDS>)
         .help(concat!(
           "Maximum time in milliseconds that can be waited from when a ",
           "worker takes over the request (disabled by default)"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ use anyhow::Context;
 use anyhow::Error;
 use base::server;
 use base::server::Builder;
+use base::server::RequestIdleTimeout;
 use base::server::ServerFlags;
 use base::server::Tls;
 use base::utils::units::percentage_value;
@@ -180,8 +181,12 @@ fn main() -> Result<ExitCode, anyhow::Error> {
           sub_matches.get_one::<usize>("max-parallelism").cloned();
         let maybe_request_wait_timeout =
           sub_matches.get_one::<u64>("request-wait-timeout").cloned();
-        let maybe_request_idle_timeout =
-          sub_matches.get_one::<u64>("request-idle-timeout").cloned();
+        let maybe_main_worker_request_idle_timeout = sub_matches
+          .get_one::<u64>("main-worker-request-idle-timeout")
+          .cloned();
+        let maybe_user_worker_request_idle_timeout = sub_matches
+          .get_one::<u64>("user-worker-request-idle-timeout")
+          .cloned();
         let maybe_request_read_timeout =
           sub_matches.get_one::<u64>("request-read-timeout").cloned();
 
@@ -249,7 +254,10 @@ fn main() -> Result<ExitCode, anyhow::Error> {
           graceful_exit_keepalive_deadline_ms,
           event_worker_exit_deadline_sec,
           request_wait_timeout_ms: maybe_request_wait_timeout,
-          request_idle_timeout_ms: maybe_request_idle_timeout,
+          request_idle_timeout: RequestIdleTimeout::from_millis(
+            maybe_main_worker_request_idle_timeout,
+            maybe_user_worker_request_idle_timeout,
+          ),
           request_read_timeout_ms: maybe_request_read_timeout,
           request_buffer_size: Some(request_buffer_size),
 

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -21,6 +21,7 @@ use base::integration_test;
 use base::integration_test_listen_fut;
 use base::integration_test_with_server_flag;
 use base::server::Builder;
+use base::server::RequestIdleTimeout;
 use base::server::ServerEvent;
 use base::server::ServerFlags;
 use base::server::ServerHealth;
@@ -1860,7 +1861,7 @@ async fn test_request_idle_timeout_no_streamed_response(
 
   integration_test_with_server_flag!(
     ServerFlags {
-      request_idle_timeout_ms: Some(1000),
+      request_idle_timeout: RequestIdleTimeout::from_millis(None, Some(1000)),
       ..Default::default()
     },
     "./test_cases/main",
@@ -1918,7 +1919,7 @@ async fn test_request_idle_timeout_streamed_response(maybe_tls: Option<Tls>) {
 
   integration_test_with_server_flag!(
     ServerFlags {
-      request_idle_timeout_ms: Some(2000),
+      request_idle_timeout: RequestIdleTimeout::from_millis(None, Some(2000)),
       ..Default::default()
     },
     "./test_cases/main",
@@ -1991,7 +1992,7 @@ async fn test_request_idle_timeout_streamed_response_first_chunk_timeout(
 
   integration_test_with_server_flag!(
     ServerFlags {
-      request_idle_timeout_ms: Some(1000),
+      request_idle_timeout: RequestIdleTimeout::from_millis(None, Some(1000)),
       ..Default::default()
     },
     "./test_cases/main",
@@ -2079,7 +2080,7 @@ async fn test_request_idle_timeout_websocket_deno(
 
   integration_test_with_server_flag!(
     ServerFlags {
-      request_idle_timeout_ms: Some(1000),
+      request_idle_timeout: RequestIdleTimeout::from_millis(None, Some(1000)),
       ..Default::default()
     },
     "./test_cases/main",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, Enhancement

## Description

If both the user worker and main worker are subject to the same request idle timeout, the main worker may return a 504 response before receiving one from the user worker.

This can result in any attempts to decorate the response in the main worker (such as adding custom headers to the response) not being reflected in the final response to the external.

Context: 
https://supabase.slack.com/archives/C02KMRX22NR/p1762252394111069
