### PR TITLE
fix(ext/workers): passed incorrect arguments to `Span.setStatus`

### DIFF
--- a/ext/workers/user_workers.js
+++ b/ext/workers/user_workers.js
@@ -161,9 +161,9 @@ class UserWorker {
     } catch (err) {
       if (TRACING_ENABLED) {
         try {
-          span.setStatus(2, JSON.stringify(err));
+          span.setStatus({ code: 2, message: JSON.stringify(err) });
         } catch {
-          span.setStatus(2, "unknown");
+          span.setStatus({ code: 2, message: "unknown" });
         }
       }
       throw err;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Wrong usage of `Span.setStatus` caused an error.
