### PR TITLE
fix(deno_facade): should not assume that all module paths to be extracted have the same prefix

### DIFF
--- a/crates/deno_facade/lib.rs
+++ b/crates/deno_facade/lib.rs
@@ -50,11 +50,10 @@ async fn create_module_path(
   output_folder: &Path,
 ) -> PathBuf {
   let cleaned_specifier = strip_file_scheme(global_specifier);
-  let cleaned_specifier =
-    cleaned_specifier.replace(entry_path.to_str().unwrap(), "");
-  let module_path = PathBuf::from(cleaned_specifier);
+  let cleaned_path =
+    pathdiff::diff_paths(&*cleaned_specifier, entry_path).unwrap();
 
-  if let Some(parent) = module_path.parent() {
+  if let Some(parent) = cleaned_path.parent() {
     if parent.parent().is_some() {
       let output_folder_and_mod_folder = output_folder.join(
         parent
@@ -68,9 +67,9 @@ async fn create_module_path(
   }
 
   output_folder.join(
-    module_path
+    cleaned_path
       .strip_prefix("/")
-      .unwrap_or_else(|_| ensure_unix_relative_path(&module_path)),
+      .unwrap_or_else(|_| ensure_unix_relative_path(&cleaned_path)),
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

The path of content included in eszip does not always start with the entrypoint's base path.

For example:

File (1): functions/meow/index.ts (marked as entrypoint)
File (2): functions/shared/mod.ts
Base path: functions/meow

Simply calling `String::replace` to trim the base path from `functions/shared/mod.ts` will do nothing.
Therefore, assuming the output path is `/home/meow/output`, `mod.ts` would be created under `/home/meow/output/functions/meow/functions/shared`, which is incorrect behavior.