### PR TITLE
fix(ext/runtime): rollback memory count #645

### DIFF
--- a/ext/runtime/external_memory.rs
+++ b/ext/runtime/external_memory.rs
@@ -59,6 +59,7 @@ unsafe extern "C" fn allocate(
   let count_loaded = allocator.count.load(Ordering::SeqCst);
 
   if count_loaded > allocator.max {
+    allocator.count.fetch_sub(n, Ordering::SeqCst);
     return std::ptr::null::<*mut [u8]>() as *mut c_void;
   }
 
@@ -78,6 +79,7 @@ unsafe extern "C" fn allocate_uninitialized(
   let count_loaded = allocator.count.load(Ordering::SeqCst);
 
   if count_loaded > allocator.max {
+    allocator.count.fetch_sub(n, Ordering::SeqCst);
     return std::ptr::null::<*mut [u8]>() as *mut c_void;
   }
 
@@ -114,6 +116,9 @@ unsafe extern "C" fn reallocate(
   let count_loaded = allocator.count.load(Ordering::SeqCst);
 
   if count_loaded > allocator.max {
+    allocator
+      .count
+      .fetch_sub(newlen.wrapping_sub(oldlen), Ordering::SeqCst);
     return std::ptr::null::<*mut [u8]>() as *mut c_void;
   }
 


### PR DESCRIPTION
When allocate, allocate_uninitialized, or reallocate exceeded the memory
  limit, the count was incremented but never rolled back on failure. This
  caused all future allocations to fail permanently, even small legitimate
  ones.

## What kind of change does this PR introduce?

Bug fix for #645