### PR TITLE
build(deps): update onig_sys to fix build on gcc 15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5552,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (build failure on Archlinux)

## What is the current behavior?

The project fails to build on Arch Linux using GCC 15.

The failure is caused by an incompatibility in onig_sys, which does not compile correctly with GCC 15.
This issue is already tracked upstream in the rust-onig repository:

https://github.com/rust-onig/rust-onig/issues/203

onig_sys is not a direct dependency of this project; it is a transitive dependency pulled in by ext_ai.

## What is the new behavior?

The build succeeds on Arch Linux with GCC 15 after updating onig_sys to a newer version where the issue has been fixed upstream.

No application code was changed — only the affected indirect dependency was updated to restore compatibility.

## Additional context

- The fix comes directly from the upstream rust-onig project.
- This PR updates a transitive dependency to resolve a toolchain-specific build failure.
- Other platforms and compilers are unaffected.