### PR TITLE
fix(devcontainer): add zstd dependency to fix build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@ FROM mcr.microsoft.com/devcontainers/rust:dev-1-bookworm
 ARG TARGETPLATFORM
 
 RUN apt-get update && apt-get install -y build-essential cmake libclang-dev lldb \
-    nodejs npm hyperfine \
-    libblas-dev liblapack-dev libopenblas-dev
+  nodejs npm hyperfine \
+  libblas-dev liblapack-dev libopenblas-dev zstd
 
 COPY .env /tmp/.env
 COPY .devcontainer/install.sh /tmp/install.sh


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The devcontainer build fails due to a missing `zstd` dependency required during the build process.

## What is the new behavior?

The devcontainer builds successfully after adding `zstd` to the Dockerfile dependencies.

## Additional context

This change ensures the development environment works out of the box without requiring manual dependency installation.