### PR TITLE
fix(ext/node): brotli async variant of brotliDecompress

### DIFF
--- a/crates/base/test_cases/brotli-async/index.ts
+++ b/crates/base/test_cases/brotli-async/index.ts
@@ -1,0 +1,11 @@
+import { promisify } from "node:util";
+import { brotliCompress, brotliDecompress } from "node:zlib";
+
+Deno.serve(async () => {
+  const meow = "meow";
+
+  const meowCompressed = await promisify(brotliCompress)(meow);
+  const meowDecompressed = await promisify(brotliDecompress)(meowCompressed);
+
+  return new Response(meowDecompressed.toString(), { status: 200 });
+});

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4290,6 +4290,25 @@ async fn test_drop_socket_when_http_handler_returns_an_invalid_value() {
   }
 }
 
+#[tokio::test]
+#[serial]
+async fn test_brotli_async() {
+  integration_test!(
+    "./test_cases/main",
+    NON_SECURE_PORT,
+    "brotli-async",
+    None,
+    None,
+    None,
+    (|resp| async {
+      let resp = resp.unwrap();
+      assert_eq!(resp.status().as_u16(), 200);
+      assert_eq!(resp.text().await.unwrap().as_str(), "meow");
+    }),
+    TerminationToken::new()
+  );
+}
+
 #[derive(Deserialize)]
 struct ErrorResponsePayload {
   msg: String,

--- a/ext/node/polyfills/_brotli.js
+++ b/ext/node/polyfills/_brotli.js
@@ -193,8 +193,14 @@ export function brotliCompressSync(
   return Buffer.from(TypedArrayPrototypeSubarray(output, 0, len));
 }
 
-export function brotliDecompress(input) {
+export function brotliDecompress(input, options, callback) {
   const buf = toU8(input);
+
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+
   return PromisePrototypeCatch(
     PromisePrototypeThen(
       op_brotli_decompress_async(buf),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Node `zlib.brotliDecompress` doesn't support async wrappers.

## What is the new behavior?

Applied the same patches from upstream: https://github.com/denoland/deno/pull/27815