### PR TITLE
fix: add missing `Session.init` typedef

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -231,6 +231,7 @@ declare namespace Supabase {
     }
 
     export class Session {
+      init: Promise<void>
       /**
        * Create a new model session using given model
        */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, docs update, ...

## What is the current behavior?

AI Session does have `init` field but is missing on typedef

## What is the new behavior?

Adding this field to typedefs