### PR TITLE
chore(example/main): move OpenTelemetry propagation setup into load event listener

### DIFF
--- a/examples/main/index.ts
+++ b/examples/main/index.ts
@@ -6,14 +6,16 @@ import { join } from "jsr:@std/path@^1.0";
 import { context, propagation } from "npm:@opentelemetry/api";
 import { W3CBaggagePropagator } from "npm:@opentelemetry/core@1";
 
-// @ts-ignore See https://github.com/denoland/deno/issues/28082
-if (globalThis[Symbol.for("opentelemetry.js.api.1")]) {
-  globalThis[Symbol.for("opentelemetry.js.api.1")].propagation =
-    new W3CBaggagePropagator();
-}
+addEventListener("load", () => {
+  console.log("main function started");
+  console.log(Deno.version);
 
-console.log("main function started");
-console.log(Deno.version);
+  // @ts-ignore See https://github.com/denoland/deno/issues/28082
+  if (globalThis[Symbol.for("opentelemetry.js.api.1")]) {
+    globalThis[Symbol.for("opentelemetry.js.api.1")].propagation =
+      new W3CBaggagePropagator();
+  }
+});
 
 addEventListener("beforeunload", () => {
   console.log("main worker exiting");


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## Description

Since #681, the timing for registering the Tracer backend with the otel symbol has been changed to after the main module has been initialized, so the example must be updated accordingly.

Towards FUNC-552