### PR TITLE
fix(deno_facade): do not include managed npm deps when graph does not have any npm pkgs

### DIFF
--- a/crates/deno_facade/eszip/mod.rs
+++ b/crates/deno_facade/eszip/mod.rs
@@ -788,19 +788,26 @@ pub async fn generate_binary_eszip(
   let (mut vfs, node_modules, npm_snapshot) = match resolver.clone().as_inner()
   {
     InnerCliNpmResolverRef::Managed(managed) => {
-      let snapshot =
-        managed.serialized_valid_snapshot_for_system(&NpmSystemInfo::default());
-      if !snapshot.as_serialized().packages.is_empty() {
-        let npm_vfs_builder = build_npm_vfs(
-          VfsOpts {
-            root_path,
-            npm_resolver: resolver.clone(),
-          },
-          emitter_factory.deno_options()?.clone(),
-          &mut vfs_content_callback_fn,
-        )?;
-
+      if graph.npm_packages.is_empty() {
         (
+          VfsBuilder::new(root_path, &mut vfs_content_callback_fn)?,
+          None,
+          None,
+        )
+      } else {
+        let snapshot = managed
+          .serialized_valid_snapshot_for_system(&NpmSystemInfo::default());
+        if !snapshot.as_serialized().packages.is_empty() {
+          let npm_vfs_builder = build_npm_vfs(
+            VfsOpts {
+              root_path,
+              npm_resolver: resolver.clone(),
+            },
+            emitter_factory.deno_options()?.clone(),
+            &mut vfs_content_callback_fn,
+          )?;
+
+          (
           npm_vfs_builder,
           Some(NodeModules::Managed {
             node_modules_dir: resolver.root_node_modules_path().map(|it| {
@@ -816,12 +823,13 @@ pub async fn generate_binary_eszip(
               .serialized_valid_snapshot_for_system(&NpmSystemInfo::default()),
           ),
         )
-      } else {
-        (
-          VfsBuilder::new(root_path, &mut vfs_content_callback_fn)?,
-          None,
-          None,
-        )
+        } else {
+          (
+            VfsBuilder::new(root_path, &mut vfs_content_callback_fn)?,
+            None,
+            None,
+          )
+        }
       }
     }
     InnerCliNpmResolverRef::Byonm(_) => {

--- a/crates/deno_facade/eszip/mod.rs
+++ b/crates/deno_facade/eszip/mod.rs
@@ -808,21 +808,21 @@ pub async fn generate_binary_eszip(
           )?;
 
           (
-          npm_vfs_builder,
-          Some(NodeModules::Managed {
-            node_modules_dir: resolver.root_node_modules_path().map(|it| {
-              root_dir_url
-                .specifier_key(
-                  &ModuleSpecifier::from_directory_path(it).unwrap(),
-                )
-                .into_owned()
+            npm_vfs_builder,
+            Some(NodeModules::Managed {
+              node_modules_dir: resolver.root_node_modules_path().map(|it| {
+                root_dir_url
+                  .specifier_key(
+                    &ModuleSpecifier::from_directory_path(it).unwrap(),
+                  )
+                  .into_owned()
+              }),
             }),
-          }),
-          Some(
-            managed
-              .serialized_valid_snapshot_for_system(&NpmSystemInfo::default()),
-          ),
-        )
+            Some(
+              managed
+                .serialized_valid_snapshot_for_system(&NpmSystemInfo::default()),
+            ),
+          )
         } else {
           (
             VfsBuilder::new(root_path, &mut vfs_content_callback_fn)?,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -231,7 +231,7 @@ declare namespace Supabase {
     }
 
     export class Session {
-      init: Promise<void>
+      init: Promise<void>;
       /**
        * Create a new model session using given model
        */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix



## Description

Manually cherry-picked from https://github.com/denoland/deno/pull/30189