### PR TITLE
fix(deno_telemetry): guard against malformed request URLs in span attrs

### DIFF
--- a/vendor/deno_telemetry/util.ts
+++ b/vendor/deno_telemetry/util.ts
@@ -9,14 +9,21 @@ export function updateSpanFromRequest(span: Span, request: Request) {
   span.updateName(request.method);
 
   span.setAttribute("http.request.method", request.method);
-  const url = new URL(request.url);
   span.setAttribute("url.full", request.url);
-  span.setAttribute(
-    "url.scheme",
-    StringPrototypeSlice(url.protocol, 0, -1),
-  );
-  span.setAttribute("url.path", url.pathname);
-  span.setAttribute("url.query", StringPrototypeSlice(url.search, 1));
+  // Malformed URLs (e.g. invalid hosts from internet scanners) would otherwise
+  // throw here and crash the request handler before it can respond. Record the
+  // raw URL above and skip the parsed attributes when parsing fails.
+  try {
+    const url = new URL(request.url);
+    span.setAttribute(
+      "url.scheme",
+      StringPrototypeSlice(url.protocol, 0, -1),
+    );
+    span.setAttribute("url.path", url.pathname);
+    span.setAttribute("url.query", StringPrototypeSlice(url.search, 1));
+  } catch {
+    span.setAttribute("url.parse_error", "true");
+  }
 }
 
 export function updateSpanFromResponse(span: Span, response: Response) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Problem

`updateSpanFromRequest` in `vendor/deno_telemetry/util.ts` calls
`new URL(request.url)` unguarded. When the incoming `request.url` is
malformed (e.g. an invalid host like `nonexistent-jscorpus-probe.171340`
sent by internet scanners / security probes), `new URL` throws
`TypeError: Invalid URL` and crashes the request handler before it can
respond. The error surfaces as a handled exception in Sentry on every
scan, and any attacker can trivially generate noise.

Traced from incident INC-475.

## Solution

Wrap the `new URL(...)` call and the derived attribute writes in a
try/catch:

- `url.full` (the raw request URL string) and `http.request.method` are
  now set **before** the parse, so malformed-URL requests remain
  observable in spans.
- `url.scheme` / `url.path` / `url.query` are only set when parsing
  succeeds.
- On parse failure, `url.parse_error = "true"` is set so these requests
  can be filtered in telemetry.

This layer is a passive observer — it doesn't reject the request.
Request rejection (400 on malformed URL) is handled upstream in
`edge-functions-ingress`.