### PR TITLE
fix: update release workflows to trigger nix build workflow on successful publish

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -1,9 +1,6 @@
 name: Release Native
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,3 +167,20 @@ jobs:
           dst: |
             public.ecr.aws/supabase/edge-runtime:v${{ needs.release.outputs.version }}
             ghcr.io/supabase/edge-runtime:v${{ needs.release.outputs.version }}
+
+  trigger_native_release:
+    needs: [release, merge_manifest]
+    if: needs.release.outputs.published == 'true' && needs.merge_manifest.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger native release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release-native.yml',
+              ref: 'v${{ needs.release.outputs.version }}'
+            })


### PR DESCRIPTION
## What kind of change does this PR introduce?
Enhancement

## What is the current behavior?
The release workflow does not trigger the Nix build workflow upon a successful publish.

## Description

Towards CLI-1383

