### PR TITLE
fix: add fetch timeout and TCP keepalive to HTTP client

### DIFF
--- a/deno/http_util.rs
+++ b/deno/http_util.rs
@@ -27,10 +27,22 @@ use http_body_util::BodyExt;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::thread::ThreadId;
 use std::time::Duration;
 use std::time::SystemTime;
 use thiserror::Error;
+
+static FETCH_TIMEOUT: OnceLock<Option<Duration>> = OnceLock::new();
+
+fn fetch_timeout() -> Option<Duration> {
+  *FETCH_TIMEOUT.get_or_init(|| {
+    std::env::var("DENO_FETCH_TIMEOUT_SECS")
+      .ok()
+      .and_then(|v| v.parse::<u64>().ok())
+      .map(Duration::from_secs)
+  })
+}
 
 // TODO(ry) HTTP headers are not unique key, value pairs. There may be more than
 // one header line with the same key. This should be changed to something like
@@ -391,13 +403,27 @@ impl HttpClient {
       let accepts_val = HeaderValue::from_str(&accept)?;
       request.headers_mut().insert(ACCEPT, accepts_val);
     }
-    let response = match self.client.clone().send(request).await {
-      Ok(resp) => resp,
-      Err(err) => {
-        if err.is_connect_error() {
-          return Ok(FetchOnceResult::RequestError(err.to_string()));
+    let response = {
+      let send_fut = self.client.clone().send(request);
+      let resp = if let Some(dur) = fetch_timeout() {
+        tokio::time::timeout(dur, send_fut).await.map_err(|_| {
+          anyhow::anyhow!(
+            "Fetch '{}' timed out after {}s",
+            args.url,
+            dur.as_secs()
+          )
+        })?
+      } else {
+        send_fut.await
+      };
+      match resp {
+        Ok(r) => r,
+        Err(err) => {
+          if err.is_connect_error() {
+            return Ok(FetchOnceResult::RequestError(err.to_string()));
+          }
+          return Err(err.into());
         }
-        return Err(err.into());
       }
     };
 
@@ -450,7 +476,19 @@ impl HttpClient {
       return Err(err);
     }
 
-    let body = get_response_body_with_progress(response).await?;
+    let body = if let Some(dur) = fetch_timeout() {
+      tokio::time::timeout(dur, get_response_body_with_progress(response))
+        .await
+        .map_err(|_| {
+          anyhow::anyhow!(
+            "Fetch '{}' body timed out after {}s",
+            args.url,
+            dur.as_secs()
+          )
+        })??
+    } else {
+      get_response_body_with_progress(response).await?
+    };
 
     Ok(FetchOnceResult::Code(body, result_headers))
   }

--- a/vendor/deno_fetch/lib.rs
+++ b/vendor/deno_fetch/lib.rs
@@ -15,8 +15,21 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::task::Context;
 use std::task::Poll;
+
+static TCP_KEEPALIVE: OnceLock<std::time::Duration> = OnceLock::new();
+
+fn tcp_keepalive() -> std::time::Duration {
+  *TCP_KEEPALIVE.get_or_init(|| {
+    let secs = std::env::var("DENO_TCP_KEEPALIVE_SECS")
+      .ok()
+      .and_then(|v| v.parse::<u64>().ok())
+      .unwrap_or(30);
+    std::time::Duration::from_secs(secs)
+  })
+}
 
 use deno_core::futures::stream::Peekable;
 use deno_core::futures::Future;
@@ -1016,6 +1029,7 @@ pub fn create_http_client(
   let mut http_connector =
     HttpConnector::new_with_resolver(options.dns_resolver.clone());
   http_connector.enforce_http(false);
+  http_connector.set_keepalive(Some(tcp_keepalive()));
 
   let user_agent = user_agent.parse::<HeaderValue>().map_err(|_| {
     HttpClientCreateError::InvalidUserAgent(user_agent.to_string())


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The HTTP client does not have a timeout for fetch requests or TCP keepalive settings.

## What is the new behavior?

- TCP keepalive is now enabled on HTTP client sockets (`SO_KEEPALIVE`). The OS will send keepalive probes after an idle period, detecting and closing dead connections before they cause indefinite hangs. Default idle time is 30s, configurable via `DENO_TCP_KEEPALIVE_SECS`.
- A fetch timeout is now applied to both response header wait and body download in the file fetcher. Configurable via `DENO_FETCH_TIMEOUT_SECS` (disabled by default).

## Description

Without TCP keepalive, if a load balancer (e.g. AWS ALB with a 60s idle timeout) silently drops a pooled connection, the client has no way to detect the dead socket and `send().await` blocks indefinitely. This was observed causing 1h+ hangs in the `bundle` subcommand and silent failures when invoking functions from within Edge Functions (ref #678).

Context: https://supabase.slack.com/archives/C02KMRX22NR/p1776767117730769?thread_ts=1776681851.847949&cid=C02KMRX22NR