### PR TITLE
chore: release name formatting in workflow

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -71,7 +71,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           draft: false
           prerelease: false
           files: artifacts/**/*


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI/CD small fix

## What is the current behavior?

Release renaming

## What is the new behavior?

Keep only the version as release name
