### PR TITLE
feat: expose EdgeRuntime.miCollect() to main worker for mimalloc force purge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "httparse",
  "hyper 0.14.28",
  "hyper 1.5.2",
+ "libc",
  "log",
  "memmem",
  "once_cell",

--- a/ext/runtime/Cargo.toml
+++ b/ext/runtime/Cargo.toml
@@ -30,6 +30,7 @@ http.workspace = true
 httparse.workspace = true
 hyper.workspace = true
 hyper_v014.workspace = true
+libc.workspace = true
 log.workspace = true
 once_cell.workspace = true
 regex.workspace = true

--- a/ext/runtime/js/namespaces.js
+++ b/ext/runtime/js/namespaces.js
@@ -33,6 +33,7 @@ function installEdgeRuntimeNamespace(kind, terminationRequestTokenRid) {
         applySupabaseTag: (src, dest) => applySupabaseTag(src, dest),
         systemMemoryInfo: () => ops.op_system_memory_info(),
         raiseSegfault: () => ops.op_raise_segfault(),
+        miCollect: () => ops.op_mi_collect(),
         ...props,
       };
       break;

--- a/ext/runtime/lib.rs
+++ b/ext/runtime/lib.rs
@@ -4,9 +4,6 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-#[cfg(target_os = "linux")]
-use libc;
-
 use base_mem_check::WorkerHeapStatistics;
 use base_rt::DropToken;
 use base_rt::RuntimeState;

--- a/ext/runtime/lib.rs
+++ b/ext/runtime/lib.rs
@@ -4,6 +4,9 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+#[cfg(target_os = "linux")]
+use libc;
+
 use base_mem_check::WorkerHeapStatistics;
 use base_rt::DropToken;
 use base_rt::RuntimeState;
@@ -443,6 +446,31 @@ fn op_cancel_drop_token(
   Ok(())
 }
 
+#[op2(fast)]
+fn op_mi_collect() {
+  #[cfg(target_os = "linux")]
+  {
+    use std::sync::OnceLock;
+
+    type MiCollectFn = unsafe extern "C" fn(force: bool);
+
+    static MI_COLLECT: OnceLock<Option<MiCollectFn>> = OnceLock::new();
+
+    let f = MI_COLLECT.get_or_init(|| unsafe {
+      let sym = libc::dlsym(libc::RTLD_DEFAULT, c"mi_collect".as_ptr());
+      if sym.is_null() {
+        None
+      } else {
+        Some(std::mem::transmute::<*mut libc::c_void, MiCollectFn>(sym))
+      }
+    });
+
+    if let Some(mi_collect) = f {
+      unsafe { mi_collect(true) };
+    }
+  }
+}
+
 #[op2]
 #[serde]
 pub fn op_bootstrap_unstable_args(_state: &mut OpState) -> Vec<String> {
@@ -485,6 +513,7 @@ deno_core::extension!(
     op_tap_promise_metrics,
     op_cancel_drop_token,
     op_check_outbound_rate_limit,
+    op_mi_collect,
   ],
   esm_entry_point = "ext:runtime/bootstrap.js",
   esm = [

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -196,6 +196,7 @@ declare namespace EdgeRuntime {
   export function applySupabaseTag(src: Request, dest: Request): void;
   export function systemMemoryInfo(): MemInfo;
   export function raiseSegfault(): void;
+  export function miCollect(): void;
 
   export { UserWorker as userWorkers };
 }


### PR DESCRIPTION
## Description
Exposes `EdgeRuntime.miCollect()` as a main-worker-only API to allow
explicit control over when mimalloc returns freed memory back to the OS.