### PR TITLE
fix(deno_facade): allow non-MainModule resolution when referrer is "."

### DIFF
--- a/crates/base/test_cases/commonjs-require-esm/index.js
+++ b/crates/base/test_cases/commonjs-require-esm/index.js
@@ -1,0 +1,7 @@
+const esm = require("./message.mjs");
+
+if (esm.message !== "cjs require esm ok") {
+  throw new Error(`unexpected ESM value: ${esm.message}`);
+}
+
+Deno.serve(() => new Response(esm.message));

--- a/crates/base/test_cases/commonjs-require-esm/message.mjs
+++ b/crates/base/test_cases/commonjs-require-esm/message.mjs
@@ -1,0 +1,1 @@
+export const message = "cjs require esm ok";

--- a/crates/base/test_cases/commonjs-require-esm/package.json
+++ b/crates/base/test_cases/commonjs-require-esm/package.json
@@ -1,0 +1,4 @@
+{
+  "workspaces": [],
+  "type": "commonjs"
+}

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -3255,6 +3255,25 @@ async fn test_commonjs() {
 
 #[tokio::test]
 #[serial]
+async fn test_commonjs_require_esm() {
+  integration_test!(
+    "./test_cases/main",
+    NON_SECURE_PORT,
+    "commonjs-require-esm",
+    None,
+    None,
+    None,
+    (|resp| async {
+      let resp = resp.unwrap();
+      assert_eq!(resp.status().as_u16(), 200);
+      assert_eq!(resp.text().await.unwrap().as_str(), "cjs require esm ok");
+    }),
+    TerminationToken::new()
+  );
+}
+
+#[tokio::test]
+#[serial]
 async fn test_commonjs_no_type_field_in_package_json() {
   integration_test!(
     "./test_cases/main",

--- a/crates/deno_facade/module_loader/standalone.rs
+++ b/crates/deno_facade/module_loader/standalone.rs
@@ -52,7 +52,6 @@ use deno::PermissionsContainer;
 use deno_config::workspace::MappedResolution;
 use deno_config::workspace::ResolverWorkspaceJsrPackage;
 use deno_config::workspace::WorkspaceResolver;
-use deno_core::error::generic_error;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::futures::FutureExt;
@@ -148,28 +147,29 @@ pub struct EmbeddedModuleLoader {
   pub(crate) include_source_map: bool,
 }
 
+fn resolve_standalone_referrer(
+  referrer: &str,
+  root_path: &Path,
+) -> Result<ModuleSpecifier, AnyError> {
+  if referrer == "." {
+    return Ok(deno_core::resolve_path(".", root_path)?);
+  }
+
+  ModuleSpecifier::parse(referrer).map_err(|err| {
+    type_error(format!("Referrer uses invalid specifier: {}", err))
+  })
+}
+
 impl ModuleLoader for EmbeddedModuleLoader {
   #[instrument(level = "debug", skip(self))]
   fn resolve(
     &self,
     specifier: &str,
     referrer: &str,
-    kind: ResolutionKind,
+    _kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, AnyError> {
-    let referrer = if referrer == "." {
-      if kind != ResolutionKind::MainModule {
-        return Err(generic_error(format!(
-          "Expected to resolve main module, got {:?} instead.",
-          kind
-        )));
-      }
-
-      deno_core::resolve_path(".", &self.shared.root_path)?
-    } else {
-      ModuleSpecifier::parse(referrer).map_err(|err| {
-        type_error(format!("Referrer uses invalid specifier: {}", err))
-      })?
-    };
+    let referrer =
+      resolve_standalone_referrer(referrer, &self.shared.root_path)?;
     let referrer_kind = if self
       .shared
       .cjs_tracker


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`EmbeddedModuleLoader::resolve` rejects any resolution where `referrer == "."`
unless `kind == ResolutionKind::MainModule`:

```rust
if kind != ResolutionKind::MainModule {
    return Err(generic_error(format!(
        "Expected to resolve main module, got {:?} instead.",
        kind
    )));
}
```

This breaks Deno's CJS→ESM bridge. When a CommonJS module synchronously
`require()`s a pure-ESM module, `loadESMFromCJS` re-enters `resolve` with
`ResolutionKind::Import` and the same `"."` referrer, and the worker boots
with:

```
Error: Expected to resolve main module, got Import instead.
    at loadESMFromCJS (node:module:777)
```

fix #703 

## What is the new behavior?

After the fix, `require("./message.mjs")` and `require("chalk")` (a
`"type": "module"` package) both load correctly from a CJS entrypoint.
