### PR TITLE
fix(deno_telemetry): guard against malformed URLs when parsing baggage headers

### DIFF
--- a/vendor/deno_telemetry/telemetry.ts
+++ b/vendor/deno_telemetry/telemetry.ts
@@ -1515,16 +1515,21 @@ function parsePairKeyValue(
     BAGGAGE_KEY_PAIR_SEPARATOR,
   );
   if (separatorIndex <= 0) return;
-  const key = decodeURIComponent(
-    StringPrototypeTrim(
-      StringPrototypeSubstring(keyPairPart, 0, separatorIndex),
-    ),
-  );
-  const value = decodeURIComponent(
-    StringPrototypeTrim(
-      StringPrototypeSubstring(keyPairPart, separatorIndex + 1),
-    ),
-  );
+  let key, value;
+  try {
+    key = decodeURIComponent(
+      StringPrototypeTrim(
+        StringPrototypeSubstring(keyPairPart, 0, separatorIndex),
+      ),
+    );
+    value = decodeURIComponent(
+      StringPrototypeTrim(
+        StringPrototypeSubstring(keyPairPart, separatorIndex + 1),
+      ),
+    );
+  } catch {
+    return;
+  }
   let metadata;
   if (valueProps.length > 0) {
     metadata = baggageEntryMetadataFromString(


### PR DESCRIPTION
## Description
Malformed URLs can also be passed when parsing the w3c baggage header.
Related #691