### PR TITLE
security: upgrade openssl, strip vim from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,12 @@ FROM debian:bookworm-slim as edge-runtime-base
 RUN apt-get update && apt-get install -y libssl-dev \
     libblas-dev liblapack-dev libopenblas-dev \
     ca-certificates \
+    && apt-get upgrade -y openssl libssl3 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get remove -y perl && apt-get autoremove -y
+RUN apt-get remove -y perl vim vim-common vim-runtime vim-tiny xxd 2>/dev/null; \
+    apt-get autoremove -y
 
 COPY --from=builder /root/edge-runtime /usr/local/bin/edge-runtime
 COPY --from=builder /root/edge-runtime.debug /usr/local/bin/edge-runtime.debug


### PR DESCRIPTION
## Security: Upgrade OpenSSL and strip dev tools from runtime image

### Changes
- **OpenSSL/libssl3**: Added `apt-get upgrade` in runtime stage to pull latest security patches
- **vim family**: Removed vim, vim-common, vim-runtime, vim-tiny, xxd from runtime image (dev tools that should not be in production)

### Findings addressed
| Package | Findings | Severity | Fix |
|---------|----------|----------|-----|
| openssl | 58 | 🔴 Critical | apt-get upgrade in runtime stage |
| libssl1.1/libssl3 | 38 | 🟠 High | apt-get upgrade in runtime stage |
| vim/xxd | 347+ | 🟠 High | Removed from runtime image |

### Triage source
Generated by [Latent Defense](https://latentdefense.ai) structural triage — findings grouped by shared precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)