### PR TITLE
docs: add macOS OpenBLAS prerequisite

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -9,6 +9,12 @@
 
 ## How to run locally
 
+On macOS, install OpenBLAS before running the Edge Runtime:
+
+```sh
+brew install openblas
+```
+
 To serve all functions in the examples folder on port 9998, you can do this with
 the [example main service](./examples/main/index.ts) provided with this repo
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

It updates install guidelines to install openblas on macOS before running edge runtime.

## What is the current behavior?

Build fails if a developer directly runs ./scripts/run.sh

## What is the new behavior?

Installing openblas fixes the build issue and  ./scripts/run.sh runs smooth.

## Additional context

As part of my onboarding, I found this system dependency requirement.