### PR TITLE
fix(ext/runtime): return 500 instead of 502 for invalid handler response

### DIFF
--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4231,7 +4231,11 @@ async fn test_drop_socket_when_http_handler_returns_an_invalid_value() {
       None,
       (|resp| async {
         let res = resp.unwrap();
-        assert!(res.status().as_u16() == 502);
+        assert!(res.status().as_u16() == 500);
+        assert_eq!(
+          res.headers().get("x-edge-runtime-error").unwrap(),
+          "invalid-handler-response"
+        );
       }),
       TerminationToken::new()
     );
@@ -4246,7 +4250,11 @@ async fn test_drop_socket_when_http_handler_returns_an_invalid_value() {
       None,
       (|resp| async {
         let res = resp.unwrap();
-        assert!(res.status().as_u16() == 502);
+        assert!(res.status().as_u16() == 500);
+        assert_eq!(
+          res.headers().get("x-edge-runtime-error").unwrap(),
+          "invalid-handler-response"
+        );
       }),
       TerminationToken::new()
     );

--- a/ext/runtime/js/http.js
+++ b/ext/runtime/js/http.js
@@ -57,8 +57,11 @@ function internalServerError() {
   return new Response("Internal Server Error", { status: 500 });
 }
 
-function badGatewayError() {
-  return new Response("Bad Gateway", { status: 502 });
+function invalidHandlerResponseError() {
+  return new Response("Internal Server Error", {
+    status: 500,
+    headers: { "x-edge-runtime-error": "invalid-handler-response" },
+  });
 }
 
 function serveHttp(conn) {
@@ -87,7 +90,7 @@ function serveHttp(conn) {
           resp = await resp;
           if (!(ObjectPrototypeIsPrototypeOf(ResponsePrototype, resp))) {
             needThrow = false;
-            await nextRequest.respondWith(badGatewayError());
+            await nextRequest.respondWith(invalidHandlerResponseError());
             throw new TypeError(
               "First argument to 'respondWith' must be a Response or a promise resolving to a Response",
             );


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
When a `serve()` handler (main worker, event worker, or a user function) resolves with something that isn't a `Response` object, `ext/runtime/js/http.js` falls back to a bare `502 Bad Gateway` with a generic `"Bad Gateway"` body.

502 implies edge-runtime received an invalid response *from an upstream/gateway target*. That's not what's happening here: the "handler" runs in-process, and the violation is edge-runtime's own contract (a handler must resolve to a `Response`) not being honored. Framing it as a gateway error also makes this failure indistinguishable from unrelated, real gateway-level 502s, which complicates 502 triage.

## What is the new behavior?
- The fallback now returns `500 Internal Server Error` instead of `502 Bad Gateway`, which more accurately reflects that the fault is internal, not upstream.
- The response carries a new header, `x-edge-runtime-error: invalid-handler-response`, so this specific failure mode can be distinguished from other 500s and from unrelated 502s in logs/metrics without relying on status code alone.
- `badGatewayError()` is renamed to `invalidHandlerResponseError()` to match what it actually represents.

## Additional context
No functional change to the "handler threw an exception" path (`internalServerError()`, still 500, unchanged) — this only affects the "handler resolved to a non-Response value" path.
