### PR TITLE
fix: reclaim isolate host RSS on oneshot user-worker retirement

### DIFF
--- a/crates/base/src/runtime/mod.rs
+++ b/crates/base/src/runtime/mod.rs
@@ -403,7 +403,8 @@ pub struct DenoRuntime<RuntimeContext = DefaultRuntimeContext> {
 
 impl<RuntimeContext> Drop for DenoRuntime<RuntimeContext> {
   fn drop(&mut self) {
-    if self.conf.is_user_worker() {
+    let is_user_worker = self.conf.is_user_worker();
+    if is_user_worker {
       self.js_runtime.v8_isolate().remove_gc_prologue_callback(
         mem_check_gc_prologue_callback_fn,
         Arc::as_ptr(&self.mem_check) as *mut _,
@@ -412,11 +413,20 @@ impl<RuntimeContext> Drop for DenoRuntime<RuntimeContext> {
 
     cleanup_js_runtime(&mut self.js_runtime);
 
+    if is_user_worker {
+      self.js_runtime.v8_isolate().low_memory_notification();
+    }
+
     unsafe {
       ManuallyDrop::drop(&mut self.js_runtime);
     }
 
     self.drop_token.cancel();
+
+    // Drop isolate host pages on the worker thread; pool counts already hit 0.
+    if is_user_worker {
+      ext_runtime::reclaim_host_memory();
+    }
   }
 }
 

--- a/crates/base/src/utils/test_utils.rs
+++ b/crates/base/src/utils/test_utils.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use anyhow::Error;
 use either::Either::Right;
 use ext_event_worker::events::WorkerEventWithMetadata;
+use ext_runtime::SharedMetricSource;
 use ext_workers::context::MainWorkerRuntimeOpts;
 use ext_workers::context::Timing;
 use ext_workers::context::UserWorkerRuntimeOpts;
@@ -217,7 +218,7 @@ impl TestBedBuilder {
   }
 
   pub async fn build(self) -> TestBed {
-    let ((_, worker_pool_tx), pool_termination_token) = {
+    let ((metric_src, worker_pool_tx), pool_termination_token) = {
       let token = TerminationToken::new();
       (
         worker::create_user_worker_pool(
@@ -269,6 +270,7 @@ impl TestBedBuilder {
       pool_termination_token,
       main_termination_token,
       main_worker_surface,
+      metric_src,
     }
   }
 }
@@ -278,6 +280,7 @@ pub struct TestBed {
   pool_termination_token: TerminationToken,
   main_termination_token: TerminationToken,
   main_worker_surface: worker::WorkerSurface,
+  pub metric_src: SharedMetricSource,
 }
 
 impl TestBed {

--- a/crates/base/src/worker/supervisor/v8_handler.rs
+++ b/crates/base/src/worker/supervisor/v8_handler.rs
@@ -50,6 +50,7 @@ pub extern "C" fn v8_handle_termination(
   }
 
   if data.should_terminate {
+    isolate.low_memory_notification();
     isolate.terminate_execution();
   }
 }

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4077,6 +4077,56 @@ async fn test_user_workers_cleanup_idle_workers() {
 
 #[tokio::test]
 #[serial]
+async fn test_oneshot_retirement_drops_user_worker() {
+  let (tx, mut rx) = mpsc::unbounded_channel();
+  let tb = TestBedBuilder::new("./test_cases/main")
+    .with_oneshot_policy(None)
+    .with_worker_event_sender(Some(tx))
+    .build()
+    .await;
+  let metric = tb.metric_src.clone();
+
+  let mut resp = tb
+    .request(|b| {
+      b.uri("/empty-response")
+        .method("GET")
+        .body(Body::empty())
+        .context("can't make request")
+    })
+    .await
+    .unwrap();
+
+  assert_eq!(resp.status().as_u16(), StatusCode::NO_CONTENT);
+  let _ = to_bytes(resp.body_mut()).await;
+  drop(resp);
+
+  timeout(Duration::from_secs(10), async {
+    loop {
+      let Some(ev) = rx.recv().await else {
+        panic!("worker event channel closed before shutdown");
+      };
+      if matches!(ev.event, WorkerEvents::Shutdown(_)) {
+        break;
+      }
+    }
+  })
+  .await
+  .expect("oneshot worker did not retire");
+
+  timeout(Duration::from_secs(5), async {
+    while metric.active_user_workers() != 0 {
+      tokio::task::yield_now().await;
+    }
+  })
+  .await
+  .expect("retired isolate still counted as active");
+
+  assert!(metric.retired_user_workers() >= 1);
+  tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
+}
+
+#[tokio::test]
+#[serial]
 async fn test_no_npm() {
   async fn send_it(
     no_npm: bool,

--- a/ext/runtime/lib.rs
+++ b/ext/runtime/lib.rs
@@ -72,6 +72,14 @@ impl SharedMetricSource {
     self.handled_requests.load(Ordering::Relaxed)
   }
 
+  pub fn active_user_workers(&self) -> usize {
+    self.active_user_workers.load(Ordering::Relaxed)
+  }
+
+  pub fn retired_user_workers(&self) -> usize {
+    self.retired_user_workers.load(Ordering::Relaxed)
+  }
+
   pub fn incl_active_user_workers(&self) {
     self.active_user_workers.fetch_add(1, Ordering::Relaxed);
   }
@@ -443,9 +451,8 @@ fn op_cancel_drop_token(
   Ok(())
 }
 
-#[op2(fast)]
-fn op_mi_collect() {
-  #[cfg(target_os = "linux")]
+pub fn reclaim_host_memory() {
+  #[cfg(unix)]
   {
     use std::sync::OnceLock;
 
@@ -466,6 +473,43 @@ fn op_mi_collect() {
       unsafe { mi_collect(true) };
     }
   }
+
+  #[cfg(target_os = "linux")]
+  unsafe {
+    libc::malloc_trim(0);
+  }
+
+  #[cfg(target_os = "macos")]
+  {
+    use std::sync::OnceLock;
+
+    type PressureFn = unsafe extern "C" fn(*mut libc::c_void, usize) -> usize;
+
+    static PRESSURE: OnceLock<Option<PressureFn>> = OnceLock::new();
+
+    let f = PRESSURE.get_or_init(|| unsafe {
+      let sym = libc::dlsym(
+        libc::RTLD_DEFAULT,
+        c"malloc_zone_pressure_relief".as_ptr(),
+      );
+      if sym.is_null() {
+        None
+      } else {
+        Some(std::mem::transmute::<*mut libc::c_void, PressureFn>(sym))
+      }
+    });
+
+    if let Some(pressure) = f {
+      unsafe {
+        pressure(std::ptr::null_mut(), 0);
+      }
+    }
+  }
+}
+
+#[op2(fast)]
+fn op_mi_collect() {
+  reclaim_host_memory();
 }
 
 #[op2]


### PR DESCRIPTION
Oneshot retirement already drives `activeUserWorkersCount` to 0. Host RSS still grows ~2.5 MiB per isolate.

The worker is gone from the pool; the isolate's host pages are not. V8 leaves committed heap on the pinned worker thread, and that thread's allocator never returns those pages (`mi_collect` / `malloc_trim` / `malloc_zone_pressure_relief`). `EdgeRuntime.miCollect()` only purges the main worker.

This decommits the isolate on termination and drops host allocator pages in `DenoRuntime::drop` after `JsRuntime` dispose, on the same thread that owned the isolate.

`test_oneshot_retirement_drops_user_worker` checks the pool count hits 0 after oneshot shutdown. It does not measure RSS.

Fixes #719