### PR TITLE
feat(fs): support Deno.copyFile for S3-backed file systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -41,6 +41,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 
 aws-config = "1.2"
 aws-credential-types = "1.2"

--- a/crates/fs/impl/s3_fs.rs
+++ b/crates/fs/impl/s3_fs.rs
@@ -819,7 +819,7 @@ impl deno_fs::FileSystem for S3Fs {
     self
       .client
       .copy_object()
-      .copy_source(copy_source(&source_bucket, &source_key))
+      .copy_source(to_encoded_copy_source_value(&source_bucket, &source_key))
       .bucket(destination_bucket)
       .key(destination_key)
       .send()
@@ -2073,7 +2073,7 @@ fn try_get_bucket_name_and_key(path: PathBuf) -> FsResult<(String, String)> {
 /// The bucket/key separator and key path separators must remain intact, while
 /// each key segment is URL-encoded so names containing spaces or reserved
 /// characters resolve to the original S3 object.
-fn copy_source(bucket: &str, key: &str) -> String {
+fn to_encoded_copy_source_value(bucket: &str, key: &str) -> String {
   let encoded_key = key
     .split('/')
     .map(urlencoding::encode)
@@ -2215,7 +2215,10 @@ mod test {
   #[test]
   fn copy_source_encodes_key_segments_without_changing_the_path() {
     assert_eq!(
-      super::copy_source("source-bucket", "reports/January 2026?#.pdf"),
+      super::to_encoded_copy_source_value(
+        "source-bucket",
+        "reports/January 2026?#.pdf"
+      ),
       "source-bucket/reports/January%202026%3F%23.pdf"
     );
   }

--- a/crates/fs/impl/s3_fs.rs
+++ b/crates/fs/impl/s3_fs.rs
@@ -26,6 +26,7 @@ use aws_credential_types::credential_fn::provide_credentials_fn;
 use aws_credential_types::Credentials;
 use aws_sdk_s3::config::SharedCredentialsProvider;
 use aws_sdk_s3::config::SharedHttpClient;
+use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::upload_part::UploadPartError;
@@ -785,17 +786,56 @@ impl deno_fs::FileSystem for S3Fs {
     Ok(())
   }
 
-  fn copy_file_sync(&self, _oldpath: &Path, _newpath: &Path) -> FsResult<()> {
-    Err(FsError::NotSupported)
+  fn copy_file_sync(&self, oldpath: &Path, newpath: &Path) -> FsResult<()> {
+    std::thread::scope(|s| {
+      let oldpath = oldpath.to_path_buf();
+      let newpath = newpath.to_path_buf();
+      s.spawn(move || {
+        rt::IO_RT
+          .block_on(async move { self.copy_file_async(oldpath, newpath).await })
+      })
+      .join()
+      .unwrap()
+    })
   }
 
+  #[instrument(level = "trace", skip(self), err(Debug))]
   async fn copy_file_async(
     &self,
-    _oldpath: PathBuf,
-    _newpath: PathBuf,
+    oldpath: PathBuf,
+    newpath: PathBuf,
   ) -> FsResult<()> {
-    // TODO
-    Err(FsError::NotSupported)
+    self.flush_background_tasks().await;
+
+    let (source_bucket, source_key) =
+      try_get_bucket_name_and_key(oldpath.try_normalize()?)?;
+    let (destination_bucket, destination_key) =
+      try_get_bucket_name_and_key(newpath.try_normalize()?)?;
+
+    if source_key.is_empty() || destination_key.is_empty() {
+      return Err(FsError::Io(io::Error::from(io::ErrorKind::InvalidInput)));
+    }
+
+    self
+      .client
+      .copy_object()
+      .copy_source(copy_source(&source_bucket, &source_key))
+      .bucket(destination_bucket)
+      .key(destination_key)
+      .send()
+      .await
+      .map_err(|err| {
+        if matches!(
+          err.as_service_error().and_then(|it| it.code()),
+          Some("NoSuchKey" | "NoSuchBucket")
+        ) {
+          FsError::Io(io::Error::from(io::ErrorKind::NotFound))
+        } else {
+          FsError::Io(io::Error::other(err))
+        }
+      })?;
+
+    Ok(())
   }
 
   fn cp_sync(&self, _path: &Path, _new_path: &Path) -> FsResult<()> {
@@ -2028,6 +2068,21 @@ fn try_get_bucket_name_and_key(path: PathBuf) -> FsResult<(String, String)> {
   ))
 }
 
+/// Builds the `x-amz-copy-source` value required by S3's CopyObject API.
+///
+/// The bucket/key separator and key path separators must remain intact, while
+/// each key segment is URL-encoded so names containing spaces or reserved
+/// characters resolve to the original S3 object.
+fn copy_source(bucket: &str, key: &str) -> String {
+  let encoded_key = key
+    .split('/')
+    .map(urlencoding::encode)
+    .collect::<Vec<_>>()
+    .join("/");
+
+  format!("{bucket}/{encoded_key}")
+}
+
 #[inline(always)]
 fn to_msec(maybe_time: DateTime) -> Option<u64> {
   match SystemTime::try_from(maybe_time) {
@@ -2063,9 +2118,13 @@ mod test {
   use std::sync::Arc;
 
   use aws_config::BehaviorVersion;
+  use aws_sdk_s3::primitives::SdkBody;
   use aws_sdk_s3::{self as s3};
   use aws_smithy_runtime::client::http::test_util::ReplayEvent;
   use aws_smithy_runtime::client::http::test_util::StaticReplayClient;
+  use aws_smithy_runtime_api::http::Request;
+  use aws_smithy_runtime_api::http::Response;
+  use aws_smithy_runtime_api::http::StatusCode;
   use deno_fs::FileSystem;
   use deno_fs::OpenOptions;
   use once_cell::sync::Lazy;
@@ -2124,6 +2183,40 @@ mod test {
         .unwrap()
         .kind(),
       io::ErrorKind::InvalidInput
+    );
+  }
+
+  #[tokio::test]
+  async fn copy_file_should_be_not_found_when_source_does_not_exist() {
+    let (fs, _) = get_s3_fs([ReplayEvent::new(
+      Request::empty(),
+      Response::new(
+        StatusCode::try_from(404).unwrap(),
+        SdkBody::from(
+          r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>"#,
+        ),
+      ),
+    )]);
+
+    assert_eq!(
+      fs.copy_file_async(
+        PathBuf::from("meowmeow/source.txt"),
+        PathBuf::from("meowmeow/destination.txt"),
+      )
+      .await
+      .err()
+      .unwrap()
+      .kind(),
+      io::ErrorKind::NotFound
+    );
+  }
+
+  #[test]
+  fn copy_source_encodes_key_segments_without_changing_the_path() {
+    assert_eq!(
+      super::copy_source("source-bucket", "reports/January 2026?#.pdf"),
+      "source-bucket/reports/January%202026%3F%23.pdf"
     );
   }
 }

--- a/crates/fs/tests/fixture/copy/index.ts
+++ b/crates/fs/tests/fixture/copy/index.ts
@@ -1,0 +1,24 @@
+export default {
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    const bucketName = Deno.env.get("S3FS_TEST_BUCKET_NAME")!;
+    const sourceKey = url.pathname.split("/").slice(2).join("/");
+    const destinationKey = url.searchParams.get("destination");
+    const sync = url.searchParams.get("sync") === "true";
+
+    if (!sourceKey || !destinationKey) {
+      return new Response(null, { status: 400 });
+    }
+
+    const source = `/s3/${bucketName}/${sourceKey}`;
+    const destination = `/s3/${bucketName}/${destinationKey}`;
+
+    if (sync) {
+      Deno.copyFileSync(source, destination);
+    } else {
+      await Deno.copyFile(source, destination);
+    }
+
+    return new Response(null, { status: 200 });
+  },
+};

--- a/crates/fs/tests/integration_tests.rs
+++ b/crates/fs/tests/integration_tests.rs
@@ -138,6 +138,76 @@ async fn test_write_and_get_bytes(bytes: usize) {
 }
 
 #[cfg_attr(not(dotenv), ignore)]
+#[tokio::test]
+#[serial]
+async fn test_copy_file() {
+  remove("", true).await;
+
+  let source_path = get_path("copy/source.txt");
+  let destination_path = get_path("copy/destination.txt");
+  let sync_destination_path = get_path("copy/destination-sync.txt");
+  let body = b"copied from the source object";
+
+  {
+    let tb = get_tb_builder().build().await;
+    let resp = tb
+      .request(|b| {
+        b.uri(format!("/write/{source_path}"))
+          .method("POST")
+          .body(body.as_slice().into())
+          .context("can't make request")
+      })
+      .await
+      .unwrap();
+
+    assert_eq!(resp.status().as_u16(), StatusCode::OK);
+    tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
+  }
+
+  {
+    let tb = get_tb_builder().build().await;
+    for (destination_path, sync) in
+      [(&destination_path, false), (&sync_destination_path, true)]
+    {
+      let resp = tb
+        .request(|b| {
+          b.uri(format!(
+            "/copy/{source_path}?destination={destination_path}&sync={sync}"
+          ))
+          .method("POST")
+          .body(Body::empty())
+          .context("can't make request")
+        })
+        .await
+        .unwrap();
+
+      assert_eq!(resp.status().as_u16(), StatusCode::OK);
+    }
+
+    tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
+  }
+
+  {
+    for destination_path in [&destination_path, &sync_destination_path] {
+      let tb = get_tb_builder().build().await;
+      let mut resp = tb
+        .request(|b| {
+          b.uri(format!("/get/{destination_path}"))
+            .method("GET")
+            .body(Body::empty())
+            .context("can't make request")
+        })
+        .await
+        .unwrap();
+
+      assert_eq!(resp.status().as_u16(), StatusCode::OK);
+      assert_eq!(to_bytes(resp.body_mut()).await.unwrap().as_ref(), body);
+      tb.exit(Duration::from_secs(TESTBED_DEADLINE_SEC)).await;
+    }
+  }
+}
+
+#[cfg_attr(not(dotenv), ignore)]
 #[serial]
 #[tokio::test]
 async fn test_write_and_get_various_bytes() {


### PR DESCRIPTION
## Summary

Adds `Deno.copyFile` and `Deno.copyFileSync` support for S3-backed file systems.

- Copies objects with S3's `CopyObject` API without downloading data locally
- Maps missing source objects/buckets to `NotFound`
- URL-encodes copy-source object keys correctly
- Adds unit and integration test coverage for async and sync copies

## Limitation

This implementation relies on S3 `CopyObject`, which supports source objects up to 5 GiB.
Copying larger objects will require multipart copy support in a follow-up change.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version=1 --locked --offline`
- `cargo test -p fs --lib copy_`