### PR TITLE
fix(types): expose OpenTelemetry APIs in event workers

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -198,6 +198,41 @@ declare namespace EdgeRuntime {
   export function raiseSegfault(): void;
   export function miCollect(): void;
 
+  /** Snapshot handle returned by {@linkcode enterSpan}. */
+  interface AsyncContextSnapshot {
+    __brand: "AsyncContextSnapshot";
+  }
+
+  /**
+   * Returns the tracer backing the runtime's built-in OpenTelemetry support.
+   *
+   * Only available in event workers.
+   */
+  export function builtinTracer(): import("npm:@opentelemetry/api").Tracer;
+
+  /**
+   * Makes the given span the current span of the active context.
+   *
+   * Only available in event workers.
+   */
+  export function enterSpan(
+    span: import("npm:@opentelemetry/api").Span,
+  ): AsyncContextSnapshot | undefined;
+
+  /**
+   * Whether OpenTelemetry metrics collection is enabled.
+   *
+   * Only available in event workers.
+   */
+  export const METRICS_ENABLED: boolean;
+
+  /**
+   * Whether OpenTelemetry tracing is enabled.
+   *
+   * Only available in event workers.
+   */
+  export const TRACING_ENABLED: boolean;
+
   export { UserWorker as userWorkers };
 }
 


### PR DESCRIPTION
## Summary

Adds TypeScript declarations for OpenTelemetry APIs already exposed through
`EdgeRuntime` in event workers:

- `builtinTracer()`
- `enterSpan(span)`
- `TRACING_ENABLED`
- `METRICS_ENABLED`

This improves type checking and editor completion without changing runtime
behavior.

## Validation

- `deno check --config deno.json types/global.d.ts`