### PR TITLE
fix(build): verify Math constants in runtime snapshot

### DIFF
--- a/crates/base/build.rs
+++ b/crates/base/build.rs
@@ -241,6 +241,61 @@ mod supabase_startup_snapshot {
     }
   }
 
+  /// Warmup script passed to `create_snapshot`, doubling as a tripwire: it
+  /// runs on a runtime booted from the freshly created snapshot (still in
+  /// snapshotting mode, so only one V8 initialization mode is ever used in
+  /// this process) and verifies, bit for bit, the `Math` constants baked
+  /// into the snapshot.
+  ///
+  /// V8 computes `Math.E`, `Math.LN10`, `Math.LN2`, `Math.LOG10E`, and
+  /// `Math.LOG2E` at snapshot-creation time, so a build environment that
+  /// corrupts those computations bakes the wrong values into every isolate
+  /// booted from the snapshot (supabase/edge-runtime#723). A mismatch throws
+  /// here, which fails `create_snapshot` -- and therefore the build --
+  /// before the snapshot is ever written to disk.
+  ///
+  /// Keep this script limited to ECMAScript intrinsics: it runs with ops
+  /// registered but without extension op state (`Extension::for_warmup`),
+  /// and everything it touches is re-serialized into the shipped (warmed)
+  /// snapshot.
+  static VERIFY_MATH_CONSTANTS_SCRIPT: &str = r#"
+    (() => {
+      const expected = {
+        E: "4005bf0a8b145769",
+        LN2: "3fe62e42fefa39ef",
+        LN10: "40026bb1bbb55516",
+        LOG2E: "3ff71547652b82fe",
+        LOG10E: "3fdbcb7b1526e50e",
+        PI: "400921fb54442d18",
+        SQRT1_2: "3fe6a09e667f3bcd",
+        SQRT2: "3ff6a09e667f3bcd",
+      };
+      const bits = (value) => {
+        const buf = new ArrayBuffer(8);
+        new DataView(buf).setFloat64(0, value, false);
+        return Array.from(new Uint8Array(buf))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+      };
+      const mismatches = [];
+      for (const [name, want] of Object.entries(expected)) {
+        const got = bits(Math[name]);
+        if (got !== want) {
+          mismatches.push(
+            `Math.${name}: expected 0x${want}, got 0x${got} (${Math[name]})`,
+          );
+        }
+      }
+      if (mismatches.length > 0) {
+        throw new Error(
+          "the freshly created startup snapshot carries corrupted Math " +
+            `constants: ${mismatches.join("; ")}; refusing to continue ` +
+            "the build (see supabase/edge-runtime#723)",
+        );
+      }
+    })();
+  "#;
+
   pub fn create_runtime_snapshot(snapshot_path: PathBuf) {
     let user_agent = String::from("supabase");
     let fs = Arc::new(deno::deno_fs::RealFs);
@@ -307,7 +362,7 @@ mod supabase_startup_snapshot {
         skip_op_registration: false,
         with_runtime_cb: None,
       },
-      None,
+      Some(VERIFY_MATH_CONSTANTS_SCRIPT),
     );
 
     let output = snapshot.unwrap();


### PR DESCRIPTION
## Summary

Follow-up to #723  — this prevents recurrence; it does not by itself fix the already-published amd64 images. V8 computes `Math.E`, `Math.LN10`, `Math.LN2`, `Math.LOG10E`, and `Math.LOG2E` at snapshot-creation time, and `crates/base/build.rs` freezes those values into the startup snapshot that every worker boots from — so a build environment that corrupts the computation ships wrong constants to every user, and nothing in the pipeline could catch it. That is exactly what happened with the linux/amd64 v1.74.2/v1.74.3 images.

This PR passes a warmup script to `create_snapshot` (its second parameter — deno_core's built-in path that boots a snapshotting-mode runtime from the freshly created snapshot, runs the script, and re-serializes). The script compares all eight `Math` constants bit-for-bit against their IEEE-754 representations and throws on any mismatch, which fails `create_snapshot` — and the build — **before the snapshot is ever written to disk**. A corrupted snapshot can no longer reach a cache or a release silently; the failure mode becomes a loud build error:

```
Uncaught Error: the freshly created startup snapshot carries corrupted Math constants:
Math.PI: expected 0xhogehogehogehoge, got 0x400921fb54442d18 (3.141592653589793);
refusing to continue the build (see supabase/edge-runtime#723)
```

Notes on the approach:

- Using the warmup path (rather than booting a regular `JsRuntime` after `create_snapshot`) keeps the whole process in V8's snapshotting mode, respecting deno_core's one-initialization-mode-per-process contract, and lets deno_core derive the ops-only extension set itself (`Extension::for_warmup`) — no duplicated extension list.
- The shipped snapshot becomes a "warmed" one (re-serialized after the script runs). Measured locally (debug, macOS arm64): **9,936,452 → 6,780,949 bytes (~32% smaller)**, and the build script gains ~130 ms.
- The check runs wherever the build runs — the release Docker lanes, CI, and local builds. Merging this also modifies `build.rs`, which forces one fresh snapshot build on the release lane, flushing any currently cached artifact.

## Limitations

- This is a canary on the eight `Math` constants, not a checksum of the whole blob — it detects the observed corruption class, not arbitrary snapshot damage.
- Verification runs one re-serialization before the final bytes; only a nondeterministic corruption striking solely the second serialization could escape. A follow-up integration test probing the built binary would close that gap completely.
- A snapshot corrupted *at rest* in a build cache after a verified build is not re-checked (cargo won't re-run the build script); that residual is covered by the cache-busting suggestion already discussed in the issue.
- Already-published images are unaffected; they need a rebuild.

## Validation

- `cargo check -p base` / full build: the verification runs on every build and passes.
- Negative test: temporarily corrupting one expected value fails the build (exit 101) with the message shown above; reverting restores a green build. (Note for anyone exercising the failure path: deno_core prints a harmless `WARNING: v8::OwnedIsolate for snapshot was leaked` on the error path.)
- Booted the resulting binary against the warmed snapshot: a main-worker service returns all eight constants bit-exact over HTTP, and a user worker created via `EdgeRuntime.userWorkers` serves requests normally, with no errors logged.
