### PR TITLE
fix(deno_crypto): return errors instead of aborting on malformed WebCrypto keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,8 +2082,6 @@ checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
 [[package]]
 name = "deno_crypto"
 version = "0.196.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01b6c50c829ae1579e4ff2ddd834d336027d1cb7f901a058d3d94416d08798d"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ eszip = { git = "https://github.com/supabase/eszip", branch = "fix-pub-vis-0-80-
 v8 = { git = "https://github.com/supabase/rusty_v8", tag = "v130.0.7" }
 
 deno_unsync = { path = "./vendor/deno_unsync" }
+deno_crypto = { path = "./vendor/deno_crypto" }
 deno_fetch = { path = "./vendor/deno_fetch" }
 deno_telemetry = { path = "./vendor/deno_telemetry" }
 deno_http = { path = "./vendor/deno_http" }

--- a/deno/runtime/errors.rs
+++ b/deno/runtime/errors.rs
@@ -457,6 +457,7 @@ fn get_crypto_import_key_error_class(e: &ImportKeyError) -> &'static str {
 fn get_crypto_x448_error_class(e: &deno_crypto::X448Error) -> &'static str {
   match e {
     deno_crypto::X448Error::FailedExport => "DOMExceptionOperationError",
+    deno_crypto::X448Error::InvalidKeyLength => "DOMExceptionDataError",
     deno_crypto::X448Error::Der(_) => "Error",
   }
 }
@@ -464,6 +465,7 @@ fn get_crypto_x448_error_class(e: &deno_crypto::X448Error) -> &'static str {
 fn get_crypto_x25519_error_class(e: &deno_crypto::X25519Error) -> &'static str {
   match e {
     deno_crypto::X25519Error::FailedExport => "DOMExceptionOperationError",
+    deno_crypto::X25519Error::InvalidKeyLength => "DOMExceptionDataError",
     deno_crypto::X25519Error::Der(_) => "Error",
   }
 }

--- a/vendor/deno_crypto/00_crypto.js
+++ b/vendor/deno_crypto/00_crypto.js
@@ -1,0 +1,5740 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// @ts-check
+/// <reference path="../../core/internal.d.ts" />
+/// <reference path="../../core/lib.deno_core.d.ts" />
+/// <reference path="../webidl/internal.d.ts" />
+/// <reference path="../web/lib.deno_web.d.ts" />
+
+import { core, primordials } from "ext:core/mod.js";
+const {
+  isArrayBuffer,
+  isTypedArray,
+  isDataView,
+} = core;
+import {
+  op_crypto_base64url_decode,
+  op_crypto_base64url_encode,
+  op_crypto_decrypt,
+  op_crypto_derive_bits,
+  op_crypto_derive_bits_x25519,
+  op_crypto_derive_bits_x448,
+  op_crypto_encrypt,
+  op_crypto_export_key,
+  op_crypto_export_pkcs8_ed25519,
+  op_crypto_export_pkcs8_x25519,
+  op_crypto_export_pkcs8_x448,
+  op_crypto_export_spki_ed25519,
+  op_crypto_export_spki_x25519,
+  op_crypto_export_spki_x448,
+  op_crypto_generate_ed25519_keypair,
+  op_crypto_generate_key,
+  op_crypto_generate_x25519_keypair,
+  op_crypto_generate_x448_keypair,
+  op_crypto_get_random_values,
+  op_crypto_import_key,
+  op_crypto_import_pkcs8_ed25519,
+  op_crypto_import_pkcs8_x25519,
+  op_crypto_import_pkcs8_x448,
+  op_crypto_import_spki_ed25519,
+  op_crypto_import_spki_x25519,
+  op_crypto_import_spki_x448,
+  op_crypto_jwk_x_ed25519,
+  op_crypto_random_uuid,
+  op_crypto_sign_ed25519,
+  op_crypto_sign_key,
+  op_crypto_subtle_digest,
+  op_crypto_unwrap_key,
+  op_crypto_verify_ed25519,
+  op_crypto_verify_key,
+  op_crypto_wrap_key,
+} from "ext:core/ops";
+const {
+  ArrayBufferIsView,
+  ArrayBufferPrototypeGetByteLength,
+  ArrayBufferPrototypeSlice,
+  ArrayPrototypeEvery,
+  ArrayPrototypeFilter,
+  ArrayPrototypeFind,
+  ArrayPrototypeIncludes,
+  DataViewPrototypeGetBuffer,
+  DataViewPrototypeGetByteLength,
+  DataViewPrototypeGetByteOffset,
+  JSONParse,
+  JSONStringify,
+  MathCeil,
+  ObjectAssign,
+  ObjectHasOwn,
+  ObjectPrototypeIsPrototypeOf,
+  SafeArrayIterator,
+  SafeWeakMap,
+  StringFromCharCode,
+  StringPrototypeCharCodeAt,
+  StringPrototypeToLowerCase,
+  StringPrototypeToUpperCase,
+  Symbol,
+  SymbolFor,
+  SyntaxError,
+  TypeError,
+  TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetByteOffset,
+  TypedArrayPrototypeGetSymbolToStringTag,
+  TypedArrayPrototypeSlice,
+  Uint8Array,
+  WeakMapPrototypeGet,
+  WeakMapPrototypeSet,
+} = primordials;
+
+import * as webidl from "ext:deno_webidl/00_webidl.js";
+import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
+import { DOMException } from "ext:deno_web/01_dom_exception.js";
+
+const supportedNamedCurves = ["P-256", "P-384", "P-521"];
+const recognisedUsages = [
+  "encrypt",
+  "decrypt",
+  "sign",
+  "verify",
+  "deriveKey",
+  "deriveBits",
+  "wrapKey",
+  "unwrapKey",
+];
+
+const simpleAlgorithmDictionaries = {
+  AesGcmParams: { iv: "BufferSource", additionalData: "BufferSource" },
+  RsaHashedKeyGenParams: { hash: "HashAlgorithmIdentifier" },
+  EcKeyGenParams: {},
+  HmacKeyGenParams: { hash: "HashAlgorithmIdentifier" },
+  RsaPssParams: {},
+  EcdsaParams: { hash: "HashAlgorithmIdentifier" },
+  HmacImportParams: { hash: "HashAlgorithmIdentifier" },
+  HkdfParams: {
+    hash: "HashAlgorithmIdentifier",
+    salt: "BufferSource",
+    info: "BufferSource",
+  },
+  Pbkdf2Params: { hash: "HashAlgorithmIdentifier", salt: "BufferSource" },
+  RsaOaepParams: { label: "BufferSource" },
+  RsaHashedImportParams: { hash: "HashAlgorithmIdentifier" },
+  EcKeyImportParams: {},
+};
+
+const supportedAlgorithms = {
+  "digest": {
+    "SHA-1": null,
+    "SHA-256": null,
+    "SHA-384": null,
+    "SHA-512": null,
+  },
+  "generateKey": {
+    "RSASSA-PKCS1-v1_5": "RsaHashedKeyGenParams",
+    "RSA-PSS": "RsaHashedKeyGenParams",
+    "RSA-OAEP": "RsaHashedKeyGenParams",
+    "ECDSA": "EcKeyGenParams",
+    "ECDH": "EcKeyGenParams",
+    "AES-CTR": "AesKeyGenParams",
+    "AES-CBC": "AesKeyGenParams",
+    "AES-GCM": "AesKeyGenParams",
+    "AES-KW": "AesKeyGenParams",
+    "HMAC": "HmacKeyGenParams",
+    "X25519": null,
+    "X448": null,
+    "Ed25519": null,
+  },
+  "sign": {
+    "RSASSA-PKCS1-v1_5": null,
+    "RSA-PSS": "RsaPssParams",
+    "ECDSA": "EcdsaParams",
+    "HMAC": null,
+    "Ed25519": null,
+  },
+  "verify": {
+    "RSASSA-PKCS1-v1_5": null,
+    "RSA-PSS": "RsaPssParams",
+    "ECDSA": "EcdsaParams",
+    "HMAC": null,
+    "Ed25519": null,
+  },
+  "importKey": {
+    "RSASSA-PKCS1-v1_5": "RsaHashedImportParams",
+    "RSA-PSS": "RsaHashedImportParams",
+    "RSA-OAEP": "RsaHashedImportParams",
+    "ECDSA": "EcKeyImportParams",
+    "ECDH": "EcKeyImportParams",
+    "HMAC": "HmacImportParams",
+    "HKDF": null,
+    "PBKDF2": null,
+    "AES-CTR": null,
+    "AES-CBC": null,
+    "AES-GCM": null,
+    "AES-KW": null,
+    "Ed25519": null,
+    "X25519": null,
+    "X448": null,
+  },
+  "deriveBits": {
+    "HKDF": "HkdfParams",
+    "PBKDF2": "Pbkdf2Params",
+    "ECDH": "EcdhKeyDeriveParams",
+    "X25519": "EcdhKeyDeriveParams",
+    "X448": "EcdhKeyDeriveParams",
+  },
+  "encrypt": {
+    "RSA-OAEP": "RsaOaepParams",
+    "AES-CBC": "AesCbcParams",
+    "AES-GCM": "AesGcmParams",
+    "AES-CTR": "AesCtrParams",
+  },
+  "decrypt": {
+    "RSA-OAEP": "RsaOaepParams",
+    "AES-CBC": "AesCbcParams",
+    "AES-GCM": "AesGcmParams",
+    "AES-CTR": "AesCtrParams",
+  },
+  "get key length": {
+    "AES-CBC": "AesDerivedKeyParams",
+    "AES-CTR": "AesDerivedKeyParams",
+    "AES-GCM": "AesDerivedKeyParams",
+    "AES-KW": "AesDerivedKeyParams",
+    "HMAC": "HmacImportParams",
+    "HKDF": null,
+    "PBKDF2": null,
+  },
+  "wrapKey": {
+    "AES-KW": null,
+  },
+  "unwrapKey": {
+    "AES-KW": null,
+  },
+};
+
+const aesJwkAlg = {
+  "AES-CTR": {
+    128: "A128CTR",
+    192: "A192CTR",
+    256: "A256CTR",
+  },
+  "AES-CBC": {
+    128: "A128CBC",
+    192: "A192CBC",
+    256: "A256CBC",
+  },
+  "AES-GCM": {
+    128: "A128GCM",
+    192: "A192GCM",
+    256: "A256GCM",
+  },
+  "AES-KW": {
+    128: "A128KW",
+    192: "A192KW",
+    256: "A256KW",
+  },
+};
+
+// See https://www.w3.org/TR/WebCryptoAPI/#dfn-normalize-an-algorithm
+// 18.4.4
+function normalizeAlgorithm(algorithm, op) {
+  if (typeof algorithm == "string") {
+    return normalizeAlgorithm({ name: algorithm }, op);
+  }
+
+  // 1.
+  const registeredAlgorithms = supportedAlgorithms[op];
+  // 2. 3.
+  const initialAlg = webidl.converters.Algorithm(
+    algorithm,
+    "Failed to normalize algorithm",
+    "passed algorithm",
+  );
+  // 4.
+  let algName = initialAlg.name;
+
+  // 5.
+  let desiredType = undefined;
+  for (const key in registeredAlgorithms) {
+    if (!ObjectHasOwn(registeredAlgorithms, key)) {
+      continue;
+    }
+    if (
+      StringPrototypeToUpperCase(key) === StringPrototypeToUpperCase(algName)
+    ) {
+      algName = key;
+      desiredType = registeredAlgorithms[key];
+    }
+  }
+  if (desiredType === undefined) {
+    throw new DOMException(
+      "Unrecognized algorithm name",
+      "NotSupportedError",
+    );
+  }
+
+  // Fast path everything below if the registered dictionary is "None".
+  if (desiredType === null) {
+    return { name: algName };
+  }
+
+  // 6.
+  const normalizedAlgorithm = webidl.converters[desiredType](
+    algorithm,
+    "Failed to normalize algorithm",
+    "passed algorithm",
+  );
+  // 7.
+  normalizedAlgorithm.name = algName;
+
+  // 9.
+  const dict = simpleAlgorithmDictionaries[desiredType];
+  // 10.
+  for (const member in dict) {
+    if (!ObjectHasOwn(dict, member)) {
+      continue;
+    }
+    const idlType = dict[member];
+    const idlValue = normalizedAlgorithm[member];
+    // 3.
+    if (idlType === "BufferSource" && idlValue) {
+      normalizedAlgorithm[member] = copyBuffer(idlValue);
+    } else if (idlType === "HashAlgorithmIdentifier") {
+      normalizedAlgorithm[member] = normalizeAlgorithm(idlValue, "digest");
+    } else if (idlType === "AlgorithmIdentifier") {
+      // TODO(lucacasonato): implement
+      throw new TypeError("Unimplemented");
+    }
+  }
+
+  return normalizedAlgorithm;
+}
+
+/**
+ * @param {ArrayBufferView | ArrayBuffer} input
+ * @returns {Uint8Array}
+ */
+function copyBuffer(input) {
+  if (isTypedArray(input)) {
+    return TypedArrayPrototypeSlice(
+      new Uint8Array(
+        TypedArrayPrototypeGetBuffer(/** @type {Uint8Array} */ (input)),
+        TypedArrayPrototypeGetByteOffset(/** @type {Uint8Array} */ (input)),
+        TypedArrayPrototypeGetByteLength(/** @type {Uint8Array} */ (input)),
+      ),
+    );
+  } else if (isDataView(input)) {
+    return TypedArrayPrototypeSlice(
+      new Uint8Array(
+        DataViewPrototypeGetBuffer(/** @type {DataView} */ (input)),
+        DataViewPrototypeGetByteOffset(/** @type {DataView} */ (input)),
+        DataViewPrototypeGetByteLength(/** @type {DataView} */ (input)),
+      ),
+    );
+  }
+  // ArrayBuffer
+  return TypedArrayPrototypeSlice(
+    new Uint8Array(
+      input,
+      0,
+      ArrayBufferPrototypeGetByteLength(input),
+    ),
+  );
+}
+
+const _handle = Symbol("[[handle]]");
+const _algorithm = Symbol("[[algorithm]]");
+const _extractable = Symbol("[[extractable]]");
+const _usages = Symbol("[[usages]]");
+const _type = Symbol("[[type]]");
+
+class CryptoKey {
+  /** @type {string} */
+  [_type];
+  /** @type {boolean} */
+  [_extractable];
+  /** @type {object} */
+  [_algorithm];
+  /** @type {string[]} */
+  [_usages];
+  /** @type {object} */
+  [_handle];
+
+  constructor() {
+    webidl.illegalConstructor();
+  }
+
+  /** @returns {string} */
+  get type() {
+    webidl.assertBranded(this, CryptoKeyPrototype);
+    return this[_type];
+  }
+
+  /** @returns {boolean} */
+  get extractable() {
+    webidl.assertBranded(this, CryptoKeyPrototype);
+    return this[_extractable];
+  }
+
+  /** @returns {string[]} */
+  get usages() {
+    webidl.assertBranded(this, CryptoKeyPrototype);
+    // TODO(lucacasonato): return a SameObject copy
+    return this[_usages];
+  }
+
+  /** @returns {object} */
+  get algorithm() {
+    webidl.assertBranded(this, CryptoKeyPrototype);
+    // TODO(lucacasonato): return a SameObject copy
+    return this[_algorithm];
+  }
+
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(CryptoKeyPrototype, this),
+        keys: [
+          "type",
+          "extractable",
+          "algorithm",
+          "usages",
+        ],
+      }),
+      inspectOptions,
+    );
+  }
+}
+
+webidl.configureInterface(CryptoKey);
+const CryptoKeyPrototype = CryptoKey.prototype;
+
+/**
+ * @param {string} type
+ * @param {boolean} extractable
+ * @param {string[]} usages
+ * @param {object} algorithm
+ * @param {object} handle
+ * @returns
+ */
+function constructKey(type, extractable, usages, algorithm, handle) {
+  const key = webidl.createBranded(CryptoKey);
+  key[_type] = type;
+  key[_extractable] = extractable;
+  key[_usages] = usages;
+  key[_algorithm] = algorithm;
+  key[_handle] = handle;
+  return key;
+}
+
+// https://w3c.github.io/webcrypto/#concept-usage-intersection
+/**
+ * @param {string[]} a
+ * @param {string[]} b
+ * @returns
+ */
+function usageIntersection(a, b) {
+  return ArrayPrototypeFilter(
+    a,
+    (i) => ArrayPrototypeIncludes(b, i),
+  );
+}
+
+// TODO(lucacasonato): this should be moved to rust
+/** @type {WeakMap<object, object>} */
+const KEY_STORE = new SafeWeakMap();
+
+function getKeyLength(algorithm) {
+  switch (algorithm.name) {
+    case "AES-CBC":
+    case "AES-CTR":
+    case "AES-GCM":
+    case "AES-KW": {
+      // 1.
+      if (!ArrayPrototypeIncludes([128, 192, 256], algorithm.length)) {
+        throw new DOMException(
+          `Length must be 128, 192, or 256: received ${algorithm.length}`,
+          "OperationError",
+        );
+      }
+
+      // 2.
+      return algorithm.length;
+    }
+    case "HMAC": {
+      // 1.
+      let length;
+      if (algorithm.length === undefined) {
+        switch (algorithm.hash.name) {
+          case "SHA-1":
+            length = 512;
+            break;
+          case "SHA-256":
+            length = 512;
+            break;
+          case "SHA-384":
+            length = 1024;
+            break;
+          case "SHA-512":
+            length = 1024;
+            break;
+          default:
+            throw new DOMException(
+              `Unrecognized hash algorithm: ${algorithm.hash.name}`,
+              "NotSupportedError",
+            );
+        }
+      } else if (algorithm.length !== 0) {
+        length = algorithm.length;
+      } else {
+        throw new TypeError(`Invalid length: ${algorithm.length}`);
+      }
+
+      // 2.
+      return length;
+    }
+    case "HKDF": {
+      // 1.
+      return null;
+    }
+    case "PBKDF2": {
+      // 1.
+      return null;
+    }
+    default:
+      throw new TypeError("Unreachable");
+  }
+}
+
+class SubtleCrypto {
+  constructor() {
+    webidl.illegalConstructor();
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {BufferSource} data
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async digest(algorithm, data) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'digest' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 2, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    data = webidl.converters.BufferSource(data, prefix, "Argument 2");
+
+    data = copyBuffer(data);
+
+    algorithm = normalizeAlgorithm(algorithm, "digest");
+
+    const result = await op_crypto_subtle_digest(
+      algorithm.name,
+      data,
+    );
+
+    return TypedArrayPrototypeGetBuffer(result);
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {CryptoKey} key
+   * @param {BufferSource} data
+   * @returns {Promise<any>}
+   */
+  async encrypt(algorithm, key, data) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'encrypt' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 3, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+    data = webidl.converters.BufferSource(data, prefix, "Argument 3");
+
+    // 2.
+    data = copyBuffer(data);
+
+    // 3.
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "encrypt");
+
+    // 8.
+    if (normalizedAlgorithm.name !== key[_algorithm].name) {
+      throw new DOMException(
+        `Encryption algorithm '${normalizedAlgorithm.name}' does not match key algorithm`,
+        "InvalidAccessError",
+      );
+    }
+
+    // 9.
+    if (!ArrayPrototypeIncludes(key[_usages], "encrypt")) {
+      throw new DOMException(
+        "Key does not support the 'encrypt' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    return await encrypt(normalizedAlgorithm, key, data);
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {CryptoKey} key
+   * @param {BufferSource} data
+   * @returns {Promise<any>}
+   */
+  async decrypt(algorithm, key, data) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'decrypt' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 3, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+    data = webidl.converters.BufferSource(data, prefix, "Argument 3");
+
+    // 2.
+    data = copyBuffer(data);
+
+    // 3.
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "decrypt");
+
+    // 8.
+    if (normalizedAlgorithm.name !== key[_algorithm].name) {
+      throw new DOMException(
+        `Decryption algorithm "${normalizedAlgorithm.name}" does not match key algorithm`,
+        "OperationError",
+      );
+    }
+
+    // 9.
+    if (!ArrayPrototypeIncludes(key[_usages], "decrypt")) {
+      throw new DOMException(
+        "Key does not support the 'decrypt' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    const handle = key[_handle];
+    const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+    switch (normalizedAlgorithm.name) {
+      case "RSA-OAEP": {
+        // 1.
+        if (key[_type] !== "private") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        // 2.
+        if (normalizedAlgorithm.label) {
+          normalizedAlgorithm.label = copyBuffer(normalizedAlgorithm.label);
+        } else {
+          normalizedAlgorithm.label = new Uint8Array();
+        }
+
+        // 3-5.
+        const hashAlgorithm = key[_algorithm].hash.name;
+        const plainText = await op_crypto_decrypt({
+          key: keyData,
+          algorithm: "RSA-OAEP",
+          hash: hashAlgorithm,
+          label: normalizedAlgorithm.label,
+        }, data);
+
+        // 6.
+        return TypedArrayPrototypeGetBuffer(plainText);
+      }
+      case "AES-CBC": {
+        normalizedAlgorithm.iv = copyBuffer(normalizedAlgorithm.iv);
+
+        // 1.
+        if (TypedArrayPrototypeGetByteLength(normalizedAlgorithm.iv) !== 16) {
+          throw new DOMException(
+            "Counter must be 16 bytes",
+            "OperationError",
+          );
+        }
+
+        const plainText = await op_crypto_decrypt({
+          key: keyData,
+          algorithm: "AES-CBC",
+          iv: normalizedAlgorithm.iv,
+          length: key[_algorithm].length,
+        }, data);
+
+        // 6.
+        return TypedArrayPrototypeGetBuffer(plainText);
+      }
+      case "AES-CTR": {
+        normalizedAlgorithm.counter = copyBuffer(normalizedAlgorithm.counter);
+
+        // 1.
+        if (
+          TypedArrayPrototypeGetByteLength(normalizedAlgorithm.counter) !== 16
+        ) {
+          throw new DOMException(
+            "Counter vector must be 16 bytes",
+            "OperationError",
+          );
+        }
+
+        // 2.
+        if (
+          normalizedAlgorithm.length === 0 || normalizedAlgorithm.length > 128
+        ) {
+          throw new DOMException(
+            `Counter length must not be 0 or greater than 128: received ${normalizedAlgorithm.length}`,
+            "OperationError",
+          );
+        }
+
+        // 3.
+        const cipherText = await op_crypto_decrypt({
+          key: keyData,
+          algorithm: "AES-CTR",
+          keyLength: key[_algorithm].length,
+          counter: normalizedAlgorithm.counter,
+          ctrLength: normalizedAlgorithm.length,
+        }, data);
+
+        // 4.
+        return TypedArrayPrototypeGetBuffer(cipherText);
+      }
+      case "AES-GCM": {
+        normalizedAlgorithm.iv = copyBuffer(normalizedAlgorithm.iv);
+
+        // 1.
+        if (normalizedAlgorithm.tagLength === undefined) {
+          normalizedAlgorithm.tagLength = 128;
+        } else if (
+          !ArrayPrototypeIncludes(
+            [32, 64, 96, 104, 112, 120, 128],
+            normalizedAlgorithm.tagLength,
+          )
+        ) {
+          throw new DOMException(
+            `Invalid tag length: ${normalizedAlgorithm.tagLength}`,
+            "OperationError",
+          );
+        }
+
+        // 2.
+        if (
+          TypedArrayPrototypeGetByteLength(data) <
+            normalizedAlgorithm.tagLength / 8
+        ) {
+          throw new DOMException(
+            "Tag length overflows ciphertext",
+            "OperationError",
+          );
+        }
+
+        // 3. We only support 96-bit and 128-bit nonce.
+        if (
+          ArrayPrototypeIncludes(
+            [12, 16],
+            TypedArrayPrototypeGetByteLength(normalizedAlgorithm.iv),
+          ) === undefined
+        ) {
+          throw new DOMException(
+            "Initialization vector length not supported",
+            "NotSupportedError",
+          );
+        }
+
+        // 4.
+        if (normalizedAlgorithm.additionalData !== undefined) {
+          // NOTE: over the size of Number.MAX_SAFE_INTEGER is not available in V8
+          // if (normalizedAlgorithm.additionalData.byteLength > (2 ** 64) - 1) {
+          //   throw new DOMException(
+          //     "Additional data too large",
+          //     "OperationError",
+          //   );
+          // }
+          normalizedAlgorithm.additionalData = copyBuffer(
+            normalizedAlgorithm.additionalData,
+          );
+        }
+
+        // 5-8.
+        const plaintext = await op_crypto_decrypt({
+          key: keyData,
+          algorithm: "AES-GCM",
+          length: key[_algorithm].length,
+          iv: normalizedAlgorithm.iv,
+          additionalData: normalizedAlgorithm.additionalData ||
+            null,
+          tagLength: normalizedAlgorithm.tagLength,
+        }, data);
+
+        // 9.
+        return TypedArrayPrototypeGetBuffer(plaintext);
+      }
+      default:
+        throw new DOMException("Not implemented", "NotSupportedError");
+    }
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {CryptoKey} key
+   * @param {BufferSource} data
+   * @returns {Promise<any>}
+   */
+  async sign(algorithm, key, data) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'sign' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 3, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+    data = webidl.converters.BufferSource(data, prefix, "Argument 3");
+
+    // 1.
+    data = copyBuffer(data);
+
+    // 2.
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "sign");
+
+    const handle = key[_handle];
+    const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+    // 8.
+    if (normalizedAlgorithm.name !== key[_algorithm].name) {
+      throw new DOMException(
+        "Signing algorithm does not match key algorithm",
+        "InvalidAccessError",
+      );
+    }
+
+    // 9.
+    if (!ArrayPrototypeIncludes(key[_usages], "sign")) {
+      throw new DOMException(
+        "Key does not support the 'sign' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    switch (normalizedAlgorithm.name) {
+      case "RSASSA-PKCS1-v1_5": {
+        // 1.
+        if (key[_type] !== "private") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        // 2.
+        const hashAlgorithm = key[_algorithm].hash.name;
+        const signature = await op_crypto_sign_key({
+          key: keyData,
+          algorithm: "RSASSA-PKCS1-v1_5",
+          hash: hashAlgorithm,
+        }, data);
+
+        return TypedArrayPrototypeGetBuffer(signature);
+      }
+      case "RSA-PSS": {
+        // 1.
+        if (key[_type] !== "private") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        // 2.
+        const hashAlgorithm = key[_algorithm].hash.name;
+        const signature = await op_crypto_sign_key({
+          key: keyData,
+          algorithm: "RSA-PSS",
+          hash: hashAlgorithm,
+          saltLength: normalizedAlgorithm.saltLength,
+        }, data);
+
+        return TypedArrayPrototypeGetBuffer(signature);
+      }
+      case "ECDSA": {
+        // 1.
+        if (key[_type] !== "private") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        // 2.
+        const hashAlgorithm = normalizedAlgorithm.hash.name;
+        const namedCurve = key[_algorithm].namedCurve;
+        if (!ArrayPrototypeIncludes(supportedNamedCurves, namedCurve)) {
+          throw new DOMException("Curve not supported", "NotSupportedError");
+        }
+
+        if (
+          (key[_algorithm].namedCurve === "P-256" &&
+            hashAlgorithm !== "SHA-256") ||
+          (key[_algorithm].namedCurve === "P-384" &&
+            hashAlgorithm !== "SHA-384")
+        ) {
+          throw new DOMException(
+            "Not implemented",
+            "NotSupportedError",
+          );
+        }
+
+        const signature = await op_crypto_sign_key({
+          key: keyData,
+          algorithm: "ECDSA",
+          hash: hashAlgorithm,
+          namedCurve,
+        }, data);
+
+        return TypedArrayPrototypeGetBuffer(signature);
+      }
+      case "HMAC": {
+        const hashAlgorithm = key[_algorithm].hash.name;
+
+        const signature = await op_crypto_sign_key({
+          key: keyData,
+          algorithm: "HMAC",
+          hash: hashAlgorithm,
+        }, data);
+
+        return TypedArrayPrototypeGetBuffer(signature);
+      }
+      case "Ed25519": {
+        // 1.
+        if (key[_type] !== "private") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        // https://briansmith.org/rustdoc/src/ring/ec/curve25519/ed25519/signing.rs.html#260
+        const SIGNATURE_LEN = 32 * 2; // ELEM_LEN + SCALAR_LEN
+        const signature = new Uint8Array(SIGNATURE_LEN);
+        if (!op_crypto_sign_ed25519(keyData, data, signature)) {
+          throw new DOMException(
+            "Failed to sign",
+            "OperationError",
+          );
+        }
+        return TypedArrayPrototypeGetBuffer(signature);
+      }
+    }
+
+    throw new TypeError("Unreachable");
+  }
+
+  /**
+   * @param {string} format
+   * @param {BufferSource} keyData
+   * @param {string} algorithm
+   * @param {boolean} extractable
+   * @param {KeyUsages[]} keyUsages
+   * @returns {Promise<any>}
+   */
+  async importKey(format, keyData, algorithm, extractable, keyUsages) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'importKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 4, prefix);
+    format = webidl.converters.KeyFormat(format, prefix, "Argument 1");
+    keyData = webidl.converters["BufferSource or JsonWebKey"](
+      keyData,
+      prefix,
+      "Argument 2",
+    );
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 3",
+    );
+    extractable = webidl.converters.boolean(extractable, prefix, "Argument 4");
+    keyUsages = webidl.converters["sequence<KeyUsage>"](
+      keyUsages,
+      prefix,
+      "Argument 5",
+    );
+
+    // 2.
+    if (format !== "jwk") {
+      if (ArrayBufferIsView(keyData) || isArrayBuffer(keyData)) {
+        keyData = copyBuffer(keyData);
+      } else {
+        throw new TypeError("Cannot import key: 'keyData' is a JsonWebKey");
+      }
+    } else {
+      if (ArrayBufferIsView(keyData) || isArrayBuffer(keyData)) {
+        throw new TypeError("Cannot import key: 'keyData' is not a JsonWebKey");
+      }
+    }
+
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "importKey");
+
+    // 8.
+    const result = await importKeyInner(
+      format,
+      normalizedAlgorithm,
+      keyData,
+      extractable,
+      keyUsages,
+    );
+
+    // 9.
+    if (
+      ArrayPrototypeIncludes(["private", "secret"], result[_type]) &&
+      keyUsages.length == 0
+    ) {
+      throw new SyntaxError("Invalid key usage");
+    }
+
+    return result;
+  }
+
+  /**
+   * @param {string} format
+   * @param {CryptoKey} key
+   * @returns {Promise<any>}
+   */
+  // deno-lint-ignore require-await
+  async exportKey(format, key) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'exportKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 2, prefix);
+    format = webidl.converters.KeyFormat(format, prefix, "Argument 1");
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+
+    const handle = key[_handle];
+    // 2.
+    const innerKey = WeakMapPrototypeGet(KEY_STORE, handle);
+
+    const algorithmName = key[_algorithm].name;
+
+    let result;
+
+    switch (algorithmName) {
+      case "HMAC": {
+        result = exportKeyHMAC(format, key, innerKey);
+        break;
+      }
+      case "RSASSA-PKCS1-v1_5":
+      case "RSA-PSS":
+      case "RSA-OAEP": {
+        result = exportKeyRSA(format, key, innerKey);
+        break;
+      }
+      case "ECDH":
+      case "ECDSA": {
+        result = exportKeyEC(format, key, innerKey);
+        break;
+      }
+      case "Ed25519": {
+        result = exportKeyEd25519(format, key, innerKey);
+        break;
+      }
+      case "X448": {
+        result = exportKeyX448(format, key, innerKey);
+        break;
+      }
+      case "X25519": {
+        result = exportKeyX25519(format, key, innerKey);
+        break;
+      }
+      case "AES-CTR":
+      case "AES-CBC":
+      case "AES-GCM":
+      case "AES-KW": {
+        result = exportKeyAES(format, key, innerKey);
+        break;
+      }
+      default:
+        throw new DOMException("Not implemented", "NotSupportedError");
+    }
+
+    if (key.extractable === false) {
+      throw new DOMException(
+        "Key is not extractable",
+        "InvalidAccessError",
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * @param {AlgorithmIdentifier} algorithm
+   * @param {CryptoKey} baseKey
+   * @param {number | null} length
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async deriveBits(algorithm, baseKey, length = null) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'deriveBits' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 2, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    baseKey = webidl.converters.CryptoKey(baseKey, prefix, "Argument 2");
+    if (length !== null) {
+      length = webidl.converters["unsigned long"](length, prefix, "Argument 3");
+    }
+
+    // 2.
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "deriveBits");
+    // 4-6.
+    const result = await deriveBits(normalizedAlgorithm, baseKey, length);
+    // 7.
+    if (normalizedAlgorithm.name !== baseKey[_algorithm].name) {
+      throw new DOMException("Invalid algorithm name", "InvalidAccessError");
+    }
+    // 8.
+    if (!ArrayPrototypeIncludes(baseKey[_usages], "deriveBits")) {
+      throw new DOMException(
+        "'baseKey' usages does not contain 'deriveBits'",
+        "InvalidAccessError",
+      );
+    }
+    // 9-10.
+    return result;
+  }
+
+  /**
+   * @param {AlgorithmIdentifier} algorithm
+   * @param {CryptoKey} baseKey
+   * @param {number} length
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async deriveKey(
+    algorithm,
+    baseKey,
+    derivedKeyType,
+    extractable,
+    keyUsages,
+  ) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'deriveKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 5, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    baseKey = webidl.converters.CryptoKey(baseKey, prefix, "Argument 2");
+    derivedKeyType = webidl.converters.AlgorithmIdentifier(
+      derivedKeyType,
+      prefix,
+      "Argument 3",
+    );
+    extractable = webidl.converters["boolean"](
+      extractable,
+      prefix,
+      "Argument 4",
+    );
+    keyUsages = webidl.converters["sequence<KeyUsage>"](
+      keyUsages,
+      prefix,
+      "Argument 5",
+    );
+
+    // 2-3.
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "deriveBits");
+
+    // 4-5.
+    const normalizedDerivedKeyAlgorithmImport = normalizeAlgorithm(
+      derivedKeyType,
+      "importKey",
+    );
+
+    // 6-7.
+    const normalizedDerivedKeyAlgorithmLength = normalizeAlgorithm(
+      derivedKeyType,
+      "get key length",
+    );
+
+    // 8-10.
+
+    // 11.
+    if (normalizedAlgorithm.name !== baseKey[_algorithm].name) {
+      throw new DOMException(
+        `Invalid algorithm name: ${normalizedAlgorithm.name}`,
+        "InvalidAccessError",
+      );
+    }
+
+    // 12.
+    if (!ArrayPrototypeIncludes(baseKey[_usages], "deriveKey")) {
+      throw new DOMException(
+        "'baseKey' usages does not contain 'deriveKey'",
+        "InvalidAccessError",
+      );
+    }
+
+    // 13.
+    const length = getKeyLength(normalizedDerivedKeyAlgorithmLength);
+
+    // 14.
+    const secret = await deriveBits(
+      normalizedAlgorithm,
+      baseKey,
+      length,
+    );
+
+    // 15.
+    const result = await this.importKey(
+      "raw",
+      secret,
+      normalizedDerivedKeyAlgorithmImport,
+      extractable,
+      keyUsages,
+    );
+
+    // 16.
+    if (
+      ArrayPrototypeIncludes(["private", "secret"], result[_type]) &&
+      keyUsages.length == 0
+    ) {
+      throw new SyntaxError("Invalid key usage");
+    }
+    // 17.
+    return result;
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {CryptoKey} key
+   * @param {BufferSource} signature
+   * @param {BufferSource} data
+   * @returns {Promise<boolean>}
+   */
+  async verify(algorithm, key, signature, data) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'verify' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 4, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+    signature = webidl.converters.BufferSource(signature, prefix, "Argument 3");
+    data = webidl.converters.BufferSource(data, prefix, "Argument 4");
+
+    // 2.
+    signature = copyBuffer(signature);
+
+    // 3.
+    data = copyBuffer(data);
+
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "verify");
+
+    const handle = key[_handle];
+    const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+    if (normalizedAlgorithm.name !== key[_algorithm].name) {
+      throw new DOMException(
+        "Verifying algorithm does not match key algorithm",
+        "InvalidAccessError",
+      );
+    }
+
+    if (!ArrayPrototypeIncludes(key[_usages], "verify")) {
+      throw new DOMException(
+        "Key does not support the 'verify' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    switch (normalizedAlgorithm.name) {
+      case "RSASSA-PKCS1-v1_5": {
+        if (key[_type] !== "public") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        const hashAlgorithm = key[_algorithm].hash.name;
+        return await op_crypto_verify_key({
+          key: keyData,
+          algorithm: "RSASSA-PKCS1-v1_5",
+          hash: hashAlgorithm,
+          signature,
+        }, data);
+      }
+      case "RSA-PSS": {
+        if (key[_type] !== "public") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        const hashAlgorithm = key[_algorithm].hash.name;
+        return await op_crypto_verify_key({
+          key: keyData,
+          algorithm: "RSA-PSS",
+          hash: hashAlgorithm,
+          signature,
+          saltLength: normalizedAlgorithm.saltLength,
+        }, data);
+      }
+      case "HMAC": {
+        const hash = key[_algorithm].hash.name;
+        return await op_crypto_verify_key({
+          key: keyData,
+          algorithm: "HMAC",
+          hash,
+          signature,
+        }, data);
+      }
+      case "ECDSA": {
+        // 1.
+        if (key[_type] !== "public") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+        // 2.
+        const hash = normalizedAlgorithm.hash.name;
+
+        if (
+          (key[_algorithm].namedCurve === "P-256" && hash !== "SHA-256") ||
+          (key[_algorithm].namedCurve === "P-384" && hash !== "SHA-384")
+        ) {
+          throw new DOMException(
+            "Not implemented",
+            "NotSupportedError",
+          );
+        }
+
+        // 3-8.
+        return await op_crypto_verify_key({
+          key: keyData,
+          algorithm: "ECDSA",
+          hash,
+          signature,
+          namedCurve: key[_algorithm].namedCurve,
+        }, data);
+      }
+      case "Ed25519": {
+        // 1.
+        if (key[_type] !== "public") {
+          throw new DOMException(
+            "Key type not supported",
+            "InvalidAccessError",
+          );
+        }
+
+        return op_crypto_verify_ed25519(keyData, data, signature);
+      }
+    }
+
+    throw new TypeError("Unreachable");
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {boolean} extractable
+   * @param {KeyUsage[]} keyUsages
+   * @returns {Promise<any>}
+   */
+  async wrapKey(format, key, wrappingKey, wrapAlgorithm) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'wrapKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 4, prefix);
+    format = webidl.converters.KeyFormat(format, prefix, "Argument 1");
+    key = webidl.converters.CryptoKey(key, prefix, "Argument 2");
+    wrappingKey = webidl.converters.CryptoKey(
+      wrappingKey,
+      prefix,
+      "Argument 3",
+    );
+    wrapAlgorithm = webidl.converters.AlgorithmIdentifier(
+      wrapAlgorithm,
+      prefix,
+      "Argument 4",
+    );
+
+    let normalizedAlgorithm;
+
+    try {
+      // 2.
+      normalizedAlgorithm = normalizeAlgorithm(wrapAlgorithm, "wrapKey");
+    } catch (_) {
+      // 3.
+      normalizedAlgorithm = normalizeAlgorithm(wrapAlgorithm, "encrypt");
+    }
+
+    // 8.
+    if (normalizedAlgorithm.name !== wrappingKey[_algorithm].name) {
+      throw new DOMException(
+        "Wrapping algorithm does not match key algorithm",
+        "InvalidAccessError",
+      );
+    }
+
+    // 9.
+    if (!ArrayPrototypeIncludes(wrappingKey[_usages], "wrapKey")) {
+      throw new DOMException(
+        "Key does not support the 'wrapKey' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    // 10. NotSupportedError will be thrown in step 12.
+    // 11.
+    if (key[_extractable] === false) {
+      throw new DOMException(
+        "Key is not extractable",
+        "InvalidAccessError",
+      );
+    }
+
+    // 12.
+    const exportedKey = await this.exportKey(format, key);
+
+    let bytes;
+    // 13.
+    if (format !== "jwk") {
+      bytes = new Uint8Array(exportedKey);
+    } else {
+      const jwk = JSONStringify(exportedKey);
+      const ret = new Uint8Array(jwk.length);
+      for (let i = 0; i < jwk.length; i++) {
+        ret[i] = StringPrototypeCharCodeAt(jwk, i);
+      }
+      bytes = ret;
+    }
+
+    // 14-15.
+    if (
+      supportedAlgorithms["wrapKey"][normalizedAlgorithm.name] !== undefined
+    ) {
+      const handle = wrappingKey[_handle];
+      const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+      switch (normalizedAlgorithm.name) {
+        case "AES-KW": {
+          const cipherText = await op_crypto_wrap_key({
+            key: keyData,
+            algorithm: normalizedAlgorithm.name,
+          }, bytes);
+
+          // 4.
+          return TypedArrayPrototypeGetBuffer(cipherText);
+        }
+        default: {
+          throw new DOMException(
+            "Not implemented",
+            "NotSupportedError",
+          );
+        }
+      }
+    } else if (
+      supportedAlgorithms["encrypt"][normalizedAlgorithm.name] !== undefined
+    ) {
+      // must construct a new key, since keyUsages is ["wrapKey"] and not ["encrypt"]
+      return await encrypt(
+        normalizedAlgorithm,
+        constructKey(
+          wrappingKey[_type],
+          wrappingKey[_extractable],
+          ["encrypt"],
+          wrappingKey[_algorithm],
+          wrappingKey[_handle],
+        ),
+        bytes,
+      );
+    } else {
+      throw new DOMException(
+        "Algorithm not supported",
+        "NotSupportedError",
+      );
+    }
+  }
+  /**
+   * @param {string} format
+   * @param {BufferSource} wrappedKey
+   * @param {CryptoKey} unwrappingKey
+   * @param {AlgorithmIdentifier} unwrapAlgorithm
+   * @param {AlgorithmIdentifier} unwrappedKeyAlgorithm
+   * @param {boolean} extractable
+   * @param {KeyUsage[]} keyUsages
+   * @returns {Promise<CryptoKey>}
+   */
+  async unwrapKey(
+    format,
+    wrappedKey,
+    unwrappingKey,
+    unwrapAlgorithm,
+    unwrappedKeyAlgorithm,
+    extractable,
+    keyUsages,
+  ) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'unwrapKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 7, prefix);
+    format = webidl.converters.KeyFormat(format, prefix, "Argument 1");
+    wrappedKey = webidl.converters.BufferSource(
+      wrappedKey,
+      prefix,
+      "Argument 2",
+    );
+    unwrappingKey = webidl.converters.CryptoKey(
+      unwrappingKey,
+      prefix,
+      "Argument 3",
+    );
+    unwrapAlgorithm = webidl.converters.AlgorithmIdentifier(
+      unwrapAlgorithm,
+      prefix,
+      "Argument 4",
+    );
+    unwrappedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(
+      unwrappedKeyAlgorithm,
+      prefix,
+      "Argument 5",
+    );
+    extractable = webidl.converters.boolean(extractable, prefix, "Argument 6");
+    keyUsages = webidl.converters["sequence<KeyUsage>"](
+      keyUsages,
+      prefix,
+      "Argument 7",
+    );
+
+    // 2.
+    wrappedKey = copyBuffer(wrappedKey);
+
+    let normalizedAlgorithm;
+
+    try {
+      // 3.
+      normalizedAlgorithm = normalizeAlgorithm(unwrapAlgorithm, "unwrapKey");
+    } catch (_) {
+      // 4.
+      normalizedAlgorithm = normalizeAlgorithm(unwrapAlgorithm, "decrypt");
+    }
+
+    // 6.
+    const normalizedKeyAlgorithm = normalizeAlgorithm(
+      unwrappedKeyAlgorithm,
+      "importKey",
+    );
+
+    // 11.
+    if (normalizedAlgorithm.name !== unwrappingKey[_algorithm].name) {
+      throw new DOMException(
+        "Unwrapping algorithm does not match key algorithm",
+        "InvalidAccessError",
+      );
+    }
+
+    // 12.
+    if (!ArrayPrototypeIncludes(unwrappingKey[_usages], "unwrapKey")) {
+      throw new DOMException(
+        "Key does not support the 'unwrapKey' operation",
+        "InvalidAccessError",
+      );
+    }
+
+    // 13.
+    let key;
+    if (
+      supportedAlgorithms["unwrapKey"][normalizedAlgorithm.name] !== undefined
+    ) {
+      const handle = unwrappingKey[_handle];
+      const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+      switch (normalizedAlgorithm.name) {
+        case "AES-KW": {
+          const plainText = await op_crypto_unwrap_key({
+            key: keyData,
+            algorithm: normalizedAlgorithm.name,
+          }, wrappedKey);
+
+          // 4.
+          key = TypedArrayPrototypeGetBuffer(plainText);
+          break;
+        }
+        default: {
+          throw new DOMException(
+            "Not implemented",
+            "NotSupportedError",
+          );
+        }
+      }
+    } else if (
+      supportedAlgorithms["decrypt"][normalizedAlgorithm.name] !== undefined
+    ) {
+      // must construct a new key, since keyUsages is ["unwrapKey"] and not ["decrypt"]
+      key = await this.decrypt(
+        normalizedAlgorithm,
+        constructKey(
+          unwrappingKey[_type],
+          unwrappingKey[_extractable],
+          ["decrypt"],
+          unwrappingKey[_algorithm],
+          unwrappingKey[_handle],
+        ),
+        wrappedKey,
+      );
+    } else {
+      throw new DOMException(
+        "Algorithm not supported",
+        "NotSupportedError",
+      );
+    }
+
+    let bytes;
+    // 14.
+    if (format !== "jwk") {
+      bytes = key;
+    } else {
+      const k = new Uint8Array(key);
+      let str = "";
+      for (let i = 0; i < k.length; i++) {
+        str += StringFromCharCode(k[i]);
+      }
+      bytes = JSONParse(str);
+    }
+
+    // 15.
+    const result = await this.importKey(
+      format,
+      bytes,
+      normalizedKeyAlgorithm,
+      extractable,
+      keyUsages,
+    );
+    // 16.
+    if (
+      (result[_type] == "secret" || result[_type] == "private") &&
+      keyUsages.length == 0
+    ) {
+      throw new SyntaxError("Invalid key type");
+    }
+    // 17.
+    result[_extractable] = extractable;
+    // 18.
+    result[_usages] = usageIntersection(keyUsages, recognisedUsages);
+    // 19.
+    return result;
+  }
+
+  /**
+   * @param {string} algorithm
+   * @param {boolean} extractable
+   * @param {KeyUsage[]} keyUsages
+   * @returns {Promise<any>}
+   */
+  async generateKey(algorithm, extractable, keyUsages) {
+    webidl.assertBranded(this, SubtleCryptoPrototype);
+    const prefix = "Failed to execute 'generateKey' on 'SubtleCrypto'";
+    webidl.requiredArguments(arguments.length, 3, prefix);
+    algorithm = webidl.converters.AlgorithmIdentifier(
+      algorithm,
+      prefix,
+      "Argument 1",
+    );
+    extractable = webidl.converters["boolean"](
+      extractable,
+      prefix,
+      "Argument 2",
+    );
+    keyUsages = webidl.converters["sequence<KeyUsage>"](
+      keyUsages,
+      prefix,
+      "Argument 3",
+    );
+
+    const usages = keyUsages;
+
+    const normalizedAlgorithm = normalizeAlgorithm(algorithm, "generateKey");
+    const result = await generateKey(
+      normalizedAlgorithm,
+      extractable,
+      usages,
+    );
+
+    if (ObjectPrototypeIsPrototypeOf(CryptoKeyPrototype, result)) {
+      const type = result[_type];
+      if ((type === "secret" || type === "private") && usages.length === 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+    } else if (
+      ObjectPrototypeIsPrototypeOf(CryptoKeyPrototype, result.privateKey)
+    ) {
+      if (result.privateKey[_usages].length === 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+    }
+
+    return result;
+  }
+
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return `${this.constructor.name} ${inspect({}, inspectOptions)}`;
+  }
+}
+const SubtleCryptoPrototype = SubtleCrypto.prototype;
+
+async function generateKey(normalizedAlgorithm, extractable, usages) {
+  const algorithmName = normalizedAlgorithm.name;
+
+  switch (algorithmName) {
+    case "RSASSA-PKCS1-v1_5":
+    case "RSA-PSS": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["sign", "verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2.
+      const keyData = await op_crypto_generate_key(
+        {
+          algorithm: "RSA",
+          modulusLength: normalizedAlgorithm.modulusLength,
+          publicExponent: normalizedAlgorithm.publicExponent,
+        },
+      );
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, {
+        type: "private",
+        data: keyData,
+      });
+
+      // 4-8.
+      const algorithm = {
+        name: algorithmName,
+        modulusLength: normalizedAlgorithm.modulusLength,
+        publicExponent: normalizedAlgorithm.publicExponent,
+        hash: normalizedAlgorithm.hash,
+      };
+
+      // 9-13.
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, ["verify"]),
+        algorithm,
+        handle,
+      );
+
+      // 14-18.
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["sign"]),
+        algorithm,
+        handle,
+      );
+
+      // 19-22.
+      return { publicKey, privateKey };
+    }
+    case "RSA-OAEP": {
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) =>
+            !ArrayPrototypeIncludes([
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+            ], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2.
+      const keyData = await op_crypto_generate_key(
+        {
+          algorithm: "RSA",
+          modulusLength: normalizedAlgorithm.modulusLength,
+          publicExponent: normalizedAlgorithm.publicExponent,
+        },
+      );
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, {
+        type: "private",
+        data: keyData,
+      });
+
+      // 4-8.
+      const algorithm = {
+        name: algorithmName,
+        modulusLength: normalizedAlgorithm.modulusLength,
+        publicExponent: normalizedAlgorithm.publicExponent,
+        hash: normalizedAlgorithm.hash,
+      };
+
+      // 9-13.
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, ["encrypt", "wrapKey"]),
+        algorithm,
+        handle,
+      );
+
+      // 14-18.
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["decrypt", "unwrapKey"]),
+        algorithm,
+        handle,
+      );
+
+      // 19-22.
+      return { publicKey, privateKey };
+    }
+    case "ECDSA": {
+      const namedCurve = normalizedAlgorithm.namedCurve;
+
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["sign", "verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2-3.
+      const handle = {};
+      if (
+        ArrayPrototypeIncludes(
+          supportedNamedCurves,
+          namedCurve,
+        )
+      ) {
+        const keyData = await op_crypto_generate_key({
+          algorithm: "EC",
+          namedCurve,
+        });
+        WeakMapPrototypeSet(KEY_STORE, handle, {
+          type: "private",
+          data: keyData,
+        });
+      } else {
+        throw new DOMException("Curve not supported", "NotSupportedError");
+      }
+
+      // 4-6.
+      const algorithm = {
+        name: algorithmName,
+        namedCurve,
+      };
+
+      // 7-11.
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, ["verify"]),
+        algorithm,
+        handle,
+      );
+
+      // 12-16.
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["sign"]),
+        algorithm,
+        handle,
+      );
+
+      // 17-20.
+      return { publicKey, privateKey };
+    }
+    case "ECDH": {
+      const namedCurve = normalizedAlgorithm.namedCurve;
+
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2-3.
+      const handle = {};
+      if (
+        ArrayPrototypeIncludes(
+          supportedNamedCurves,
+          namedCurve,
+        )
+      ) {
+        const keyData = await op_crypto_generate_key({
+          algorithm: "EC",
+          namedCurve,
+        });
+        WeakMapPrototypeSet(KEY_STORE, handle, {
+          type: "private",
+          data: keyData,
+        });
+      } else {
+        throw new DOMException("Curve not supported", "NotSupportedError");
+      }
+
+      // 4-6.
+      const algorithm = {
+        name: algorithmName,
+        namedCurve,
+      };
+
+      // 7-11.
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, []),
+        algorithm,
+        handle,
+      );
+
+      // 12-16.
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["deriveKey", "deriveBits"]),
+        algorithm,
+        handle,
+      );
+
+      // 17-20.
+      return { publicKey, privateKey };
+    }
+    case "AES-CTR":
+    case "AES-CBC":
+    case "AES-GCM": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) =>
+            !ArrayPrototypeIncludes([
+              "encrypt",
+              "decrypt",
+              "wrapKey",
+              "unwrapKey",
+            ], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      return generateKeyAES(normalizedAlgorithm, extractable, usages);
+    }
+    case "AES-KW": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["wrapKey", "unwrapKey"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      return generateKeyAES(normalizedAlgorithm, extractable, usages);
+    }
+    case "X448": {
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+      const privateKeyData = new Uint8Array(56);
+      const publicKeyData = new Uint8Array(56);
+
+      op_crypto_generate_x448_keypair(privateKeyData, publicKeyData);
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const publicHandle = {};
+      WeakMapPrototypeSet(KEY_STORE, publicHandle, publicKeyData);
+
+      const algorithm = {
+        name: algorithmName,
+      };
+
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, []),
+        algorithm,
+        publicHandle,
+      );
+
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["deriveKey", "deriveBits"]),
+        algorithm,
+        handle,
+      );
+
+      return { publicKey, privateKey };
+    }
+    case "X25519": {
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+      const privateKeyData = new Uint8Array(32);
+      const publicKeyData = new Uint8Array(32);
+      op_crypto_generate_x25519_keypair(privateKeyData, publicKeyData);
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const publicHandle = {};
+      WeakMapPrototypeSet(KEY_STORE, publicHandle, publicKeyData);
+
+      const algorithm = {
+        name: algorithmName,
+      };
+
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, []),
+        algorithm,
+        publicHandle,
+      );
+
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["deriveKey", "deriveBits"]),
+        algorithm,
+        handle,
+      );
+
+      return { publicKey, privateKey };
+    }
+    case "Ed25519": {
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["sign", "verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const ED25519_SEED_LEN = 32;
+      const ED25519_PUBLIC_KEY_LEN = 32;
+      const privateKeyData = new Uint8Array(ED25519_SEED_LEN);
+      const publicKeyData = new Uint8Array(ED25519_PUBLIC_KEY_LEN);
+      if (
+        !op_crypto_generate_ed25519_keypair(privateKeyData, publicKeyData)
+      ) {
+        throw new DOMException("Failed to generate key", "OperationError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const publicHandle = {};
+      WeakMapPrototypeSet(KEY_STORE, publicHandle, publicKeyData);
+
+      const algorithm = {
+        name: algorithmName,
+      };
+
+      const publicKey = constructKey(
+        "public",
+        true,
+        usageIntersection(usages, ["verify"]),
+        algorithm,
+        publicHandle,
+      );
+
+      const privateKey = constructKey(
+        "private",
+        extractable,
+        usageIntersection(usages, ["sign"]),
+        algorithm,
+        handle,
+      );
+
+      return { publicKey, privateKey };
+    }
+    case "HMAC": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          usages,
+          (u) => !ArrayPrototypeIncludes(["sign", "verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2.
+      let length;
+      if (normalizedAlgorithm.length === undefined) {
+        length = null;
+      } else if (normalizedAlgorithm.length !== 0) {
+        length = normalizedAlgorithm.length;
+      } else {
+        throw new DOMException("Invalid length", "OperationError");
+      }
+
+      // 3-4.
+      const keyData = await op_crypto_generate_key({
+        algorithm: "HMAC",
+        hash: normalizedAlgorithm.hash.name,
+        length,
+      });
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, {
+        type: "secret",
+        data: keyData,
+      });
+
+      // 6-10.
+      const algorithm = {
+        name: algorithmName,
+        hash: {
+          name: normalizedAlgorithm.hash.name,
+        },
+        length: TypedArrayPrototypeGetByteLength(keyData) * 8,
+      };
+
+      // 5, 11-13.
+      const key = constructKey(
+        "secret",
+        extractable,
+        usages,
+        algorithm,
+        handle,
+      );
+
+      // 14.
+      return key;
+    }
+  }
+}
+
+function importKeyX448(
+  format,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      if (TypedArrayPrototypeGetByteLength(keyData) !== 56) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, keyData);
+
+      // 2-3.
+      const algorithm = {
+        name: "X448",
+      };
+
+      // 4-6.
+      return constructKey(
+        "public",
+        extractable,
+        [],
+        algorithm,
+        handle,
+      );
+    }
+    case "spki": {
+      // 1.
+      if (keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const publicKeyData = new Uint8Array(56);
+      if (!op_crypto_import_spki_x448(keyData, publicKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+      const algorithm = {
+        name: "X448",
+      };
+
+      return constructKey(
+        "public",
+        extractable,
+        [],
+        algorithm,
+        handle,
+      );
+    }
+    case "pkcs8": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const privateKeyData = new Uint8Array(32);
+      if (!op_crypto_import_pkcs8_x448(keyData, privateKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const algorithm = {
+        name: "X448",
+      };
+
+      return constructKey(
+        "private",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+    }
+    case "jwk": {
+      // 1.
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.d !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                ["deriveKey", "deriveBits"],
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      }
+
+      // 3.
+      if (jwk.d === undefined && keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 4.
+      if (jwk.kty !== "OKP") {
+        throw new DOMException("Invalid key type", "DataError");
+      }
+
+      // 5.
+      if (jwk.crv !== "X448") {
+        throw new DOMException("Invalid curve", "DataError");
+      }
+
+      // 6.
+      if (keyUsages.length > 0 && jwk.use !== undefined) {
+        if (jwk.use !== "enc") {
+          throw new DOMException("Invalid key use", "DataError");
+        }
+      }
+
+      // 7.
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 8.
+      if (jwk.ext !== undefined && jwk.ext === false && extractable) {
+        throw new DOMException("Invalid key extractability", "DataError");
+      }
+
+      // 9.
+      if (jwk.d !== undefined) {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let privateKeyData;
+        try {
+          privateKeyData = op_crypto_base64url_decode(jwk.d);
+        } catch (_) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(privateKeyData) !== 56) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+        const algorithm = {
+          name: "X448",
+        };
+
+        return constructKey(
+          "private",
+          extractable,
+          usageIntersection(keyUsages, ["deriveKey", "deriveBits"]),
+          algorithm,
+          handle,
+        );
+      } else {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let publicKeyData;
+        try {
+          publicKeyData = op_crypto_base64url_decode(jwk.x);
+        } catch (_) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(publicKeyData) !== 56) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+        const algorithm = {
+          name: "X448",
+        };
+
+        return constructKey(
+          "public",
+          extractable,
+          [],
+          algorithm,
+          handle,
+        );
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function importKeyEd25519(
+  format,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(["verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      if (TypedArrayPrototypeGetByteLength(keyData) !== 32) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, keyData);
+
+      // 2-3.
+      const algorithm = {
+        name: "Ed25519",
+      };
+
+      // 4-6.
+      return constructKey(
+        "public",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+    }
+    case "spki": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(["verify"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const publicKeyData = new Uint8Array(32);
+      if (!op_crypto_import_spki_ed25519(keyData, publicKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+      const algorithm = {
+        name: "Ed25519",
+      };
+
+      return constructKey(
+        "public",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+    }
+    case "pkcs8": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(["sign"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const privateKeyData = new Uint8Array(32);
+      if (!op_crypto_import_pkcs8_ed25519(keyData, privateKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const algorithm = {
+        name: "Ed25519",
+      };
+
+      return constructKey(
+        "private",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+    }
+    case "jwk": {
+      // 1.
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.d !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                ["sign"],
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      } else {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                ["verify"],
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      }
+
+      // 3.
+      if (jwk.kty !== "OKP") {
+        throw new DOMException("Invalid key type", "DataError");
+      }
+
+      // 4.
+      if (jwk.crv !== "Ed25519") {
+        throw new DOMException("Invalid curve", "DataError");
+      }
+
+      // 5.
+      if (
+        keyUsages.length > 0 && jwk.use !== undefined && jwk.use !== "sig"
+      ) {
+        throw new DOMException("Invalid key usage", "DataError");
+      }
+
+      // 6.
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 7.
+      if (jwk.ext !== undefined && jwk.ext === false && extractable) {
+        throw new DOMException("Invalid key extractability", "DataError");
+      }
+
+      // 8.
+      if (jwk.d !== undefined) {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let privateKeyData;
+        try {
+          privateKeyData = op_crypto_base64url_decode(jwk.d);
+        } catch (_) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(privateKeyData) !== 32) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+        const algorithm = {
+          name: "Ed25519",
+        };
+
+        return constructKey(
+          "private",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+      } else {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let publicKeyData;
+        try {
+          publicKeyData = op_crypto_base64url_decode(jwk.x);
+        } catch (_) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(publicKeyData) !== 32) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+        const algorithm = {
+          name: "Ed25519",
+        };
+
+        return constructKey(
+          "public",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function importKeyX25519(
+  format,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      if (TypedArrayPrototypeGetByteLength(keyData) !== 32) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, keyData);
+
+      // 2-3.
+      const algorithm = {
+        name: "X25519",
+      };
+
+      // 4-6.
+      return constructKey(
+        "public",
+        extractable,
+        [],
+        algorithm,
+        handle,
+      );
+    }
+    case "spki": {
+      // 1.
+      if (keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const publicKeyData = new Uint8Array(32);
+      if (!op_crypto_import_spki_x25519(keyData, publicKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+      const algorithm = {
+        name: "X25519",
+      };
+
+      return constructKey(
+        "public",
+        extractable,
+        [],
+        algorithm,
+        handle,
+      );
+    }
+    case "pkcs8": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      const privateKeyData = new Uint8Array(32);
+      if (!op_crypto_import_pkcs8_x25519(keyData, privateKeyData)) {
+        throw new DOMException("Invalid key data", "DataError");
+      }
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+      const algorithm = {
+        name: "X25519",
+      };
+
+      return constructKey(
+        "private",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+    }
+    case "jwk": {
+      // 1.
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.d !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                ["deriveKey", "deriveBits"],
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      }
+
+      // 3.
+      if (jwk.d === undefined && keyUsages.length > 0) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 4.
+      if (jwk.kty !== "OKP") {
+        throw new DOMException("Invalid key type", "DataError");
+      }
+
+      // 5.
+      if (jwk.crv !== "X25519") {
+        throw new DOMException("Invalid curve", "DataError");
+      }
+
+      // 6.
+      if (keyUsages.length > 0 && jwk.use !== undefined) {
+        if (jwk.use !== "enc") {
+          throw new DOMException("Invalid key use", "DataError");
+        }
+      }
+
+      // 7.
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 8.
+      if (jwk.ext !== undefined && jwk.ext === false && extractable) {
+        throw new DOMException("Invalid key extractability", "DataError");
+      }
+
+      // 9.
+      if (jwk.d !== undefined) {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let privateKeyData;
+        try {
+          privateKeyData = op_crypto_base64url_decode(jwk.d);
+        } catch (_) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(privateKeyData) !== 32) {
+          throw new DOMException("Invalid private key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
+
+        const algorithm = {
+          name: "X25519",
+        };
+
+        return constructKey(
+          "private",
+          extractable,
+          usageIntersection(keyUsages, ["deriveKey", "deriveBits"]),
+          algorithm,
+          handle,
+        );
+      } else {
+        // https://www.rfc-editor.org/rfc/rfc8037#section-2
+        let publicKeyData;
+        try {
+          publicKeyData = op_crypto_base64url_decode(jwk.x);
+        } catch (_) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+        if (TypedArrayPrototypeGetByteLength(publicKeyData) !== 32) {
+          throw new DOMException("Invalid public key data", "DataError");
+        }
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+
+        const algorithm = {
+          name: "X25519",
+        };
+
+        return constructKey(
+          "public",
+          extractable,
+          [],
+          algorithm,
+          handle,
+        );
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyAES(
+  format,
+  key,
+  innerKey,
+) {
+  switch (format) {
+    // 2.
+    case "raw": {
+      // 1.
+      const data = innerKey.data;
+      // 2.
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "jwk": {
+      // 1-2.
+      const jwk = {
+        kty: "oct",
+      };
+
+      // 3.
+      const data = op_crypto_export_key({
+        format: "jwksecret",
+        algorithm: "AES",
+      }, innerKey);
+      ObjectAssign(jwk, data);
+
+      // 4.
+      const algorithm = key[_algorithm];
+      switch (algorithm.length) {
+        case 128:
+          jwk.alg = aesJwkAlg[algorithm.name][128];
+          break;
+        case 192:
+          jwk.alg = aesJwkAlg[algorithm.name][192];
+          break;
+        case 256:
+          jwk.alg = aesJwkAlg[algorithm.name][256];
+          break;
+        default:
+          throw new DOMException(
+            `Invalid key length: ${algorithm.length}`,
+            "NotSupportedError",
+          );
+      }
+
+      // 5.
+      jwk.key_ops = key.usages;
+
+      // 6.
+      jwk.ext = key[_extractable];
+
+      // 7.
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function importKeyAES(
+  format,
+  normalizedAlgorithm,
+  keyData,
+  extractable,
+  keyUsages,
+  supportedKeyUsages,
+) {
+  // 1.
+  if (
+    ArrayPrototypeFind(
+      keyUsages,
+      (u) => !ArrayPrototypeIncludes(supportedKeyUsages, u),
+    ) !== undefined
+  ) {
+    throw new DOMException("Invalid key usage", "SyntaxError");
+  }
+
+  const algorithmName = normalizedAlgorithm.name;
+
+  // 2.
+  let data = keyData;
+
+  switch (format) {
+    case "raw": {
+      // 2.
+      if (
+        !ArrayPrototypeIncludes(
+          [128, 192, 256],
+          TypedArrayPrototypeGetByteLength(keyData) * 8,
+        )
+      ) {
+        throw new DOMException("Invalid key length", "DataError");
+      }
+
+      break;
+    }
+    case "jwk": {
+      // 1.
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.kty !== "oct") {
+        throw new DOMException(
+          "'kty' property of JsonWebKey must be 'oct'",
+          "DataError",
+        );
+      }
+
+      // Section 6.4.1 of RFC7518
+      if (jwk.k === undefined) {
+        throw new DOMException(
+          "'k' property of JsonWebKey must be present",
+          "DataError",
+        );
+      }
+
+      // 4.
+      const { rawData } = op_crypto_import_key(
+        { algorithm: "AES" },
+        { jwkSecret: jwk },
+      );
+      data = rawData.data;
+
+      // 5.
+      switch (TypedArrayPrototypeGetByteLength(data) * 8) {
+        case 128:
+          if (
+            jwk.alg !== undefined &&
+            jwk.alg !== aesJwkAlg[algorithmName][128]
+          ) {
+            throw new DOMException(
+              `Invalid algorithm: ${jwk.alg}`,
+              "DataError",
+            );
+          }
+          break;
+        case 192:
+          if (
+            jwk.alg !== undefined &&
+            jwk.alg !== aesJwkAlg[algorithmName][192]
+          ) {
+            throw new DOMException(
+              `Invalid algorithm: ${jwk.alg}`,
+              "DataError",
+            );
+          }
+          break;
+        case 256:
+          if (
+            jwk.alg !== undefined &&
+            jwk.alg !== aesJwkAlg[algorithmName][256]
+          ) {
+            throw new DOMException(
+              `Invalid algorithm: ${jwk.alg}`,
+              "DataError",
+            );
+          }
+          break;
+        default:
+          throw new DOMException(
+            "Invalid key length",
+            "DataError",
+          );
+      }
+
+      // 6.
+      if (
+        keyUsages.length > 0 && jwk.use !== undefined && jwk.use !== "enc"
+      ) {
+        throw new DOMException("Invalid key usage", "DataError");
+      }
+
+      // 7.
+      // Section 4.3 of RFC7517
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 8.
+      if (jwk.ext === false && extractable === true) {
+        throw new DOMException(
+          "'ext' property of JsonWebKey must not be false if extractable is true",
+          "DataError",
+        );
+      }
+
+      break;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+
+  const handle = {};
+  WeakMapPrototypeSet(KEY_STORE, handle, {
+    type: "secret",
+    data,
+  });
+
+  // 4-7.
+  const algorithm = {
+    name: algorithmName,
+    length: TypedArrayPrototypeGetByteLength(data) * 8,
+  };
+
+  const key = constructKey(
+    "secret",
+    extractable,
+    usageIntersection(keyUsages, recognisedUsages),
+    algorithm,
+    handle,
+  );
+
+  // 8.
+  return key;
+}
+
+function importKeyHMAC(
+  format,
+  normalizedAlgorithm,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  // 2.
+  if (
+    ArrayPrototypeFind(
+      keyUsages,
+      (u) => !ArrayPrototypeIncludes(["sign", "verify"], u),
+    ) !== undefined
+  ) {
+    throw new DOMException("Invalid key usage", "SyntaxError");
+  }
+
+  // 3.
+  let hash;
+  let data;
+
+  // 4. https://w3c.github.io/webcrypto/#hmac-operations
+  switch (format) {
+    case "raw": {
+      data = keyData;
+      hash = normalizedAlgorithm.hash;
+      break;
+    }
+    case "jwk": {
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.kty !== "oct") {
+        throw new DOMException(
+          "'kty' property of JsonWebKey must be 'oct'",
+          "DataError",
+        );
+      }
+
+      // Section 6.4.1 of RFC7518
+      if (jwk.k === undefined) {
+        throw new DOMException(
+          "'k' property of JsonWebKey must be present",
+          "DataError",
+        );
+      }
+
+      // 4.
+      const { rawData } = op_crypto_import_key(
+        { algorithm: "HMAC" },
+        { jwkSecret: jwk },
+      );
+      data = rawData.data;
+
+      // 5.
+      hash = normalizedAlgorithm.hash;
+
+      // 6.
+      switch (hash.name) {
+        case "SHA-1": {
+          if (jwk.alg !== undefined && jwk.alg !== "HS1") {
+            throw new DOMException(
+              "'alg' property of JsonWebKey must be 'HS1'",
+              "DataError",
+            );
+          }
+          break;
+        }
+        case "SHA-256": {
+          if (jwk.alg !== undefined && jwk.alg !== "HS256") {
+            throw new DOMException(
+              "'alg' property of JsonWebKey must be 'HS256'",
+              "DataError",
+            );
+          }
+          break;
+        }
+        case "SHA-384": {
+          if (jwk.alg !== undefined && jwk.alg !== "HS384") {
+            throw new DOMException(
+              "'alg' property of JsonWebKey must be 'HS384'",
+              "DataError",
+            );
+          }
+          break;
+        }
+        case "SHA-512": {
+          if (jwk.alg !== undefined && jwk.alg !== "HS512") {
+            throw new DOMException(
+              "'alg' property of JsonWebKey must be 'HS512'",
+              "DataError",
+            );
+          }
+          break;
+        }
+        default:
+          throw new TypeError("Unreachable");
+      }
+
+      // 7.
+      if (
+        keyUsages.length > 0 && jwk.use !== undefined && jwk.use !== "sig"
+      ) {
+        throw new DOMException(
+          "'use' property of JsonWebKey must be 'sig'",
+          "DataError",
+        );
+      }
+
+      // 8.
+      // Section 4.3 of RFC7517
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 9.
+      if (jwk.ext === false && extractable === true) {
+        throw new DOMException(
+          "'ext' property of JsonWebKey must not be false if extractable is true",
+          "DataError",
+        );
+      }
+
+      break;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+
+  // 5.
+  let length = TypedArrayPrototypeGetByteLength(data) * 8;
+  // 6.
+  if (length === 0) {
+    throw new DOMException("Key length is zero", "DataError");
+  }
+  // 7.
+  if (normalizedAlgorithm.length !== undefined) {
+    if (
+      normalizedAlgorithm.length > length ||
+      normalizedAlgorithm.length <= (length - 8)
+    ) {
+      throw new DOMException(
+        "Key length is invalid",
+        "DataError",
+      );
+    }
+    length = normalizedAlgorithm.length;
+  }
+
+  const handle = {};
+  WeakMapPrototypeSet(KEY_STORE, handle, {
+    type: "secret",
+    data,
+  });
+
+  const algorithm = {
+    name: "HMAC",
+    length,
+    hash,
+  };
+
+  const key = constructKey(
+    "secret",
+    extractable,
+    usageIntersection(keyUsages, recognisedUsages),
+    algorithm,
+    handle,
+  );
+
+  return key;
+}
+
+function importKeyEC(
+  format,
+  normalizedAlgorithm,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  const supportedUsages = SUPPORTED_KEY_USAGES[normalizedAlgorithm.name];
+
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (
+        !ArrayPrototypeIncludes(
+          supportedNamedCurves,
+          normalizedAlgorithm.namedCurve,
+        )
+      ) {
+        throw new DOMException(
+          "Invalid namedCurve",
+          "DataError",
+        );
+      }
+
+      // 2.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) =>
+            !ArrayPrototypeIncludes(
+              SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].public,
+              u,
+            ),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 3.
+      const { rawData } = op_crypto_import_key({
+        algorithm: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      }, { raw: keyData });
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+      // 4-5.
+      const algorithm = {
+        name: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      };
+
+      // 6-8.
+      const key = constructKey(
+        "public",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+
+      return key;
+    }
+    case "pkcs8": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) =>
+            !ArrayPrototypeIncludes(
+              SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].private,
+              u,
+            ),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2-9.
+      const { rawData } = op_crypto_import_key({
+        algorithm: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      }, { pkcs8: keyData });
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+      const algorithm = {
+        name: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      };
+
+      const key = constructKey(
+        "private",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+
+      return key;
+    }
+    case "spki": {
+      // 1.
+      if (normalizedAlgorithm.name == "ECDSA") {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].public,
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      } else if (keyUsages.length != 0) {
+        throw new DOMException("Key usage must be empty", "SyntaxError");
+      }
+
+      // 2-12
+      const { rawData } = op_crypto_import_key({
+        algorithm: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      }, { spki: keyData });
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+      const algorithm = {
+        name: normalizedAlgorithm.name,
+        namedCurve: normalizedAlgorithm.namedCurve,
+      };
+
+      // 6-8.
+      const key = constructKey(
+        "public",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+
+      return key;
+    }
+    case "jwk": {
+      const jwk = keyData;
+
+      const keyType = (jwk.d !== undefined) ? "private" : "public";
+
+      // 2.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) => !ArrayPrototypeIncludes(supportedUsages[keyType], u),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 3.
+      if (jwk.kty !== "EC") {
+        throw new DOMException(
+          "'kty' property of JsonWebKey must be 'EC'",
+          "DataError",
+        );
+      }
+
+      // 4.
+      if (
+        keyUsages.length > 0 && jwk.use !== undefined &&
+        jwk.use !== supportedUsages.jwkUse
+      ) {
+        throw new DOMException(
+          `'use' property of JsonWebKey must be '${supportedUsages.jwkUse}'`,
+          "DataError",
+        );
+      }
+
+      // 5.
+      // Section 4.3 of RFC7517
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' member of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' member of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      // 6.
+      if (jwk.ext === false && extractable === true) {
+        throw new DOMException(
+          "'ext' property of JsonWebKey must not be false if extractable is true",
+          "DataError",
+        );
+      }
+
+      // 9.
+      if (jwk.alg !== undefined && normalizedAlgorithm.name == "ECDSA") {
+        let algNamedCurve;
+
+        switch (jwk.alg) {
+          case "ES256": {
+            algNamedCurve = "P-256";
+            break;
+          }
+          case "ES384": {
+            algNamedCurve = "P-384";
+            break;
+          }
+          case "ES512": {
+            algNamedCurve = "P-521";
+            break;
+          }
+          default:
+            throw new DOMException(
+              "Curve algorithm not supported",
+              "DataError",
+            );
+        }
+
+        if (algNamedCurve) {
+          if (algNamedCurve !== normalizedAlgorithm.namedCurve) {
+            throw new DOMException(
+              "Mismatched curve algorithm",
+              "DataError",
+            );
+          }
+        }
+      }
+
+      // Validate that this is a valid public key.
+      if (jwk.x === undefined) {
+        throw new DOMException(
+          "'x' property of JsonWebKey is required for EC keys",
+          "DataError",
+        );
+      }
+      if (jwk.y === undefined) {
+        throw new DOMException(
+          "'y' property of JsonWebKey is required for EC keys",
+          "DataError",
+        );
+      }
+
+      if (jwk.d !== undefined) {
+        // it's also a Private key
+        const { rawData } = op_crypto_import_key({
+          algorithm: normalizedAlgorithm.name,
+          namedCurve: normalizedAlgorithm.namedCurve,
+        }, { jwkPrivateEc: jwk });
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+        const algorithm = {
+          name: normalizedAlgorithm.name,
+          namedCurve: normalizedAlgorithm.namedCurve,
+        };
+
+        const key = constructKey(
+          "private",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+
+        return key;
+      } else {
+        const { rawData } = op_crypto_import_key({
+          algorithm: normalizedAlgorithm.name,
+          namedCurve: normalizedAlgorithm.namedCurve,
+        }, { jwkPublicEc: jwk });
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+        const algorithm = {
+          name: normalizedAlgorithm.name,
+          namedCurve: normalizedAlgorithm.namedCurve,
+        };
+
+        const key = constructKey(
+          "public",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+
+        return key;
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+// deno-lint-ignore require-await
+async function importKeyInner(
+  format,
+  normalizedAlgorithm,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  const algorithmName = normalizedAlgorithm.name;
+
+  switch (algorithmName) {
+    case "HMAC": {
+      return importKeyHMAC(
+        format,
+        normalizedAlgorithm,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    case "ECDH":
+    case "ECDSA": {
+      return importKeyEC(
+        format,
+        normalizedAlgorithm,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    case "RSASSA-PKCS1-v1_5":
+    case "RSA-PSS":
+    case "RSA-OAEP": {
+      return importKeyRSA(
+        format,
+        normalizedAlgorithm,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    case "HKDF": {
+      return importKeyHKDF(format, keyData, extractable, keyUsages);
+    }
+    case "PBKDF2": {
+      return importKeyPBKDF2(format, keyData, extractable, keyUsages);
+    }
+    case "AES-CTR":
+    case "AES-CBC":
+    case "AES-GCM": {
+      return importKeyAES(
+        format,
+        normalizedAlgorithm,
+        keyData,
+        extractable,
+        keyUsages,
+        ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
+      );
+    }
+    case "AES-KW": {
+      return importKeyAES(
+        format,
+        normalizedAlgorithm,
+        keyData,
+        extractable,
+        keyUsages,
+        ["wrapKey", "unwrapKey"],
+      );
+    }
+    case "X448": {
+      return importKeyX448(
+        format,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    case "X25519": {
+      return importKeyX25519(
+        format,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    case "Ed25519": {
+      return importKeyEd25519(
+        format,
+        keyData,
+        extractable,
+        keyUsages,
+      );
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+const SUPPORTED_KEY_USAGES = {
+  "RSASSA-PKCS1-v1_5": {
+    public: ["verify"],
+    private: ["sign"],
+    jwkUse: "sig",
+  },
+  "RSA-PSS": {
+    public: ["verify"],
+    private: ["sign"],
+    jwkUse: "sig",
+  },
+  "RSA-OAEP": {
+    public: ["encrypt", "wrapKey"],
+    private: ["decrypt", "unwrapKey"],
+    jwkUse: "enc",
+  },
+  "ECDSA": {
+    public: ["verify"],
+    private: ["sign"],
+    jwkUse: "sig",
+  },
+  "ECDH": {
+    public: [],
+    private: ["deriveKey", "deriveBits"],
+    jwkUse: "enc",
+  },
+};
+
+function importKeyRSA(
+  format,
+  normalizedAlgorithm,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  switch (format) {
+    case "pkcs8": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) =>
+            !ArrayPrototypeIncludes(
+              SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].private,
+              u,
+            ),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2-9.
+      const { modulusLength, publicExponent, rawData } = op_crypto_import_key(
+        {
+          algorithm: normalizedAlgorithm.name,
+          // Needed to perform step 7 without normalization.
+          hash: normalizedAlgorithm.hash.name,
+        },
+        { pkcs8: keyData },
+      );
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+      const algorithm = {
+        name: normalizedAlgorithm.name,
+        modulusLength,
+        publicExponent,
+        hash: normalizedAlgorithm.hash,
+      };
+
+      const key = constructKey(
+        "private",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+
+      return key;
+    }
+    case "spki": {
+      // 1.
+      if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) =>
+            !ArrayPrototypeIncludes(
+              SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].public,
+              u,
+            ),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 2-9.
+      const { modulusLength, publicExponent, rawData } = op_crypto_import_key(
+        {
+          algorithm: normalizedAlgorithm.name,
+          // Needed to perform step 7 without normalization.
+          hash: normalizedAlgorithm.hash.name,
+        },
+        { spki: keyData },
+      );
+
+      const handle = {};
+      WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+      const algorithm = {
+        name: normalizedAlgorithm.name,
+        modulusLength,
+        publicExponent,
+        hash: normalizedAlgorithm.hash,
+      };
+
+      const key = constructKey(
+        "public",
+        extractable,
+        usageIntersection(keyUsages, recognisedUsages),
+        algorithm,
+        handle,
+      );
+
+      return key;
+    }
+    case "jwk": {
+      // 1.
+      const jwk = keyData;
+
+      // 2.
+      if (jwk.d !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            keyUsages,
+            (u) =>
+              !ArrayPrototypeIncludes(
+                SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].private,
+                u,
+              ),
+          ) !== undefined
+        ) {
+          throw new DOMException("Invalid key usage", "SyntaxError");
+        }
+      } else if (
+        ArrayPrototypeFind(
+          keyUsages,
+          (u) =>
+            !ArrayPrototypeIncludes(
+              SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].public,
+              u,
+            ),
+        ) !== undefined
+      ) {
+        throw new DOMException("Invalid key usage", "SyntaxError");
+      }
+
+      // 3.
+      if (StringPrototypeToUpperCase(jwk.kty) !== "RSA") {
+        throw new DOMException(
+          "'kty' property of JsonWebKey must be 'RSA'",
+          "DataError",
+        );
+      }
+
+      // 4.
+      if (
+        keyUsages.length > 0 && jwk.use !== undefined &&
+        StringPrototypeToLowerCase(jwk.use) !==
+          SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].jwkUse
+      ) {
+        throw new DOMException(
+          `'use' property of JsonWebKey must be '${
+            SUPPORTED_KEY_USAGES[normalizedAlgorithm.name].jwkUse
+          }'`,
+          "DataError",
+        );
+      }
+
+      // 5.
+      if (jwk.key_ops !== undefined) {
+        if (
+          ArrayPrototypeFind(
+            jwk.key_ops,
+            (u) => !ArrayPrototypeIncludes(recognisedUsages, u),
+          ) !== undefined
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+
+        if (
+          !ArrayPrototypeEvery(
+            jwk.key_ops,
+            (u) => ArrayPrototypeIncludes(keyUsages, u),
+          )
+        ) {
+          throw new DOMException(
+            "'key_ops' property of JsonWebKey is invalid",
+            "DataError",
+          );
+        }
+      }
+
+      if (jwk.ext === false && extractable === true) {
+        throw new DOMException(
+          "'ext' property of JsonWebKey must not be false if extractable is true",
+          "DataError",
+        );
+      }
+
+      // 7.
+      let hash;
+
+      // 8.
+      if (normalizedAlgorithm.name === "RSASSA-PKCS1-v1_5") {
+        switch (jwk.alg) {
+          case undefined:
+            hash = undefined;
+            break;
+          case "RS1":
+            hash = "SHA-1";
+            break;
+          case "RS256":
+            hash = "SHA-256";
+            break;
+          case "RS384":
+            hash = "SHA-384";
+            break;
+          case "RS512":
+            hash = "SHA-512";
+            break;
+          default:
+            throw new DOMException(
+              `'alg' property of JsonWebKey must be one of 'RS1', 'RS256', 'RS384', 'RS512': received ${jwk.alg}`,
+              "DataError",
+            );
+        }
+      } else if (normalizedAlgorithm.name === "RSA-PSS") {
+        switch (jwk.alg) {
+          case undefined:
+            hash = undefined;
+            break;
+          case "PS1":
+            hash = "SHA-1";
+            break;
+          case "PS256":
+            hash = "SHA-256";
+            break;
+          case "PS384":
+            hash = "SHA-384";
+            break;
+          case "PS512":
+            hash = "SHA-512";
+            break;
+          default:
+            throw new DOMException(
+              `'alg' property of JsonWebKey must be one of 'PS1', 'PS256', 'PS384', 'PS512': received ${jwk.alg}`,
+              "DataError",
+            );
+        }
+      } else {
+        switch (jwk.alg) {
+          case undefined:
+            hash = undefined;
+            break;
+          case "RSA-OAEP":
+            hash = "SHA-1";
+            break;
+          case "RSA-OAEP-256":
+            hash = "SHA-256";
+            break;
+          case "RSA-OAEP-384":
+            hash = "SHA-384";
+            break;
+          case "RSA-OAEP-512":
+            hash = "SHA-512";
+            break;
+          default:
+            throw new DOMException(
+              `'alg' property of JsonWebKey must be one of 'RSA-OAEP', 'RSA-OAEP-256', 'RSA-OAEP-384', or 'RSA-OAEP-512': received ${jwk.alg}`,
+              "DataError",
+            );
+        }
+      }
+
+      // 9.
+      if (hash !== undefined) {
+        // 9.1.
+        const normalizedHash = normalizeAlgorithm(hash, "digest");
+
+        // 9.2.
+        if (normalizedHash.name !== normalizedAlgorithm.hash.name) {
+          throw new DOMException(
+            `'alg' property of JsonWebKey must be '${normalizedAlgorithm.name}': received ${jwk.alg}`,
+            "DataError",
+          );
+        }
+      }
+
+      // 10.
+      if (jwk.d !== undefined) {
+        // Private key
+        const optimizationsPresent = jwk.p !== undefined ||
+          jwk.q !== undefined || jwk.dp !== undefined ||
+          jwk.dq !== undefined || jwk.qi !== undefined;
+        if (optimizationsPresent) {
+          if (jwk.q === undefined) {
+            throw new DOMException(
+              "'q' property of JsonWebKey is required for private keys",
+              "DataError",
+            );
+          }
+          if (jwk.dp === undefined) {
+            throw new DOMException(
+              "'dp' property of JsonWebKey is required for private keys",
+              "DataError",
+            );
+          }
+          if (jwk.dq === undefined) {
+            throw new DOMException(
+              "'dq' property of JsonWebKey is required for private keys",
+              "DataError",
+            );
+          }
+          if (jwk.qi === undefined) {
+            throw new DOMException(
+              "'qi' property of JsonWebKey is required for private keys",
+              "DataError",
+            );
+          }
+          if (jwk.oth !== undefined) {
+            throw new DOMException(
+              "'oth' property of JsonWebKey is not supported",
+              "NotSupportedError",
+            );
+          }
+        } else {
+          throw new DOMException(
+            "Only optimized private keys are supported",
+            "NotSupportedError",
+          );
+        }
+
+        const { modulusLength, publicExponent, rawData } = op_crypto_import_key(
+          {
+            algorithm: normalizedAlgorithm.name,
+            hash: normalizedAlgorithm.hash.name,
+          },
+          { jwkPrivateRsa: jwk },
+        );
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+        const algorithm = {
+          name: normalizedAlgorithm.name,
+          modulusLength,
+          publicExponent,
+          hash: normalizedAlgorithm.hash,
+        };
+
+        const key = constructKey(
+          "private",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+
+        return key;
+      } else {
+        // Validate that this is a valid public key.
+        if (jwk.n === undefined) {
+          throw new DOMException(
+            "'n' property of JsonWebKey is required for public keys",
+            "DataError",
+          );
+        }
+        if (jwk.e === undefined) {
+          throw new DOMException(
+            "'e' property of JsonWebKey is required for public keys",
+            "DataError",
+          );
+        }
+
+        const { modulusLength, publicExponent, rawData } = op_crypto_import_key(
+          {
+            algorithm: normalizedAlgorithm.name,
+            hash: normalizedAlgorithm.hash.name,
+          },
+          { jwkPublicRsa: jwk },
+        );
+
+        const handle = {};
+        WeakMapPrototypeSet(KEY_STORE, handle, rawData);
+
+        const algorithm = {
+          name: normalizedAlgorithm.name,
+          modulusLength,
+          publicExponent,
+          hash: normalizedAlgorithm.hash,
+        };
+
+        const key = constructKey(
+          "public",
+          extractable,
+          usageIntersection(keyUsages, recognisedUsages),
+          algorithm,
+          handle,
+        );
+
+        return key;
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function importKeyHKDF(
+  format,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  if (format !== "raw") {
+    throw new DOMException("Format not supported", "NotSupportedError");
+  }
+
+  // 1.
+  if (
+    ArrayPrototypeFind(
+      keyUsages,
+      (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+    ) !== undefined
+  ) {
+    throw new DOMException("Invalid key usage", "SyntaxError");
+  }
+
+  // 2.
+  if (extractable !== false) {
+    throw new DOMException(
+      "Key must not be extractable",
+      "SyntaxError",
+    );
+  }
+
+  // 3.
+  const handle = {};
+  WeakMapPrototypeSet(KEY_STORE, handle, {
+    type: "secret",
+    data: keyData,
+  });
+
+  // 4-8.
+  const algorithm = {
+    name: "HKDF",
+  };
+  const key = constructKey(
+    "secret",
+    false,
+    usageIntersection(keyUsages, recognisedUsages),
+    algorithm,
+    handle,
+  );
+
+  // 9.
+  return key;
+}
+
+function importKeyPBKDF2(
+  format,
+  keyData,
+  extractable,
+  keyUsages,
+) {
+  // 1.
+  if (format !== "raw") {
+    throw new DOMException("Format not supported", "NotSupportedError");
+  }
+
+  // 2.
+  if (
+    ArrayPrototypeFind(
+      keyUsages,
+      (u) => !ArrayPrototypeIncludes(["deriveKey", "deriveBits"], u),
+    ) !== undefined
+  ) {
+    throw new DOMException("Invalid key usage", "SyntaxError");
+  }
+
+  // 3.
+  if (extractable !== false) {
+    throw new DOMException(
+      "Key must not be extractable",
+      "SyntaxError",
+    );
+  }
+
+  // 4.
+  const handle = {};
+  WeakMapPrototypeSet(KEY_STORE, handle, {
+    type: "secret",
+    data: keyData,
+  });
+
+  // 5-9.
+  const algorithm = {
+    name: "PBKDF2",
+  };
+  const key = constructKey(
+    "secret",
+    false,
+    usageIntersection(keyUsages, recognisedUsages),
+    algorithm,
+    handle,
+  );
+
+  // 10.
+  return key;
+}
+
+function exportKeyHMAC(format, key, innerKey) {
+  // 1.
+  if (innerKey == null) {
+    throw new DOMException("Key is not available", "OperationError");
+  }
+
+  switch (format) {
+    // 3.
+    case "raw": {
+      const bits = innerKey.data;
+      // TODO(petamoriken): Uint8Array does not have push method
+      // for (let _i = 7 & (8 - bits.length % 8); _i > 0; _i--) {
+      //   bits.push(0);
+      // }
+      // 4-5.
+      return TypedArrayPrototypeGetBuffer(bits);
+    }
+    case "jwk": {
+      // 1-2.
+      const jwk = {
+        kty: "oct",
+      };
+
+      // 3.
+      const data = op_crypto_export_key({
+        format: "jwksecret",
+        algorithm: key[_algorithm].name,
+      }, innerKey);
+      jwk.k = data.k;
+
+      // 4.
+      const algorithm = key[_algorithm];
+      // 5.
+      const hash = algorithm.hash;
+      // 6.
+      switch (hash.name) {
+        case "SHA-1":
+          jwk.alg = "HS1";
+          break;
+        case "SHA-256":
+          jwk.alg = "HS256";
+          break;
+        case "SHA-384":
+          jwk.alg = "HS384";
+          break;
+        case "SHA-512":
+          jwk.alg = "HS512";
+          break;
+        default:
+          throw new DOMException(
+            "Hash algorithm not supported",
+            "NotSupportedError",
+          );
+      }
+      // 7.
+      jwk.key_ops = key.usages;
+      // 8.
+      jwk.ext = key[_extractable];
+      // 9.
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyRSA(format, key, innerKey) {
+  switch (format) {
+    case "pkcs8": {
+      // 1.
+      if (key[_type] !== "private") {
+        throw new DOMException(
+          "Key is not a private key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      const data = op_crypto_export_key({
+        algorithm: key[_algorithm].name,
+        format: "pkcs8",
+      }, innerKey);
+
+      // 3.
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "spki": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      const data = op_crypto_export_key({
+        algorithm: key[_algorithm].name,
+        format: "spki",
+      }, innerKey);
+
+      // 3.
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "jwk": {
+      // 1-2.
+      const jwk = {
+        kty: "RSA",
+      };
+
+      // 3.
+      const hash = key[_algorithm].hash.name;
+
+      // 4.
+      if (key[_algorithm].name === "RSASSA-PKCS1-v1_5") {
+        switch (hash) {
+          case "SHA-1":
+            jwk.alg = "RS1";
+            break;
+          case "SHA-256":
+            jwk.alg = "RS256";
+            break;
+          case "SHA-384":
+            jwk.alg = "RS384";
+            break;
+          case "SHA-512":
+            jwk.alg = "RS512";
+            break;
+          default:
+            throw new DOMException(
+              "Hash algorithm not supported",
+              "NotSupportedError",
+            );
+        }
+      } else if (key[_algorithm].name === "RSA-PSS") {
+        switch (hash) {
+          case "SHA-1":
+            jwk.alg = "PS1";
+            break;
+          case "SHA-256":
+            jwk.alg = "PS256";
+            break;
+          case "SHA-384":
+            jwk.alg = "PS384";
+            break;
+          case "SHA-512":
+            jwk.alg = "PS512";
+            break;
+          default:
+            throw new DOMException(
+              "Hash algorithm not supported",
+              "NotSupportedError",
+            );
+        }
+      } else {
+        switch (hash) {
+          case "SHA-1":
+            jwk.alg = "RSA-OAEP";
+            break;
+          case "SHA-256":
+            jwk.alg = "RSA-OAEP-256";
+            break;
+          case "SHA-384":
+            jwk.alg = "RSA-OAEP-384";
+            break;
+          case "SHA-512":
+            jwk.alg = "RSA-OAEP-512";
+            break;
+          default:
+            throw new DOMException(
+              "Hash algorithm not supported",
+              "NotSupportedError",
+            );
+        }
+      }
+
+      // 5-6.
+      const data = op_crypto_export_key({
+        format: key[_type] === "private" ? "jwkprivate" : "jwkpublic",
+        algorithm: key[_algorithm].name,
+      }, innerKey);
+      ObjectAssign(jwk, data);
+
+      // 7.
+      jwk.key_ops = key.usages;
+
+      // 8.
+      jwk.ext = key[_extractable];
+
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyEd25519(format, key, innerKey) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2-3.
+      return TypedArrayPrototypeGetBuffer(innerKey);
+    }
+    case "spki": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      const spkiDer = op_crypto_export_spki_ed25519(innerKey);
+      return TypedArrayPrototypeGetBuffer(spkiDer);
+    }
+    case "pkcs8": {
+      // 1.
+      if (key[_type] !== "private") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      const pkcs8Der = op_crypto_export_pkcs8_ed25519(
+        new Uint8Array([0x04, 0x22, ...new SafeArrayIterator(innerKey)]),
+      );
+      pkcs8Der[15] = 0x20;
+      return TypedArrayPrototypeGetBuffer(pkcs8Der);
+    }
+    case "jwk": {
+      const x = key[_type] === "private"
+        ? op_crypto_jwk_x_ed25519(innerKey)
+        : op_crypto_base64url_encode(innerKey);
+      const jwk = {
+        kty: "OKP",
+        crv: "Ed25519",
+        x,
+        "key_ops": key.usages,
+        ext: key[_extractable],
+      };
+      if (key[_type] === "private") {
+        jwk.d = op_crypto_base64url_encode(innerKey);
+      }
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyX448(format, key, innerKey) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2-3.
+      return TypedArrayPrototypeGetBuffer(innerKey);
+    }
+    case "spki": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      const spkiDer = op_crypto_export_spki_x448(innerKey);
+      return TypedArrayPrototypeGetBuffer(spkiDer);
+    }
+    case "pkcs8": {
+      // 1.
+      if (key[_type] !== "private") {
+        throw new DOMException(
+          "Key is not a private key",
+          "InvalidAccessError",
+        );
+      }
+
+      const pkcs8Der = op_crypto_export_pkcs8_x448(
+        new Uint8Array([0x04, 0x22, ...new SafeArrayIterator(innerKey)]),
+      );
+      pkcs8Der[15] = 0x20;
+      return TypedArrayPrototypeGetBuffer(pkcs8Der);
+    }
+    case "jwk": {
+      if (key[_type] === "private") {
+        throw new DOMException("Not implemented", "NotSupportedError");
+      }
+      const x = op_crypto_base64url_encode(innerKey);
+      const jwk = {
+        kty: "OKP",
+        crv: "X448",
+        x,
+        "key_ops": key.usages,
+        ext: key[_extractable],
+      };
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyX25519(format, key, innerKey) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2-3.
+      return TypedArrayPrototypeGetBuffer(innerKey);
+    }
+    case "spki": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      const spkiDer = op_crypto_export_spki_x25519(innerKey);
+      return TypedArrayPrototypeGetBuffer(spkiDer);
+    }
+    case "pkcs8": {
+      // 1.
+      if (key[_type] !== "private") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      const pkcs8Der = op_crypto_export_pkcs8_x25519(
+        new Uint8Array([0x04, 0x22, ...new SafeArrayIterator(innerKey)]),
+      );
+      pkcs8Der[15] = 0x20;
+      return TypedArrayPrototypeGetBuffer(pkcs8Der);
+    }
+    case "jwk": {
+      if (key[_type] === "private") {
+        throw new DOMException("Not implemented", "NotSupportedError");
+      }
+      const x = op_crypto_base64url_encode(innerKey);
+      const jwk = {
+        kty: "OKP",
+        crv: "X25519",
+        x,
+        "key_ops": key.usages,
+        ext: key[_extractable],
+      };
+      return jwk;
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+function exportKeyEC(format, key, innerKey) {
+  switch (format) {
+    case "raw": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      const data = op_crypto_export_key({
+        algorithm: key[_algorithm].name,
+        namedCurve: key[_algorithm].namedCurve,
+        format: "raw",
+      }, innerKey);
+
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "pkcs8": {
+      // 1.
+      if (key[_type] !== "private") {
+        throw new DOMException(
+          "Key is not a private key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      const data = op_crypto_export_key({
+        algorithm: key[_algorithm].name,
+        namedCurve: key[_algorithm].namedCurve,
+        format: "pkcs8",
+      }, innerKey);
+
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "spki": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key is not a public key",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      const data = op_crypto_export_key({
+        algorithm: key[_algorithm].name,
+        namedCurve: key[_algorithm].namedCurve,
+        format: "spki",
+      }, innerKey);
+
+      return TypedArrayPrototypeGetBuffer(data);
+    }
+    case "jwk": {
+      if (key[_algorithm].name == "ECDSA") {
+        // 1-2.
+        const jwk = {
+          kty: "EC",
+        };
+
+        // 3.1
+        jwk.crv = key[_algorithm].namedCurve;
+
+        // Missing from spec
+        let algNamedCurve;
+
+        switch (key[_algorithm].namedCurve) {
+          case "P-256": {
+            algNamedCurve = "ES256";
+            break;
+          }
+          case "P-384": {
+            algNamedCurve = "ES384";
+            break;
+          }
+          case "P-521": {
+            algNamedCurve = "ES512";
+            break;
+          }
+          default:
+            throw new DOMException(
+              "Curve algorithm not supported",
+              "DataError",
+            );
+        }
+
+        jwk.alg = algNamedCurve;
+
+        // 3.2 - 3.4.
+        const data = op_crypto_export_key({
+          format: key[_type] === "private" ? "jwkprivate" : "jwkpublic",
+          algorithm: key[_algorithm].name,
+          namedCurve: key[_algorithm].namedCurve,
+        }, innerKey);
+        ObjectAssign(jwk, data);
+
+        // 4.
+        jwk.key_ops = key.usages;
+
+        // 5.
+        jwk.ext = key[_extractable];
+
+        return jwk;
+      } else { // ECDH
+        // 1-2.
+        const jwk = {
+          kty: "EC",
+        };
+
+        // missing step from spec
+        jwk.alg = "ECDH";
+
+        // 3.1
+        jwk.crv = key[_algorithm].namedCurve;
+
+        // 3.2 - 3.4
+        const data = op_crypto_export_key({
+          format: key[_type] === "private" ? "jwkprivate" : "jwkpublic",
+          algorithm: key[_algorithm].name,
+          namedCurve: key[_algorithm].namedCurve,
+        }, innerKey);
+        ObjectAssign(jwk, data);
+
+        // 4.
+        jwk.key_ops = key.usages;
+
+        // 5.
+        jwk.ext = key[_extractable];
+
+        return jwk;
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+async function generateKeyAES(normalizedAlgorithm, extractable, usages) {
+  const algorithmName = normalizedAlgorithm.name;
+
+  // 2.
+  if (!ArrayPrototypeIncludes([128, 192, 256], normalizedAlgorithm.length)) {
+    throw new DOMException(
+      `Invalid key length: ${normalizedAlgorithm.length}`,
+      "OperationError",
+    );
+  }
+
+  // 3.
+  const keyData = await op_crypto_generate_key({
+    algorithm: "AES",
+    length: normalizedAlgorithm.length,
+  });
+  const handle = {};
+  WeakMapPrototypeSet(KEY_STORE, handle, {
+    type: "secret",
+    data: keyData,
+  });
+
+  // 6-8.
+  const algorithm = {
+    name: algorithmName,
+    length: normalizedAlgorithm.length,
+  };
+
+  // 9-11.
+  const key = constructKey(
+    "secret",
+    extractable,
+    usages,
+    algorithm,
+    handle,
+  );
+
+  // 12.
+  return key;
+}
+
+async function deriveBits(normalizedAlgorithm, baseKey, length) {
+  switch (normalizedAlgorithm.name) {
+    case "PBKDF2": {
+      // 1.
+      if (length == null || length == 0 || length % 8 !== 0) {
+        throw new DOMException("Invalid length", "OperationError");
+      }
+
+      if (normalizedAlgorithm.iterations == 0) {
+        throw new DOMException(
+          "iterations must not be zero",
+          "OperationError",
+        );
+      }
+
+      const handle = baseKey[_handle];
+      const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+      normalizedAlgorithm.salt = copyBuffer(normalizedAlgorithm.salt);
+
+      const buf = await op_crypto_derive_bits({
+        key: keyData,
+        algorithm: "PBKDF2",
+        hash: normalizedAlgorithm.hash.name,
+        iterations: normalizedAlgorithm.iterations,
+        length,
+      }, normalizedAlgorithm.salt);
+
+      return TypedArrayPrototypeGetBuffer(buf);
+    }
+    case "ECDH": {
+      // 1.
+      if (baseKey[_type] !== "private") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 2.
+      const publicKey = normalizedAlgorithm.public;
+      // 3.
+      if (publicKey[_type] !== "public") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 4.
+      if (publicKey[_algorithm].name !== baseKey[_algorithm].name) {
+        throw new DOMException(
+          "Algorithm mismatch",
+          "InvalidAccessError",
+        );
+      }
+      // 5.
+      if (
+        publicKey[_algorithm].namedCurve !== baseKey[_algorithm].namedCurve
+      ) {
+        throw new DOMException(
+          "'namedCurve' mismatch",
+          "InvalidAccessError",
+        );
+      }
+      // 6.
+      if (
+        ArrayPrototypeIncludes(
+          supportedNamedCurves,
+          publicKey[_algorithm].namedCurve,
+        )
+      ) {
+        const baseKeyhandle = baseKey[_handle];
+        const baseKeyData = WeakMapPrototypeGet(KEY_STORE, baseKeyhandle);
+        const publicKeyhandle = publicKey[_handle];
+        const publicKeyData = WeakMapPrototypeGet(KEY_STORE, publicKeyhandle);
+
+        const buf = await op_crypto_derive_bits({
+          key: baseKeyData,
+          publicKey: publicKeyData,
+          algorithm: "ECDH",
+          namedCurve: publicKey[_algorithm].namedCurve,
+          length: length ?? 0,
+        });
+
+        // 8.
+        if (length === null) {
+          return TypedArrayPrototypeGetBuffer(buf);
+        } else if (TypedArrayPrototypeGetByteLength(buf) * 8 < length) {
+          throw new DOMException("Invalid length", "OperationError");
+        } else {
+          return ArrayBufferPrototypeSlice(
+            TypedArrayPrototypeGetBuffer(buf),
+            0,
+            MathCeil(length / 8),
+          );
+        }
+      } else {
+        throw new DOMException("Not implemented", "NotSupportedError");
+      }
+    }
+    case "HKDF": {
+      // 1.
+      if (length === null || length === 0 || length % 8 !== 0) {
+        throw new DOMException("Invalid length", "OperationError");
+      }
+
+      const handle = baseKey[_handle];
+      const keyDerivationKey = WeakMapPrototypeGet(KEY_STORE, handle);
+
+      normalizedAlgorithm.salt = copyBuffer(normalizedAlgorithm.salt);
+
+      normalizedAlgorithm.info = copyBuffer(normalizedAlgorithm.info);
+
+      const buf = await op_crypto_derive_bits({
+        key: keyDerivationKey,
+        algorithm: "HKDF",
+        hash: normalizedAlgorithm.hash.name,
+        info: normalizedAlgorithm.info,
+        length,
+      }, normalizedAlgorithm.salt);
+
+      return TypedArrayPrototypeGetBuffer(buf);
+    }
+    case "X448": {
+      // 1.
+      if (baseKey[_type] !== "private") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 2.
+      const publicKey = normalizedAlgorithm.public;
+      // 3.
+      if (publicKey[_type] !== "public") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 4.
+      if (publicKey[_algorithm].name !== baseKey[_algorithm].name) {
+        throw new DOMException(
+          "Algorithm mismatch",
+          "InvalidAccessError",
+        );
+      }
+
+      // 5.
+      const kHandle = baseKey[_handle];
+      const k = WeakMapPrototypeGet(KEY_STORE, kHandle);
+
+      const uHandle = publicKey[_handle];
+      const u = WeakMapPrototypeGet(KEY_STORE, uHandle);
+
+      const secret = new Uint8Array(56);
+      const isIdentity = op_crypto_derive_bits_x448(k, u, secret);
+
+      // 6.
+      if (isIdentity) {
+        throw new DOMException("Invalid key", "OperationError");
+      }
+
+      // 7.
+      if (length === null) {
+        return TypedArrayPrototypeGetBuffer(secret);
+      } else if (
+        TypedArrayPrototypeGetByteLength(secret) * 8 < length
+      ) {
+        throw new DOMException("Invalid length", "OperationError");
+      } else {
+        return ArrayBufferPrototypeSlice(
+          TypedArrayPrototypeGetBuffer(secret),
+          0,
+          MathCeil(length / 8),
+        );
+      }
+    }
+    case "X25519": {
+      // 1.
+      if (baseKey[_type] !== "private") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 2.
+      const publicKey = normalizedAlgorithm.public;
+      // 3.
+      if (publicKey[_type] !== "public") {
+        throw new DOMException("Invalid key type", "InvalidAccessError");
+      }
+      // 4.
+      if (publicKey[_algorithm].name !== baseKey[_algorithm].name) {
+        throw new DOMException(
+          "Algorithm mismatch",
+          "InvalidAccessError",
+        );
+      }
+
+      // 5.
+      const kHandle = baseKey[_handle];
+      const k = WeakMapPrototypeGet(KEY_STORE, kHandle);
+
+      const uHandle = publicKey[_handle];
+      const u = WeakMapPrototypeGet(KEY_STORE, uHandle);
+
+      const secret = new Uint8Array(32);
+      const isIdentity = op_crypto_derive_bits_x25519(k, u, secret);
+
+      // 6.
+      if (isIdentity) {
+        throw new DOMException("Invalid key", "OperationError");
+      }
+
+      // 7.
+      if (length === null) {
+        return TypedArrayPrototypeGetBuffer(secret);
+      } else if (
+        TypedArrayPrototypeGetByteLength(secret) * 8 < length
+      ) {
+        throw new DOMException("Invalid length", "OperationError");
+      } else {
+        return ArrayBufferPrototypeSlice(
+          TypedArrayPrototypeGetBuffer(secret),
+          0,
+          MathCeil(length / 8),
+        );
+      }
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+async function encrypt(normalizedAlgorithm, key, data) {
+  const handle = key[_handle];
+  const keyData = WeakMapPrototypeGet(KEY_STORE, handle);
+
+  switch (normalizedAlgorithm.name) {
+    case "RSA-OAEP": {
+      // 1.
+      if (key[_type] !== "public") {
+        throw new DOMException(
+          "Key type not supported",
+          "InvalidAccessError",
+        );
+      }
+
+      // 2.
+      if (normalizedAlgorithm.label) {
+        normalizedAlgorithm.label = copyBuffer(normalizedAlgorithm.label);
+      } else {
+        normalizedAlgorithm.label = new Uint8Array();
+      }
+
+      // 3-5.
+      const hashAlgorithm = key[_algorithm].hash.name;
+      const cipherText = await op_crypto_encrypt({
+        key: keyData,
+        algorithm: "RSA-OAEP",
+        hash: hashAlgorithm,
+        label: normalizedAlgorithm.label,
+      }, data);
+
+      // 6.
+      return TypedArrayPrototypeGetBuffer(cipherText);
+    }
+    case "AES-CBC": {
+      normalizedAlgorithm.iv = copyBuffer(normalizedAlgorithm.iv);
+
+      // 1.
+      if (TypedArrayPrototypeGetByteLength(normalizedAlgorithm.iv) !== 16) {
+        throw new DOMException(
+          "Initialization vector must be 16 bytes",
+          "OperationError",
+        );
+      }
+
+      // 2.
+      const cipherText = await op_crypto_encrypt({
+        key: keyData,
+        algorithm: "AES-CBC",
+        length: key[_algorithm].length,
+        iv: normalizedAlgorithm.iv,
+      }, data);
+
+      // 4.
+      return TypedArrayPrototypeGetBuffer(cipherText);
+    }
+    case "AES-CTR": {
+      normalizedAlgorithm.counter = copyBuffer(normalizedAlgorithm.counter);
+
+      // 1.
+      if (
+        TypedArrayPrototypeGetByteLength(normalizedAlgorithm.counter) !== 16
+      ) {
+        throw new DOMException(
+          "Counter vector must be 16 bytes",
+          "OperationError",
+        );
+      }
+
+      // 2.
+      if (
+        normalizedAlgorithm.length == 0 || normalizedAlgorithm.length > 128
+      ) {
+        throw new DOMException(
+          "Counter length must not be 0 or greater than 128",
+          "OperationError",
+        );
+      }
+
+      // 3.
+      const cipherText = await op_crypto_encrypt({
+        key: keyData,
+        algorithm: "AES-CTR",
+        keyLength: key[_algorithm].length,
+        counter: normalizedAlgorithm.counter,
+        ctrLength: normalizedAlgorithm.length,
+      }, data);
+
+      // 4.
+      return TypedArrayPrototypeGetBuffer(cipherText);
+    }
+    case "AES-GCM": {
+      normalizedAlgorithm.iv = copyBuffer(normalizedAlgorithm.iv);
+
+      // 1.
+      if (TypedArrayPrototypeGetByteLength(data) > (2 ** 39) - 256) {
+        throw new DOMException(
+          "Plaintext too large",
+          "OperationError",
+        );
+      }
+
+      // 2.
+      // We only support 96-bit and 128-bit nonce.
+      if (
+        ArrayPrototypeIncludes(
+          [12, 16],
+          TypedArrayPrototypeGetByteLength(normalizedAlgorithm.iv),
+        ) === undefined
+      ) {
+        throw new DOMException(
+          "Initialization vector length not supported",
+          "NotSupportedError",
+        );
+      }
+
+      // 3.
+      // NOTE: over the size of Number.MAX_SAFE_INTEGER is not available in V8
+      // if (normalizedAlgorithm.additionalData !== undefined) {
+      //   if (normalizedAlgorithm.additionalData.byteLength > (2 ** 64) - 1) {
+      //     throw new DOMException(
+      //       "Additional data too large",
+      //       "OperationError",
+      //     );
+      //   }
+      // }
+
+      // 4.
+      if (normalizedAlgorithm.tagLength == undefined) {
+        normalizedAlgorithm.tagLength = 128;
+      } else if (
+        !ArrayPrototypeIncludes(
+          [32, 64, 96, 104, 112, 120, 128],
+          normalizedAlgorithm.tagLength,
+        )
+      ) {
+        throw new DOMException(
+          `Invalid tag length: ${normalizedAlgorithm.tagLength}`,
+          "OperationError",
+        );
+      }
+      // 5.
+      if (normalizedAlgorithm.additionalData) {
+        normalizedAlgorithm.additionalData = copyBuffer(
+          normalizedAlgorithm.additionalData,
+        );
+      }
+      // 6-7.
+      const cipherText = await op_crypto_encrypt({
+        key: keyData,
+        algorithm: "AES-GCM",
+        length: key[_algorithm].length,
+        iv: normalizedAlgorithm.iv,
+        additionalData: normalizedAlgorithm.additionalData || null,
+        tagLength: normalizedAlgorithm.tagLength,
+      }, data);
+
+      // 8.
+      return TypedArrayPrototypeGetBuffer(cipherText);
+    }
+    default:
+      throw new DOMException("Not implemented", "NotSupportedError");
+  }
+}
+
+webidl.configureInterface(SubtleCrypto);
+const subtle = webidl.createBranded(SubtleCrypto);
+
+class Crypto {
+  constructor() {
+    webidl.illegalConstructor();
+  }
+
+  getRandomValues(typedArray) {
+    webidl.assertBranded(this, CryptoPrototype);
+    const prefix = "Failed to execute 'getRandomValues' on 'Crypto'";
+    webidl.requiredArguments(arguments.length, 1, prefix);
+    // Fast path for Uint8Array
+    const tag = TypedArrayPrototypeGetSymbolToStringTag(typedArray);
+    if (tag === "Uint8Array") {
+      op_crypto_get_random_values(typedArray);
+      return typedArray;
+    }
+    typedArray = webidl.converters.ArrayBufferView(
+      typedArray,
+      prefix,
+      "Argument 1",
+    );
+    switch (tag) {
+      case "Int8Array":
+      case "Uint8ClampedArray":
+      case "Int16Array":
+      case "Uint16Array":
+      case "Int32Array":
+      case "Uint32Array":
+      case "BigInt64Array":
+      case "BigUint64Array":
+        break;
+      default:
+        throw new DOMException(
+          "The provided ArrayBufferView is not an integer array type",
+          "TypeMismatchError",
+        );
+    }
+    const ui8 = new Uint8Array(
+      TypedArrayPrototypeGetBuffer(typedArray),
+      TypedArrayPrototypeGetByteOffset(typedArray),
+      TypedArrayPrototypeGetByteLength(typedArray),
+    );
+    op_crypto_get_random_values(ui8);
+    return typedArray;
+  }
+
+  randomUUID() {
+    webidl.assertBranded(this, CryptoPrototype);
+    return op_crypto_random_uuid();
+  }
+
+  get subtle() {
+    webidl.assertBranded(this, CryptoPrototype);
+    return subtle;
+  }
+
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(CryptoPrototype, this),
+        keys: ["subtle"],
+      }),
+      inspectOptions,
+    );
+  }
+}
+
+webidl.configureInterface(Crypto);
+const CryptoPrototype = Crypto.prototype;
+
+const crypto = webidl.createBranded(Crypto);
+
+webidl.converters.AlgorithmIdentifier = (V, prefix, context, opts) => {
+  // Union for (object or DOMString)
+  if (webidl.type(V) == "Object") {
+    return webidl.converters.object(V, prefix, context, opts);
+  }
+  return webidl.converters.DOMString(V, prefix, context, opts);
+};
+
+webidl.converters["BufferSource or JsonWebKey"] = (
+  V,
+  prefix,
+  context,
+  opts,
+) => {
+  // Union for (BufferSource or JsonWebKey)
+  if (ArrayBufferIsView(V) || isArrayBuffer(V)) {
+    return webidl.converters.BufferSource(V, prefix, context, opts);
+  }
+  return webidl.converters.JsonWebKey(V, prefix, context, opts);
+};
+
+webidl.converters.KeyType = webidl.createEnumConverter("KeyType", [
+  "public",
+  "private",
+  "secret",
+]);
+
+webidl.converters.KeyFormat = webidl.createEnumConverter("KeyFormat", [
+  "raw",
+  "pkcs8",
+  "spki",
+  "jwk",
+]);
+
+webidl.converters.KeyUsage = webidl.createEnumConverter("KeyUsage", [
+  "encrypt",
+  "decrypt",
+  "sign",
+  "verify",
+  "deriveKey",
+  "deriveBits",
+  "wrapKey",
+  "unwrapKey",
+]);
+
+webidl.converters["sequence<KeyUsage>"] = webidl.createSequenceConverter(
+  webidl.converters.KeyUsage,
+);
+
+webidl.converters.HashAlgorithmIdentifier =
+  webidl.converters.AlgorithmIdentifier;
+
+/** @type {webidl.Dictionary} */
+const dictAlgorithm = [{
+  key: "name",
+  converter: webidl.converters.DOMString,
+  required: true,
+}];
+
+webidl.converters.Algorithm = webidl
+  .createDictionaryConverter("Algorithm", dictAlgorithm);
+
+webidl.converters.BigInteger = webidl.converters.Uint8Array;
+
+/** @type {webidl.Dictionary} */
+const dictRsaKeyGenParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "modulusLength",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+  {
+    key: "publicExponent",
+    converter: webidl.converters.BigInteger,
+    required: true,
+  },
+];
+
+webidl.converters.RsaKeyGenParams = webidl
+  .createDictionaryConverter("RsaKeyGenParams", dictRsaKeyGenParams);
+
+const dictRsaHashedKeyGenParams = [
+  ...new SafeArrayIterator(dictRsaKeyGenParams),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+];
+
+webidl.converters.RsaHashedKeyGenParams = webidl.createDictionaryConverter(
+  "RsaHashedKeyGenParams",
+  dictRsaHashedKeyGenParams,
+);
+
+const dictRsaHashedImportParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+];
+
+webidl.converters.RsaHashedImportParams = webidl.createDictionaryConverter(
+  "RsaHashedImportParams",
+  dictRsaHashedImportParams,
+);
+
+webidl.converters.NamedCurve = webidl.converters.DOMString;
+
+const dictEcKeyImportParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "namedCurve",
+    converter: webidl.converters.NamedCurve,
+    required: true,
+  },
+];
+
+webidl.converters.EcKeyImportParams = webidl.createDictionaryConverter(
+  "EcKeyImportParams",
+  dictEcKeyImportParams,
+);
+
+const dictEcKeyGenParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "namedCurve",
+    converter: webidl.converters.NamedCurve,
+    required: true,
+  },
+];
+
+webidl.converters.EcKeyGenParams = webidl
+  .createDictionaryConverter("EcKeyGenParams", dictEcKeyGenParams);
+
+const dictAesKeyGenParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "length",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned short"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+];
+
+webidl.converters.AesKeyGenParams = webidl
+  .createDictionaryConverter("AesKeyGenParams", dictAesKeyGenParams);
+
+const dictHmacKeyGenParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+  {
+    key: "length",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+  },
+];
+
+webidl.converters.HmacKeyGenParams = webidl
+  .createDictionaryConverter("HmacKeyGenParams", dictHmacKeyGenParams);
+
+const dictRsaPssParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "saltLength",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+];
+
+webidl.converters.RsaPssParams = webidl
+  .createDictionaryConverter("RsaPssParams", dictRsaPssParams);
+
+const dictRsaOaepParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "label",
+    converter: webidl.converters["BufferSource"],
+  },
+];
+
+webidl.converters.RsaOaepParams = webidl
+  .createDictionaryConverter("RsaOaepParams", dictRsaOaepParams);
+
+const dictEcdsaParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+];
+
+webidl.converters["EcdsaParams"] = webidl
+  .createDictionaryConverter("EcdsaParams", dictEcdsaParams);
+
+const dictHmacImportParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+  {
+    key: "length",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+  },
+];
+
+webidl.converters.HmacImportParams = webidl
+  .createDictionaryConverter("HmacImportParams", dictHmacImportParams);
+
+const dictRsaOtherPrimesInfo = [
+  {
+    key: "r",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "d",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "t",
+    converter: webidl.converters["DOMString"],
+  },
+];
+
+webidl.converters.RsaOtherPrimesInfo = webidl.createDictionaryConverter(
+  "RsaOtherPrimesInfo",
+  dictRsaOtherPrimesInfo,
+);
+webidl.converters["sequence<RsaOtherPrimesInfo>"] = webidl
+  .createSequenceConverter(
+    webidl.converters.RsaOtherPrimesInfo,
+  );
+
+const dictJsonWebKey = [
+  // Sections 4.2 and 4.3 of RFC7517.
+  // https://datatracker.ietf.org/doc/html/rfc7517#section-4
+  {
+    key: "kty",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "use",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "key_ops",
+    converter: webidl.converters["sequence<DOMString>"],
+  },
+  {
+    key: "alg",
+    converter: webidl.converters["DOMString"],
+  },
+  // JSON Web Key Parameters Registration
+  {
+    key: "ext",
+    converter: webidl.converters["boolean"],
+  },
+  // Section 6 of RFC7518 JSON Web Algorithms
+  // https://datatracker.ietf.org/doc/html/rfc7518#section-6
+  {
+    key: "crv",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "x",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "y",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "d",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "n",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "e",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "p",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "q",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "dp",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "dq",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "qi",
+    converter: webidl.converters["DOMString"],
+  },
+  {
+    key: "oth",
+    converter: webidl.converters["sequence<RsaOtherPrimesInfo>"],
+  },
+  {
+    key: "k",
+    converter: webidl.converters["DOMString"],
+  },
+];
+
+webidl.converters.JsonWebKey = webidl.createDictionaryConverter(
+  "JsonWebKey",
+  dictJsonWebKey,
+);
+
+const dictHkdfParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+  {
+    key: "salt",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+  {
+    key: "info",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+];
+
+webidl.converters.HkdfParams = webidl
+  .createDictionaryConverter("HkdfParams", dictHkdfParams);
+
+const dictPbkdf2Params = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "hash",
+    converter: webidl.converters.HashAlgorithmIdentifier,
+    required: true,
+  },
+  {
+    key: "iterations",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+  {
+    key: "salt",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+];
+
+webidl.converters.Pbkdf2Params = webidl
+  .createDictionaryConverter("Pbkdf2Params", dictPbkdf2Params);
+
+const dictAesDerivedKeyParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "length",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+];
+
+const dictAesCbcParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "iv",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+];
+
+const dictAesGcmParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "iv",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+  {
+    key: "tagLength",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned long"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+  },
+  {
+    key: "additionalData",
+    converter: webidl.converters["BufferSource"],
+  },
+];
+
+const dictAesCtrParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "counter",
+    converter: webidl.converters["BufferSource"],
+    required: true,
+  },
+  {
+    key: "length",
+    converter: (V, prefix, context, opts) =>
+      webidl.converters["unsigned short"](V, prefix, context, {
+        ...opts,
+        enforceRange: true,
+      }),
+    required: true,
+  },
+];
+
+webidl.converters.AesDerivedKeyParams = webidl
+  .createDictionaryConverter("AesDerivedKeyParams", dictAesDerivedKeyParams);
+
+webidl.converters.AesCbcParams = webidl
+  .createDictionaryConverter("AesCbcParams", dictAesCbcParams);
+
+webidl.converters.AesGcmParams = webidl
+  .createDictionaryConverter("AesGcmParams", dictAesGcmParams);
+
+webidl.converters.AesCtrParams = webidl
+  .createDictionaryConverter("AesCtrParams", dictAesCtrParams);
+
+webidl.converters.CryptoKey = webidl.createInterfaceConverter(
+  "CryptoKey",
+  CryptoKey.prototype,
+);
+
+const dictCryptoKeyPair = [
+  {
+    key: "publicKey",
+    converter: webidl.converters.CryptoKey,
+  },
+  {
+    key: "privateKey",
+    converter: webidl.converters.CryptoKey,
+  },
+];
+
+webidl.converters.CryptoKeyPair = webidl
+  .createDictionaryConverter("CryptoKeyPair", dictCryptoKeyPair);
+
+const dictEcdhKeyDeriveParams = [
+  ...new SafeArrayIterator(dictAlgorithm),
+  {
+    key: "public",
+    converter: webidl.converters.CryptoKey,
+    required: true,
+  },
+];
+
+webidl.converters.EcdhKeyDeriveParams = webidl
+  .createDictionaryConverter("EcdhKeyDeriveParams", dictEcdhKeyDeriveParams);
+
+export { Crypto, crypto, CryptoKey, SubtleCrypto };

--- a/vendor/deno_crypto/Cargo.toml
+++ b/vendor/deno_crypto/Cargo.toml
@@ -1,0 +1,47 @@
+# Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+[package]
+name = "deno_crypto"
+version = "0.196.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+description = "Web Cryptography API implementation for Deno"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+aes.workspace = true
+aes-gcm = "0.10"
+aes-kw = { version = "0.2.1", features = ["alloc"] }
+base64.workspace = true
+cbc.workspace = true
+const-oid = "0.9.0"
+ctr = "0.9.1"
+curve25519-dalek = "4.1.3"
+deno_core.workspace = true
+deno_web.workspace = true
+ed448-goldilocks = { version = "0.8.3", features = ["zeroize"] }
+elliptic-curve = { version = "0.13.1", features = ["std", "pem"] }
+num-traits = "0.2.14"
+once_cell.workspace = true
+p256 = { version = "0.13.2", features = ["ecdh"] }
+p384 = "0.13.0"
+p521 = "0.13.3"
+rand.workspace = true
+ring = { workspace = true, features = ["std"] }
+rsa.workspace = true
+sec1.workspace = true
+serde.workspace = true
+serde_bytes = "0.11"
+sha1.workspace = true
+sha2.workspace = true
+signature.workspace = true
+spki.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+uuid.workspace = true
+x25519-dalek = "2.0.0"

--- a/vendor/deno_crypto/README.md
+++ b/vendor/deno_crypto/README.md
@@ -1,0 +1,87 @@
+# deno_crypto
+
+**This crate implements the Web Cryptography API.**
+
+Spec: https://www.w3.org/TR/WebCryptoAPI/
+
+## Usage Example
+
+From javascript, include the extension's source, and assign `CryptoKey`,
+`crypto`, `Crypto`, and `SubtleCrypto` to the global scope:
+
+```javascript
+import * as crypto from "ext:deno_crypto/00_crypto.js";
+
+Object.defineProperty(globalThis, "CryptoKey", {
+  value: crypto.CryptoKey,
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+Object.defineProperty(globalThis, "crypto", {
+  value: crypto.crypto,
+  enumerable: false,
+  configurable: true,
+  writable: false,
+});
+
+Object.defineProperty(globalThis, "Crypto", {
+  value: crypto.Crypto,
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+Object.defineProperty(globalThis, "SubtleCrypto", {
+  value: crypto.SubtleCrypto,
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+```
+
+Then from rust, provide:
+`deno_crypto::deno_crypto::init_ops_and_esm(Option<u64>)` in the `extensions`
+field of your `RuntimeOptions`
+
+Where the `Option<u64>` represents an optional seed for initialization.
+
+## Dependencies
+
+- **deno_webidl**: Provided by the `deno_webidl` crate
+- **deno_web**: Provided by the `deno_web` crate
+
+## Provided ops
+
+Following ops are provided, which can be accessed through `Deno.ops`:
+
+- op_crypto_get_random_values
+- op_crypto_generate_key
+- op_crypto_sign_key
+- op_crypto_verify_key
+- op_crypto_derive_bits
+- op_crypto_import_key
+- op_crypto_export_key
+- op_crypto_encrypt
+- op_crypto_decrypt
+- op_crypto_subtle_digest
+- op_crypto_random_uuid
+- op_crypto_wrap_key
+- op_crypto_unwrap_key
+- op_crypto_base64url_decode
+- op_crypto_base64url_encode
+- x25519::op_crypto_generate_x25519_keypair
+- x25519::op_crypto_derive_bits_x25519
+- x25519::op_crypto_import_spki_x25519
+- x25519::op_crypto_import_pkcs8_x25519
+- ed25519::op_crypto_generate_ed25519_keypair
+- ed25519::op_crypto_import_spki_ed25519
+- ed25519::op_crypto_import_pkcs8_ed25519
+- ed25519::op_crypto_sign_ed25519
+- ed25519::op_crypto_verify_ed25519
+- ed25519::op_crypto_export_spki_ed25519
+- ed25519::op_crypto_export_pkcs8_ed25519
+- ed25519::op_crypto_jwk_x_ed25519
+- x25519::op_crypto_export_spki_x25519
+- x25519::op_crypto_export_pkcs8_x25519

--- a/vendor/deno_crypto/decrypt.rs
+++ b/vendor/deno_crypto/decrypt.rs
@@ -1,0 +1,362 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use aes::cipher::block_padding::Pkcs7;
+use aes::cipher::BlockDecryptMut;
+use aes::cipher::KeyIvInit;
+use aes_gcm::aead::generic_array::typenum::U12;
+use aes_gcm::aead::generic_array::typenum::U16;
+use aes_gcm::aead::generic_array::ArrayLength;
+use aes_gcm::aes::Aes128;
+use aes_gcm::aes::Aes192;
+use aes_gcm::aes::Aes256;
+use aes_gcm::AeadInPlace;
+use aes_gcm::KeyInit;
+use aes_gcm::Nonce;
+use ctr::cipher::StreamCipher;
+use ctr::Ctr128BE;
+use ctr::Ctr32BE;
+use ctr::Ctr64BE;
+use deno_core::op2;
+use deno_core::unsync::spawn_blocking;
+use deno_core::JsBuffer;
+use deno_core::ToJsBuffer;
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use serde::Deserialize;
+use sha1::Sha1;
+use sha2::Sha256;
+use sha2::Sha384;
+use sha2::Sha512;
+
+use crate::shared::*;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecryptOptions {
+  key: V8RawKeyData,
+  #[serde(flatten)]
+  algorithm: DecryptAlgorithm,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "algorithm")]
+pub enum DecryptAlgorithm {
+  #[serde(rename = "RSA-OAEP")]
+  RsaOaep {
+    hash: ShaHash,
+    #[serde(with = "serde_bytes")]
+    label: Vec<u8>,
+  },
+  #[serde(rename = "AES-CBC", rename_all = "camelCase")]
+  AesCbc {
+    #[serde(with = "serde_bytes")]
+    iv: Vec<u8>,
+    length: usize,
+  },
+  #[serde(rename = "AES-CTR", rename_all = "camelCase")]
+  AesCtr {
+    #[serde(with = "serde_bytes")]
+    counter: Vec<u8>,
+    ctr_length: usize,
+    key_length: usize,
+  },
+  #[serde(rename = "AES-GCM", rename_all = "camelCase")]
+  AesGcm {
+    #[serde(with = "serde_bytes")]
+    iv: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    additional_data: Option<Vec<u8>>,
+    length: usize,
+    tag_length: usize,
+  },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DecryptError {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error(transparent)]
+  Pkcs1(#[from] rsa::pkcs1::Error),
+  #[error("Decryption failed")]
+  Failed,
+  #[error("invalid length")]
+  InvalidLength,
+  #[error("invalid counter length. Currently supported 32/64/128 bits")]
+  InvalidCounterLength,
+  #[error("tag length not equal to 128")]
+  InvalidTagLength,
+  #[error("invalid key or iv")]
+  InvalidKeyOrIv,
+  #[error("tried to decrypt too much data")]
+  TooMuchData,
+  #[error("iv length not equal to 12 or 16")]
+  InvalidIvLength,
+  #[error("{0}")]
+  Rsa(rsa::Error),
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_decrypt(
+  #[serde] opts: DecryptOptions,
+  #[buffer] data: JsBuffer,
+) -> Result<ToJsBuffer, DecryptError> {
+  let key = opts.key;
+  let fun = move || match opts.algorithm {
+    DecryptAlgorithm::RsaOaep { hash, label } => {
+      decrypt_rsa_oaep(key, hash, label, &data)
+    }
+    DecryptAlgorithm::AesCbc { iv, length } => {
+      decrypt_aes_cbc(key, length, iv, &data)
+    }
+    DecryptAlgorithm::AesCtr {
+      counter,
+      ctr_length,
+      key_length,
+    } => decrypt_aes_ctr(key, key_length, &counter, ctr_length, &data),
+    DecryptAlgorithm::AesGcm {
+      iv,
+      additional_data,
+      length,
+      tag_length,
+    } => decrypt_aes_gcm(key, length, tag_length, iv, additional_data, &data),
+  };
+  let buf = spawn_blocking(fun).await.unwrap()?;
+  Ok(buf.into())
+}
+
+fn decrypt_rsa_oaep(
+  key: V8RawKeyData,
+  hash: ShaHash,
+  label: Vec<u8>,
+  data: &[u8],
+) -> Result<Vec<u8>, DecryptError> {
+  let key = key.as_rsa_private_key()?;
+
+  let private_key = rsa::RsaPrivateKey::from_pkcs1_der(key)?;
+  let label = Some(String::from_utf8_lossy(&label).to_string());
+
+  let padding = match hash {
+    ShaHash::Sha1 => rsa::Oaep {
+      digest: Box::<Sha1>::default(),
+      mgf_digest: Box::<Sha1>::default(),
+      label,
+    },
+    ShaHash::Sha256 => rsa::Oaep {
+      digest: Box::<Sha256>::default(),
+      mgf_digest: Box::<Sha256>::default(),
+      label,
+    },
+    ShaHash::Sha384 => rsa::Oaep {
+      digest: Box::<Sha384>::default(),
+      mgf_digest: Box::<Sha384>::default(),
+      label,
+    },
+    ShaHash::Sha512 => rsa::Oaep {
+      digest: Box::<Sha512>::default(),
+      mgf_digest: Box::<Sha512>::default(),
+      label,
+    },
+  };
+
+  private_key
+    .decrypt(padding, data)
+    .map_err(DecryptError::Rsa)
+}
+
+fn decrypt_aes_cbc(
+  key: V8RawKeyData,
+  length: usize,
+  iv: Vec<u8>,
+  data: &[u8],
+) -> Result<Vec<u8>, DecryptError> {
+  let key = key.as_secret_key()?;
+
+  // 2.
+  let plaintext = match length {
+    128 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
+      let cipher = Aes128CbcDec::new_from_slices(key, &iv)
+        .map_err(|_| DecryptError::InvalidKeyOrIv)?;
+
+      cipher
+        .decrypt_padded_vec_mut::<Pkcs7>(data)
+        .map_err(|_| DecryptError::Failed)?
+    }
+    192 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes192CbcDec = cbc::Decryptor<aes::Aes192>;
+      let cipher = Aes192CbcDec::new_from_slices(key, &iv)
+        .map_err(|_| DecryptError::InvalidKeyOrIv)?;
+
+      cipher
+        .decrypt_padded_vec_mut::<Pkcs7>(data)
+        .map_err(|_| DecryptError::Failed)?
+    }
+    256 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
+      let cipher = Aes256CbcDec::new_from_slices(key, &iv)
+        .map_err(|_| DecryptError::InvalidKeyOrIv)?;
+
+      cipher
+        .decrypt_padded_vec_mut::<Pkcs7>(data)
+        .map_err(|_| DecryptError::Failed)?
+    }
+    _ => unreachable!(),
+  };
+
+  // 6.
+  Ok(plaintext)
+}
+
+fn decrypt_aes_ctr_gen<B>(
+  key: &[u8],
+  counter: &[u8],
+  data: &[u8],
+) -> Result<Vec<u8>, DecryptError>
+where
+  B: KeyIvInit + StreamCipher,
+{
+  let mut cipher = B::new(key.into(), counter.into());
+
+  let mut plaintext = data.to_vec();
+  cipher
+    .try_apply_keystream(&mut plaintext)
+    .map_err(|_| DecryptError::TooMuchData)?;
+
+  Ok(plaintext)
+}
+
+fn decrypt_aes_gcm_gen<N: ArrayLength<u8>>(
+  key: &[u8],
+  tag: &aes_gcm::Tag,
+  nonce: &[u8],
+  length: usize,
+  additional_data: Vec<u8>,
+  plaintext: &mut [u8],
+) -> Result<(), DecryptError> {
+  let nonce = Nonce::from_slice(nonce);
+  match length {
+    128 => {
+      let cipher = aes_gcm::AesGcm::<Aes128, N>::new_from_slice(key)
+        .map_err(|_| DecryptError::Failed)?;
+      cipher
+        .decrypt_in_place_detached(
+          nonce,
+          additional_data.as_slice(),
+          plaintext,
+          tag,
+        )
+        .map_err(|_| DecryptError::Failed)?
+    }
+    192 => {
+      let cipher = aes_gcm::AesGcm::<Aes192, N>::new_from_slice(key)
+        .map_err(|_| DecryptError::Failed)?;
+      cipher
+        .decrypt_in_place_detached(
+          nonce,
+          additional_data.as_slice(),
+          plaintext,
+          tag,
+        )
+        .map_err(|_| DecryptError::Failed)?
+    }
+    256 => {
+      let cipher = aes_gcm::AesGcm::<Aes256, N>::new_from_slice(key)
+        .map_err(|_| DecryptError::Failed)?;
+      cipher
+        .decrypt_in_place_detached(
+          nonce,
+          additional_data.as_slice(),
+          plaintext,
+          tag,
+        )
+        .map_err(|_| DecryptError::Failed)?
+    }
+    _ => return Err(DecryptError::InvalidLength),
+  };
+
+  Ok(())
+}
+
+fn decrypt_aes_ctr(
+  key: V8RawKeyData,
+  key_length: usize,
+  counter: &[u8],
+  ctr_length: usize,
+  data: &[u8],
+) -> Result<Vec<u8>, DecryptError> {
+  let key = key.as_secret_key()?;
+
+  match ctr_length {
+    32 => match key_length {
+      128 => decrypt_aes_ctr_gen::<Ctr32BE<aes::Aes128>>(key, counter, data),
+      192 => decrypt_aes_ctr_gen::<Ctr32BE<aes::Aes192>>(key, counter, data),
+      256 => decrypt_aes_ctr_gen::<Ctr32BE<aes::Aes256>>(key, counter, data),
+      _ => Err(DecryptError::InvalidLength),
+    },
+    64 => match key_length {
+      128 => decrypt_aes_ctr_gen::<Ctr64BE<aes::Aes128>>(key, counter, data),
+      192 => decrypt_aes_ctr_gen::<Ctr64BE<aes::Aes192>>(key, counter, data),
+      256 => decrypt_aes_ctr_gen::<Ctr64BE<aes::Aes256>>(key, counter, data),
+      _ => Err(DecryptError::InvalidLength),
+    },
+    128 => match key_length {
+      128 => decrypt_aes_ctr_gen::<Ctr128BE<aes::Aes128>>(key, counter, data),
+      192 => decrypt_aes_ctr_gen::<Ctr128BE<aes::Aes192>>(key, counter, data),
+      256 => decrypt_aes_ctr_gen::<Ctr128BE<aes::Aes256>>(key, counter, data),
+      _ => Err(DecryptError::InvalidLength),
+    },
+    _ => Err(DecryptError::InvalidCounterLength),
+  }
+}
+
+fn decrypt_aes_gcm(
+  key: V8RawKeyData,
+  length: usize,
+  tag_length: usize,
+  iv: Vec<u8>,
+  additional_data: Option<Vec<u8>>,
+  data: &[u8],
+) -> Result<Vec<u8>, DecryptError> {
+  let key = key.as_secret_key()?;
+  let additional_data = additional_data.unwrap_or_default();
+
+  // The `aes_gcm` crate only supports 128 bits tag length.
+  //
+  // Note that encryption won't fail, it instead truncates the tag
+  // to the specified tag length as specified in the spec.
+  if tag_length != 128 {
+    return Err(DecryptError::InvalidTagLength);
+  }
+
+  let sep = data.len() - (tag_length / 8);
+  let tag = &data[sep..];
+
+  // The actual ciphertext, called plaintext because it is reused in place.
+  let mut plaintext = data[..sep].to_vec();
+
+  // Fixed 96-bit or 128-bit nonce
+  match iv.len() {
+    12 => decrypt_aes_gcm_gen::<U12>(
+      key,
+      tag.into(),
+      &iv,
+      length,
+      additional_data,
+      &mut plaintext,
+    )?,
+    16 => decrypt_aes_gcm_gen::<U16>(
+      key,
+      tag.into(),
+      &iv,
+      length,
+      additional_data,
+      &mut plaintext,
+    )?,
+    _ => return Err(DecryptError::InvalidIvLength),
+  }
+
+  Ok(plaintext)
+}

--- a/vendor/deno_crypto/ed25519.rs
+++ b/vendor/deno_crypto/ed25519.rs
@@ -1,0 +1,176 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::Engine;
+use deno_core::op2;
+use deno_core::ToJsBuffer;
+use elliptic_curve::pkcs8::PrivateKeyInfo;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use ring::signature::Ed25519KeyPair;
+use ring::signature::KeyPair;
+use spki::der::asn1::BitString;
+use spki::der::Decode;
+use spki::der::Encode;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Ed25519Error {
+  #[error("Failed to export key")]
+  FailedExport,
+  #[error(transparent)]
+  Der(#[from] rsa::pkcs1::der::Error),
+  #[error(transparent)]
+  KeyRejected(#[from] ring::error::KeyRejected),
+}
+
+#[op2(fast)]
+pub fn op_crypto_generate_ed25519_keypair(
+  #[buffer] pkey: &mut [u8],
+  #[buffer] pubkey: &mut [u8],
+) -> bool {
+  let mut rng = OsRng;
+  rng.fill_bytes(pkey);
+
+  let pair = match Ed25519KeyPair::from_seed_unchecked(pkey) {
+    Ok(p) => p,
+    Err(_) => return false,
+  };
+  pubkey.copy_from_slice(pair.public_key().as_ref());
+  true
+}
+
+#[op2(fast)]
+pub fn op_crypto_sign_ed25519(
+  #[buffer] key: &[u8],
+  #[buffer] data: &[u8],
+  #[buffer] signature: &mut [u8],
+) -> bool {
+  let pair = match Ed25519KeyPair::from_seed_unchecked(key) {
+    Ok(p) => p,
+    Err(_) => return false,
+  };
+  signature.copy_from_slice(pair.sign(data).as_ref());
+  true
+}
+
+#[op2(fast)]
+pub fn op_crypto_verify_ed25519(
+  #[buffer] pubkey: &[u8],
+  #[buffer] data: &[u8],
+  #[buffer] signature: &[u8],
+) -> bool {
+  ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, pubkey)
+    .verify(data, signature)
+    .is_ok()
+}
+
+// id-Ed25519 OBJECT IDENTIFIER ::= { 1 3 101 112 }
+pub const ED25519_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.3.101.112");
+
+#[op2(fast)]
+pub fn op_crypto_import_spki_ed25519(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  let pk_info = match spki::SubjectPublicKeyInfoRef::try_from(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != ED25519_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  out.copy_from_slice(pk_info.subject_public_key.raw_bytes());
+  true
+}
+
+#[op2(fast)]
+pub fn op_crypto_import_pkcs8_ed25519(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  // This should probably use OneAsymmetricKey instead
+  let pk_info = match PrivateKeyInfo::from_der(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != ED25519_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  // 6.
+  // CurvePrivateKey ::= OCTET STRING
+  if pk_info.private_key.len() != 34 {
+    return false;
+  }
+  out.copy_from_slice(&pk_info.private_key[2..]);
+  true
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_spki_ed25519(
+  #[buffer] pubkey: &[u8],
+) -> Result<ToJsBuffer, Ed25519Error> {
+  let key_info = spki::SubjectPublicKeyInfo {
+    algorithm: spki::AlgorithmIdentifierOwned {
+      // id-Ed25519
+      oid: ED25519_OID,
+      parameters: None,
+    },
+    subject_public_key: BitString::from_bytes(pubkey)?,
+  };
+  Ok(
+    key_info
+      .to_der()
+      .map_err(|_| Ed25519Error::FailedExport)?
+      .into(),
+  )
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_pkcs8_ed25519(
+  #[buffer] pkey: &[u8],
+) -> Result<ToJsBuffer, Ed25519Error> {
+  use rsa::pkcs1::der::Encode;
+
+  // This should probably use OneAsymmetricKey instead
+  let pk_info = rsa::pkcs8::PrivateKeyInfo {
+    public_key: None,
+    algorithm: rsa::pkcs8::AlgorithmIdentifierRef {
+      // id-Ed25519
+      oid: ED25519_OID,
+      parameters: None,
+    },
+    private_key: pkey, // OCTET STRING
+  };
+
+  let mut buf = Vec::new();
+  pk_info.encode_to_vec(&mut buf)?;
+  Ok(buf.into())
+}
+
+// 'x' from Section 2 of RFC 8037
+// https://www.rfc-editor.org/rfc/rfc8037#section-2
+#[op2]
+#[string]
+pub fn op_crypto_jwk_x_ed25519(
+  #[buffer] pkey: &[u8],
+) -> Result<String, Ed25519Error> {
+  let pair = Ed25519KeyPair::from_seed_unchecked(pkey)?;
+  Ok(BASE64_URL_SAFE_NO_PAD.encode(pair.public_key().as_ref()))
+}

--- a/vendor/deno_crypto/encrypt.rs
+++ b/vendor/deno_crypto/encrypt.rs
@@ -1,0 +1,324 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use aes::cipher::block_padding::Pkcs7;
+use aes::cipher::BlockEncryptMut;
+use aes::cipher::KeyIvInit;
+use aes::cipher::StreamCipher;
+use aes_gcm::aead::generic_array::typenum::U12;
+use aes_gcm::aead::generic_array::typenum::U16;
+use aes_gcm::aead::generic_array::ArrayLength;
+use aes_gcm::aes::Aes128;
+use aes_gcm::aes::Aes192;
+use aes_gcm::aes::Aes256;
+use aes_gcm::AeadInPlace;
+use aes_gcm::KeyInit;
+use aes_gcm::Nonce;
+use ctr::Ctr128BE;
+use ctr::Ctr32BE;
+use ctr::Ctr64BE;
+use deno_core::op2;
+use deno_core::unsync::spawn_blocking;
+use deno_core::JsBuffer;
+use deno_core::ToJsBuffer;
+use rand::rngs::OsRng;
+use rsa::pkcs1::DecodeRsaPublicKey;
+use serde::Deserialize;
+use sha1::Sha1;
+use sha2::Sha256;
+use sha2::Sha384;
+use sha2::Sha512;
+
+use crate::shared::*;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncryptOptions {
+  key: V8RawKeyData,
+  #[serde(flatten)]
+  algorithm: EncryptAlgorithm,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "algorithm")]
+pub enum EncryptAlgorithm {
+  #[serde(rename = "RSA-OAEP")]
+  RsaOaep {
+    hash: ShaHash,
+    #[serde(with = "serde_bytes")]
+    label: Vec<u8>,
+  },
+  #[serde(rename = "AES-CBC", rename_all = "camelCase")]
+  AesCbc {
+    #[serde(with = "serde_bytes")]
+    iv: Vec<u8>,
+    length: usize,
+  },
+  #[serde(rename = "AES-GCM", rename_all = "camelCase")]
+  AesGcm {
+    #[serde(with = "serde_bytes")]
+    iv: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    additional_data: Option<Vec<u8>>,
+    length: usize,
+    tag_length: usize,
+  },
+  #[serde(rename = "AES-CTR", rename_all = "camelCase")]
+  AesCtr {
+    #[serde(with = "serde_bytes")]
+    counter: Vec<u8>,
+    ctr_length: usize,
+    key_length: usize,
+  },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptError {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error("invalid length")]
+  InvalidLength,
+  #[error("invalid key or iv")]
+  InvalidKeyOrIv,
+  #[error("iv length not equal to 12 or 16")]
+  InvalidIvLength,
+  #[error("invalid counter length. Currently supported 32/64/128 bits")]
+  InvalidCounterLength,
+  #[error("tried to encrypt too much data")]
+  TooMuchData,
+  #[error("Encryption failed")]
+  Failed,
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_encrypt(
+  #[serde] opts: EncryptOptions,
+  #[buffer] data: JsBuffer,
+) -> Result<ToJsBuffer, EncryptError> {
+  let key = opts.key;
+  let fun = move || match opts.algorithm {
+    EncryptAlgorithm::RsaOaep { hash, label } => {
+      encrypt_rsa_oaep(key, hash, label, &data)
+    }
+    EncryptAlgorithm::AesCbc { iv, length } => {
+      encrypt_aes_cbc(key, length, iv, &data)
+    }
+    EncryptAlgorithm::AesGcm {
+      iv,
+      additional_data,
+      length,
+      tag_length,
+    } => encrypt_aes_gcm(key, length, tag_length, iv, additional_data, &data),
+    EncryptAlgorithm::AesCtr {
+      counter,
+      ctr_length,
+      key_length,
+    } => encrypt_aes_ctr(key, key_length, &counter, ctr_length, &data),
+  };
+  let buf = spawn_blocking(fun).await.unwrap()?;
+  Ok(buf.into())
+}
+
+fn encrypt_rsa_oaep(
+  key: V8RawKeyData,
+  hash: ShaHash,
+  label: Vec<u8>,
+  data: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+  let label = String::from_utf8_lossy(&label).to_string();
+
+  let public_key = key.as_rsa_public_key()?;
+  let public_key = rsa::RsaPublicKey::from_pkcs1_der(&public_key)
+    .map_err(|_| SharedError::FailedDecodePublicKey)?;
+  let mut rng = OsRng;
+  let padding = match hash {
+    ShaHash::Sha1 => rsa::Oaep {
+      digest: Box::<Sha1>::default(),
+      mgf_digest: Box::<Sha1>::default(),
+      label: Some(label),
+    },
+    ShaHash::Sha256 => rsa::Oaep {
+      digest: Box::<Sha256>::default(),
+      mgf_digest: Box::<Sha256>::default(),
+      label: Some(label),
+    },
+    ShaHash::Sha384 => rsa::Oaep {
+      digest: Box::<Sha384>::default(),
+      mgf_digest: Box::<Sha384>::default(),
+      label: Some(label),
+    },
+    ShaHash::Sha512 => rsa::Oaep {
+      digest: Box::<Sha512>::default(),
+      mgf_digest: Box::<Sha512>::default(),
+      label: Some(label),
+    },
+  };
+  let encrypted = public_key
+    .encrypt(&mut rng, padding, data)
+    .map_err(|_| EncryptError::Failed)?;
+  Ok(encrypted)
+}
+
+fn encrypt_aes_cbc(
+  key: V8RawKeyData,
+  length: usize,
+  iv: Vec<u8>,
+  data: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+  let key = key.as_secret_key()?;
+  let ciphertext = match length {
+    128 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+
+      let cipher = Aes128CbcEnc::new_from_slices(key, &iv)
+        .map_err(|_| EncryptError::InvalidKeyOrIv)?;
+      cipher.encrypt_padded_vec_mut::<Pkcs7>(data)
+    }
+    192 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes192CbcEnc = cbc::Encryptor<aes::Aes192>;
+
+      let cipher = Aes192CbcEnc::new_from_slices(key, &iv)
+        .map_err(|_| EncryptError::InvalidKeyOrIv)?;
+      cipher.encrypt_padded_vec_mut::<Pkcs7>(data)
+    }
+    256 => {
+      // Section 10.3 Step 2 of RFC 2315 https://www.rfc-editor.org/rfc/rfc2315
+      type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
+
+      let cipher = Aes256CbcEnc::new_from_slices(key, &iv)
+        .map_err(|_| EncryptError::InvalidKeyOrIv)?;
+      cipher.encrypt_padded_vec_mut::<Pkcs7>(data)
+    }
+    _ => return Err(EncryptError::InvalidLength),
+  };
+  Ok(ciphertext)
+}
+
+fn encrypt_aes_gcm_general<N: ArrayLength<u8>>(
+  key: &[u8],
+  iv: Vec<u8>,
+  length: usize,
+  ciphertext: &mut [u8],
+  additional_data: Vec<u8>,
+) -> Result<aes_gcm::Tag, EncryptError> {
+  let nonce = Nonce::<N>::from_slice(&iv);
+  let tag = match length {
+    128 => {
+      let cipher = aes_gcm::AesGcm::<Aes128, N>::new_from_slice(key)
+        .map_err(|_| EncryptError::Failed)?;
+      cipher
+        .encrypt_in_place_detached(nonce, &additional_data, ciphertext)
+        .map_err(|_| EncryptError::Failed)?
+    }
+    192 => {
+      let cipher = aes_gcm::AesGcm::<Aes192, N>::new_from_slice(key)
+        .map_err(|_| EncryptError::Failed)?;
+      cipher
+        .encrypt_in_place_detached(nonce, &additional_data, ciphertext)
+        .map_err(|_| EncryptError::Failed)?
+    }
+    256 => {
+      let cipher = aes_gcm::AesGcm::<Aes256, N>::new_from_slice(key)
+        .map_err(|_| EncryptError::Failed)?;
+      cipher
+        .encrypt_in_place_detached(nonce, &additional_data, ciphertext)
+        .map_err(|_| EncryptError::Failed)?
+    }
+    _ => return Err(EncryptError::InvalidLength),
+  };
+
+  Ok(tag)
+}
+
+fn encrypt_aes_gcm(
+  key: V8RawKeyData,
+  length: usize,
+  tag_length: usize,
+  iv: Vec<u8>,
+  additional_data: Option<Vec<u8>>,
+  data: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+  let key = key.as_secret_key()?;
+  let additional_data = additional_data.unwrap_or_default();
+
+  let mut ciphertext = data.to_vec();
+  // Fixed 96-bit OR 128-bit nonce
+  let tag = match iv.len() {
+    12 => encrypt_aes_gcm_general::<U12>(
+      key,
+      iv,
+      length,
+      &mut ciphertext,
+      additional_data,
+    )?,
+    16 => encrypt_aes_gcm_general::<U16>(
+      key,
+      iv,
+      length,
+      &mut ciphertext,
+      additional_data,
+    )?,
+    _ => return Err(EncryptError::InvalidIvLength),
+  };
+
+  // Truncated tag to the specified tag length.
+  // `tag` is fixed to be 16 bytes long and (tag_length / 8) is always <= 16
+  let tag = &tag[..(tag_length / 8)];
+
+  // C | T
+  ciphertext.extend_from_slice(tag);
+
+  Ok(ciphertext)
+}
+
+fn encrypt_aes_ctr_gen<B>(
+  key: &[u8],
+  counter: &[u8],
+  data: &[u8],
+) -> Result<Vec<u8>, EncryptError>
+where
+  B: KeyIvInit + StreamCipher,
+{
+  let mut cipher = B::new(key.into(), counter.into());
+
+  let mut ciphertext = data.to_vec();
+  cipher
+    .try_apply_keystream(&mut ciphertext)
+    .map_err(|_| EncryptError::TooMuchData)?;
+
+  Ok(ciphertext)
+}
+
+fn encrypt_aes_ctr(
+  key: V8RawKeyData,
+  key_length: usize,
+  counter: &[u8],
+  ctr_length: usize,
+  data: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+  let key = key.as_secret_key()?;
+
+  match ctr_length {
+    32 => match key_length {
+      128 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes128>>(key, counter, data),
+      192 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes192>>(key, counter, data),
+      256 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes256>>(key, counter, data),
+      _ => Err(EncryptError::InvalidLength),
+    },
+    64 => match key_length {
+      128 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes128>>(key, counter, data),
+      192 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes192>>(key, counter, data),
+      256 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes256>>(key, counter, data),
+      _ => Err(EncryptError::InvalidLength),
+    },
+    128 => match key_length {
+      128 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes128>>(key, counter, data),
+      192 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes192>>(key, counter, data),
+      256 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes256>>(key, counter, data),
+      _ => Err(EncryptError::InvalidLength),
+    },
+    _ => Err(EncryptError::InvalidCounterLength),
+  }
+}

--- a/vendor/deno_crypto/export_key.rs
+++ b/vendor/deno_crypto/export_key.rs
@@ -1,0 +1,411 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::Engine;
+use const_oid::AssociatedOid;
+use const_oid::ObjectIdentifier;
+use deno_core::op2;
+use deno_core::ToJsBuffer;
+use elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::DecodePrivateKey;
+use rsa::pkcs1::der::Decode;
+use rsa::pkcs8::der::asn1::UintRef;
+use rsa::pkcs8::der::Encode;
+use serde::Deserialize;
+use serde::Serialize;
+use spki::der::asn1;
+use spki::der::asn1::BitString;
+use spki::AlgorithmIdentifier;
+use spki::AlgorithmIdentifierOwned;
+
+use crate::shared::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExportKeyError {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error(transparent)]
+  Der(#[from] spki::der::Error),
+  #[error("Unsupported named curve")]
+  UnsupportedNamedCurve,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportKeyOptions {
+  format: ExportKeyFormat,
+  #[serde(flatten)]
+  algorithm: ExportKeyAlgorithm,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportKeyFormat {
+  Raw,
+  Pkcs8,
+  Spki,
+  JwkPublic,
+  JwkPrivate,
+  JwkSecret,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "algorithm")]
+pub enum ExportKeyAlgorithm {
+  #[serde(rename = "RSASSA-PKCS1-v1_5")]
+  RsassaPkcs1v15 {},
+  #[serde(rename = "RSA-PSS")]
+  RsaPss {},
+  #[serde(rename = "RSA-OAEP")]
+  RsaOaep {},
+  #[serde(rename = "ECDSA", rename_all = "camelCase")]
+  Ecdsa { named_curve: EcNamedCurve },
+  #[serde(rename = "ECDH", rename_all = "camelCase")]
+  Ecdh { named_curve: EcNamedCurve },
+  #[serde(rename = "AES")]
+  Aes {},
+  #[serde(rename = "HMAC")]
+  Hmac {},
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ExportKeyResult {
+  Raw(ToJsBuffer),
+  Pkcs8(ToJsBuffer),
+  Spki(ToJsBuffer),
+  JwkSecret {
+    k: String,
+  },
+  JwkPublicRsa {
+    n: String,
+    e: String,
+  },
+  JwkPrivateRsa {
+    n: String,
+    e: String,
+    d: String,
+    p: String,
+    q: String,
+    dp: String,
+    dq: String,
+    qi: String,
+  },
+  JwkPublicEc {
+    x: String,
+    y: String,
+  },
+  JwkPrivateEc {
+    x: String,
+    y: String,
+    d: String,
+  },
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_key(
+  #[serde] opts: ExportKeyOptions,
+  #[serde] key_data: V8RawKeyData,
+) -> Result<ExportKeyResult, ExportKeyError> {
+  match opts.algorithm {
+    ExportKeyAlgorithm::RsassaPkcs1v15 {}
+    | ExportKeyAlgorithm::RsaPss {}
+    | ExportKeyAlgorithm::RsaOaep {} => export_key_rsa(opts.format, key_data),
+    ExportKeyAlgorithm::Ecdh { named_curve }
+    | ExportKeyAlgorithm::Ecdsa { named_curve } => {
+      export_key_ec(opts.format, key_data, opts.algorithm, named_curve)
+    }
+    ExportKeyAlgorithm::Aes {} | ExportKeyAlgorithm::Hmac {} => {
+      export_key_symmetric(opts.format, key_data)
+    }
+  }
+}
+
+fn uint_to_b64(bytes: UintRef) -> String {
+  BASE64_URL_SAFE_NO_PAD.encode(bytes.as_bytes())
+}
+
+fn bytes_to_b64(bytes: &[u8]) -> String {
+  BASE64_URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn export_key_rsa(
+  format: ExportKeyFormat,
+  key_data: V8RawKeyData,
+) -> Result<ExportKeyResult, ExportKeyError> {
+  match format {
+    ExportKeyFormat::Spki => {
+      let subject_public_key = &key_data.as_rsa_public_key()?;
+
+      // the SPKI structure
+      let key_info = spki::SubjectPublicKeyInfo {
+        algorithm: spki::AlgorithmIdentifier {
+          // rsaEncryption(1)
+          oid: const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1"),
+          // parameters field should not be omitted (None).
+          // It MUST have ASN.1 type NULL.
+          parameters: Some(asn1::AnyRef::from(asn1::Null)),
+        },
+        subject_public_key: BitString::from_bytes(subject_public_key).unwrap(),
+      };
+
+      // Infallible because we know the public key is valid.
+      let spki_der = key_info.to_der().unwrap();
+      Ok(ExportKeyResult::Spki(spki_der.into()))
+    }
+    ExportKeyFormat::Pkcs8 => {
+      let private_key = key_data.as_rsa_private_key()?;
+
+      // the PKCS#8 v1 structure
+      // PrivateKeyInfo ::= SEQUENCE {
+      //   version                   Version,
+      //   privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
+      //   privateKey                PrivateKey,
+      //   attributes           [0]  IMPLICIT Attributes OPTIONAL }
+
+      // version is 0 when publickey is None
+
+      let pk_info = rsa::pkcs8::PrivateKeyInfo {
+        public_key: None,
+        algorithm: rsa::pkcs8::AlgorithmIdentifierRef {
+          // rsaEncryption(1)
+          oid: rsa::pkcs8::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1"),
+          // parameters field should not be omitted (None).
+          // It MUST have ASN.1 type NULL as per defined in RFC 3279 Section 2.3.1
+          parameters: Some(rsa::pkcs8::der::asn1::AnyRef::from(
+            rsa::pkcs8::der::asn1::Null,
+          )),
+        },
+        private_key,
+      };
+
+      // Infallible because we know the private key is valid.
+      let mut pkcs8_der = Vec::new();
+      pk_info.encode_to_vec(&mut pkcs8_der)?;
+
+      Ok(ExportKeyResult::Pkcs8(pkcs8_der.into()))
+    }
+    ExportKeyFormat::JwkPublic => {
+      let public_key = key_data.as_rsa_public_key()?;
+      let public_key = rsa::pkcs1::RsaPublicKey::from_der(&public_key)
+        .map_err(|_| SharedError::FailedDecodePublicKey)?;
+
+      Ok(ExportKeyResult::JwkPublicRsa {
+        n: uint_to_b64(public_key.modulus),
+        e: uint_to_b64(public_key.public_exponent),
+      })
+    }
+    ExportKeyFormat::JwkPrivate => {
+      let private_key = key_data.as_rsa_private_key()?;
+      let private_key = rsa::pkcs1::RsaPrivateKey::from_der(private_key)
+        .map_err(|_| SharedError::FailedDecodePrivateKey)?;
+
+      Ok(ExportKeyResult::JwkPrivateRsa {
+        n: uint_to_b64(private_key.modulus),
+        e: uint_to_b64(private_key.public_exponent),
+        d: uint_to_b64(private_key.private_exponent),
+        p: uint_to_b64(private_key.prime1),
+        q: uint_to_b64(private_key.prime2),
+        dp: uint_to_b64(private_key.exponent1),
+        dq: uint_to_b64(private_key.exponent2),
+        qi: uint_to_b64(private_key.coefficient),
+      })
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn export_key_symmetric(
+  format: ExportKeyFormat,
+  key_data: V8RawKeyData,
+) -> Result<ExportKeyResult, ExportKeyError> {
+  match format {
+    ExportKeyFormat::JwkSecret => {
+      let bytes = key_data.as_secret_key()?;
+
+      Ok(ExportKeyResult::JwkSecret {
+        k: bytes_to_b64(bytes),
+      })
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn export_key_ec(
+  format: ExportKeyFormat,
+  key_data: V8RawKeyData,
+  algorithm: ExportKeyAlgorithm,
+  named_curve: EcNamedCurve,
+) -> Result<ExportKeyResult, ExportKeyError> {
+  match format {
+    ExportKeyFormat::Raw => {
+      let subject_public_key = match named_curve {
+        EcNamedCurve::P256 => {
+          let point = key_data.as_ec_public_key_p256()?;
+
+          point.as_ref().to_vec()
+        }
+        EcNamedCurve::P384 => {
+          let point = key_data.as_ec_public_key_p384()?;
+
+          point.as_ref().to_vec()
+        }
+        EcNamedCurve::P521 => {
+          let point = key_data.as_ec_public_key_p521()?;
+
+          point.as_ref().to_vec()
+        }
+      };
+      Ok(ExportKeyResult::Raw(subject_public_key.into()))
+    }
+    ExportKeyFormat::Spki => {
+      let subject_public_key = match named_curve {
+        EcNamedCurve::P256 => {
+          let point = key_data.as_ec_public_key_p256()?;
+
+          point.as_ref().to_vec()
+        }
+        EcNamedCurve::P384 => {
+          let point = key_data.as_ec_public_key_p384()?;
+
+          point.as_ref().to_vec()
+        }
+        EcNamedCurve::P521 => {
+          let point = key_data.as_ec_public_key_p521()?;
+
+          point.as_ref().to_vec()
+        }
+      };
+
+      let alg_id = match named_curve {
+        EcNamedCurve::P256 => AlgorithmIdentifierOwned {
+          oid: elliptic_curve::ALGORITHM_OID,
+          parameters: Some((&p256::NistP256::OID).into()),
+        },
+        EcNamedCurve::P384 => AlgorithmIdentifierOwned {
+          oid: elliptic_curve::ALGORITHM_OID,
+          parameters: Some((&p384::NistP384::OID).into()),
+        },
+        EcNamedCurve::P521 => AlgorithmIdentifierOwned {
+          oid: elliptic_curve::ALGORITHM_OID,
+          parameters: Some((&p521::NistP521::OID).into()),
+        },
+      };
+
+      let alg_id = match algorithm {
+        ExportKeyAlgorithm::Ecdh { .. } => AlgorithmIdentifier {
+          oid: ObjectIdentifier::new_unwrap("1.2.840.10045.2.1"),
+          parameters: alg_id.parameters,
+        },
+        _ => alg_id,
+      };
+
+      // the SPKI structure
+      let key_info = spki::SubjectPublicKeyInfo {
+        algorithm: alg_id,
+        subject_public_key: BitString::from_bytes(&subject_public_key).unwrap(),
+      };
+
+      let spki_der = key_info.to_der().unwrap();
+
+      Ok(ExportKeyResult::Spki(spki_der.into()))
+    }
+    ExportKeyFormat::Pkcs8 => {
+      // private_key is a PKCS#8 DER-encoded private key
+      let private_key = key_data.as_ec_private_key()?;
+
+      Ok(ExportKeyResult::Pkcs8(private_key.to_vec().into()))
+    }
+    ExportKeyFormat::JwkPublic => match named_curve {
+      EcNamedCurve::P256 => {
+        let point = key_data.as_ec_public_key_p256()?;
+        let coords = point.coordinates();
+
+        if let p256::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } =
+          coords
+        {
+          Ok(ExportKeyResult::JwkPublicEc {
+            x: bytes_to_b64(x),
+            y: bytes_to_b64(y),
+          })
+        } else {
+          Err(SharedError::FailedDecodePublicKey.into())
+        }
+      }
+      EcNamedCurve::P384 => {
+        let point = key_data.as_ec_public_key_p384()?;
+        let coords = point.coordinates();
+
+        if let p384::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } =
+          coords
+        {
+          Ok(ExportKeyResult::JwkPublicEc {
+            x: bytes_to_b64(x),
+            y: bytes_to_b64(y),
+          })
+        } else {
+          Err(SharedError::FailedDecodePublicKey.into())
+        }
+      }
+      EcNamedCurve::P521 => {
+        let point = key_data.as_ec_public_key_p521()?;
+        let coords = point.coordinates();
+
+        if let p521::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } =
+          coords
+        {
+          Ok(ExportKeyResult::JwkPublicEc {
+            x: bytes_to_b64(x),
+            y: bytes_to_b64(y),
+          })
+        } else {
+          Err(SharedError::FailedDecodePublicKey.into())
+        }
+      }
+    },
+    ExportKeyFormat::JwkPrivate => {
+      let private_key = key_data.as_ec_private_key()?;
+
+      match named_curve {
+        EcNamedCurve::P256 => {
+          let ec_key = p256::SecretKey::from_pkcs8_der(private_key)
+            .map_err(|_| SharedError::FailedDecodePrivateKey)?;
+
+          let point = ec_key.public_key().to_encoded_point(false);
+          if let elliptic_curve::sec1::Coordinates::Uncompressed { x, y } =
+            point.coordinates()
+          {
+            Ok(ExportKeyResult::JwkPrivateEc {
+              x: bytes_to_b64(x),
+              y: bytes_to_b64(y),
+              d: bytes_to_b64(&ec_key.to_bytes()),
+            })
+          } else {
+            Err(SharedError::ExpectedValidPublicECKey.into())
+          }
+        }
+
+        EcNamedCurve::P384 => {
+          let ec_key = p384::SecretKey::from_pkcs8_der(private_key)
+            .map_err(|_| SharedError::FailedDecodePrivateKey)?;
+
+          let point = ec_key.public_key().to_encoded_point(false);
+          if let elliptic_curve::sec1::Coordinates::Uncompressed { x, y } =
+            point.coordinates()
+          {
+            Ok(ExportKeyResult::JwkPrivateEc {
+              x: bytes_to_b64(x),
+              y: bytes_to_b64(y),
+              d: bytes_to_b64(&ec_key.to_bytes()),
+            })
+          } else {
+            Err(SharedError::ExpectedValidPublicECKey.into())
+          }
+        }
+        _ => Err(ExportKeyError::UnsupportedNamedCurve),
+      }
+    }
+    ExportKeyFormat::JwkSecret => Err(SharedError::UnsupportedFormat.into()),
+  }
+}

--- a/vendor/deno_crypto/generate_key.rs
+++ b/vendor/deno_crypto/generate_key.rs
@@ -1,0 +1,176 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::op2;
+use deno_core::unsync::spawn_blocking;
+use deno_core::ToJsBuffer;
+use elliptic_curve::rand_core::OsRng;
+use num_traits::FromPrimitive;
+use once_cell::sync::Lazy;
+use ring::rand::SecureRandom;
+use ring::signature::EcdsaKeyPair;
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::BigUint;
+use rsa::RsaPrivateKey;
+use serde::Deserialize;
+
+use crate::shared::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GenerateKeyError {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error("Bad public exponent")]
+  BadPublicExponent,
+  #[error("Invalid HMAC key length")]
+  InvalidHMACKeyLength,
+  #[error("Failed to serialize RSA key")]
+  FailedRSAKeySerialization,
+  #[error("Invalid AES key length")]
+  InvalidAESKeyLength,
+  #[error("Failed to generate RSA key")]
+  FailedRSAKeyGeneration,
+  #[error("Failed to generate EC key")]
+  FailedECKeyGeneration,
+  #[error("Failed to generate key")]
+  FailedKeyGeneration,
+}
+
+// Allowlist for RSA public exponents.
+static PUB_EXPONENT_1: Lazy<BigUint> =
+  Lazy::new(|| BigUint::from_u64(3).unwrap());
+static PUB_EXPONENT_2: Lazy<BigUint> =
+  Lazy::new(|| BigUint::from_u64(65537).unwrap());
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "algorithm")]
+pub enum GenerateKeyOptions {
+  #[serde(rename = "RSA", rename_all = "camelCase")]
+  Rsa {
+    modulus_length: u32,
+    #[serde(with = "serde_bytes")]
+    public_exponent: Vec<u8>,
+  },
+  #[serde(rename = "EC", rename_all = "camelCase")]
+  Ec { named_curve: EcNamedCurve },
+  #[serde(rename = "AES", rename_all = "camelCase")]
+  Aes { length: usize },
+  #[serde(rename = "HMAC", rename_all = "camelCase")]
+  Hmac {
+    hash: ShaHash,
+    length: Option<usize>,
+  },
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_generate_key(
+  #[serde] opts: GenerateKeyOptions,
+) -> Result<ToJsBuffer, GenerateKeyError> {
+  let fun = || match opts {
+    GenerateKeyOptions::Rsa {
+      modulus_length,
+      public_exponent,
+    } => generate_key_rsa(modulus_length, &public_exponent),
+    GenerateKeyOptions::Ec { named_curve } => generate_key_ec(named_curve),
+    GenerateKeyOptions::Aes { length } => generate_key_aes(length),
+    GenerateKeyOptions::Hmac { hash, length } => {
+      generate_key_hmac(hash, length)
+    }
+  };
+  let buf = spawn_blocking(fun).await.unwrap()?;
+  Ok(buf.into())
+}
+
+fn generate_key_rsa(
+  modulus_length: u32,
+  public_exponent: &[u8],
+) -> Result<Vec<u8>, GenerateKeyError> {
+  let exponent = BigUint::from_bytes_be(public_exponent);
+  if exponent != *PUB_EXPONENT_1 && exponent != *PUB_EXPONENT_2 {
+    return Err(GenerateKeyError::BadPublicExponent);
+  }
+
+  let mut rng = OsRng;
+
+  let private_key =
+    RsaPrivateKey::new_with_exp(&mut rng, modulus_length as usize, &exponent)
+      .map_err(|_| GenerateKeyError::FailedRSAKeyGeneration)?;
+
+  let private_key = private_key
+    .to_pkcs1_der()
+    .map_err(|_| GenerateKeyError::FailedRSAKeySerialization)?;
+
+  Ok(private_key.as_bytes().to_vec())
+}
+
+fn generate_key_ec_p521() -> Vec<u8> {
+  let mut rng = OsRng;
+  let key = p521::SecretKey::random(&mut rng);
+  key.to_nonzero_scalar().to_bytes().to_vec()
+}
+
+fn generate_key_ec(
+  named_curve: EcNamedCurve,
+) -> Result<Vec<u8>, GenerateKeyError> {
+  let curve = match named_curve {
+    EcNamedCurve::P256 => &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+    EcNamedCurve::P384 => &ring::signature::ECDSA_P384_SHA384_FIXED_SIGNING,
+    EcNamedCurve::P521 => return Ok(generate_key_ec_p521()),
+  };
+
+  let rng = ring::rand::SystemRandom::new();
+
+  let pkcs8 = EcdsaKeyPair::generate_pkcs8(curve, &rng)
+    .map_err(|_| GenerateKeyError::FailedECKeyGeneration)?;
+
+  Ok(pkcs8.as_ref().to_vec())
+}
+
+fn generate_key_aes(length: usize) -> Result<Vec<u8>, GenerateKeyError> {
+  if length % 8 != 0 || length > 256 {
+    return Err(GenerateKeyError::InvalidAESKeyLength);
+  }
+
+  let mut key = vec![0u8; length / 8];
+  let rng = ring::rand::SystemRandom::new();
+  rng
+    .fill(&mut key)
+    .map_err(|_| GenerateKeyError::FailedKeyGeneration)?;
+
+  Ok(key)
+}
+
+fn generate_key_hmac(
+  hash: ShaHash,
+  length: Option<usize>,
+) -> Result<Vec<u8>, GenerateKeyError> {
+  let hash = match hash {
+    ShaHash::Sha1 => &ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+    ShaHash::Sha256 => &ring::hmac::HMAC_SHA256,
+    ShaHash::Sha384 => &ring::hmac::HMAC_SHA384,
+    ShaHash::Sha512 => &ring::hmac::HMAC_SHA512,
+  };
+
+  let length = if let Some(length) = length {
+    if length % 8 != 0 {
+      return Err(GenerateKeyError::InvalidHMACKeyLength);
+    }
+
+    let length = length / 8;
+    if length > ring::digest::MAX_BLOCK_LEN {
+      return Err(GenerateKeyError::InvalidHMACKeyLength);
+    }
+
+    length
+  } else {
+    hash.digest_algorithm().block_len()
+  };
+
+  let rng = ring::rand::SystemRandom::new();
+  let mut key = vec![0u8; length];
+  rng
+    .fill(&mut key)
+    .map_err(|_| GenerateKeyError::FailedKeyGeneration)?;
+
+  Ok(key)
+}

--- a/vendor/deno_crypto/import_key.rs
+++ b/vendor/deno_crypto/import_key.rs
@@ -1,0 +1,828 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use base64::Engine;
+use deno_core::op2;
+use deno_core::JsBuffer;
+use deno_core::ToJsBuffer;
+use elliptic_curve::pkcs8::PrivateKeyInfo;
+use p256::pkcs8::EncodePrivateKey;
+use rsa::pkcs1::UintRef;
+use rsa::pkcs8::der::Encode;
+use serde::Deserialize;
+use serde::Serialize;
+use spki::der::Decode;
+
+use crate::shared::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ImportKeyError {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error("invalid modulus")]
+  InvalidModulus,
+  #[error("invalid public exponent")]
+  InvalidPublicExponent,
+  #[error("invalid private exponent")]
+  InvalidPrivateExponent,
+  #[error("invalid first prime factor")]
+  InvalidFirstPrimeFactor,
+  #[error("invalid second prime factor")]
+  InvalidSecondPrimeFactor,
+  #[error("invalid first CRT exponent")]
+  InvalidFirstCRTExponent,
+  #[error("invalid second CRT exponent")]
+  InvalidSecondCRTExponent,
+  #[error("invalid CRT coefficient")]
+  InvalidCRTCoefficient,
+  #[error("invalid b64 coordinate")]
+  InvalidB64Coordinate,
+  #[error("invalid RSA public key")]
+  InvalidRSAPublicKey,
+  #[error("invalid RSA private key")]
+  InvalidRSAPrivateKey,
+  #[error("unsupported algorithm")]
+  UnsupportedAlgorithm,
+  #[error("public key is invalid (too long)")]
+  PublicKeyTooLong,
+  #[error("private key is invalid (too long)")]
+  PrivateKeyTooLong,
+  #[error("invalid P-256 elliptic curve point")]
+  InvalidP256ECPoint,
+  #[error("invalid P-384 elliptic curve point")]
+  InvalidP384ECPoint,
+  #[error("invalid P-521 elliptic curve point")]
+  InvalidP521ECPoint,
+  #[error("invalid P-256 elliptic curve SPKI data")]
+  InvalidP256ECSPKIData,
+  #[error("invalid P-384 elliptic curve SPKI data")]
+  InvalidP384ECSPKIData,
+  #[error("invalid P-521 elliptic curve SPKI data")]
+  InvalidP521ECSPKIData,
+  #[error("curve mismatch")]
+  CurveMismatch,
+  #[error("Unsupported named curve")]
+  UnsupportedNamedCurve,
+  #[error("invalid key data")]
+  InvalidKeyData,
+  #[error("invalid JWK private key")]
+  InvalidJWKPrivateKey,
+  #[error(transparent)]
+  EllipticCurve(#[from] elliptic_curve::Error),
+  #[error("expected valid PKCS#8 data")]
+  ExpectedValidPkcs8Data,
+  #[error("malformed parameters")]
+  MalformedParameters,
+  #[error(transparent)]
+  Spki(#[from] spki::Error),
+  #[error(transparent)]
+  Der(#[from] rsa::pkcs1::der::Error),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum KeyData {
+  Spki(JsBuffer),
+  Pkcs8(JsBuffer),
+  Raw(JsBuffer),
+  JwkSecret {
+    k: String,
+  },
+  JwkPublicRsa {
+    n: String,
+    e: String,
+  },
+  JwkPrivateRsa {
+    n: String,
+    e: String,
+    d: String,
+    p: String,
+    q: String,
+    dp: String,
+    dq: String,
+    qi: String,
+  },
+  JwkPublicEc {
+    x: String,
+    y: String,
+  },
+  JwkPrivateEc {
+    #[allow(dead_code)]
+    x: String,
+    #[allow(dead_code)]
+    y: String,
+    d: String,
+  },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", tag = "algorithm")]
+pub enum ImportKeyOptions {
+  #[serde(rename = "RSASSA-PKCS1-v1_5")]
+  RsassaPkcs1v15 {},
+  #[serde(rename = "RSA-PSS")]
+  RsaPss {},
+  #[serde(rename = "RSA-OAEP")]
+  RsaOaep {},
+  #[serde(rename = "ECDSA", rename_all = "camelCase")]
+  Ecdsa { named_curve: EcNamedCurve },
+  #[serde(rename = "ECDH", rename_all = "camelCase")]
+  Ecdh { named_curve: EcNamedCurve },
+  #[serde(rename = "AES", rename_all = "camelCase")]
+  Aes {},
+  #[serde(rename = "HMAC", rename_all = "camelCase")]
+  Hmac {},
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ImportKeyResult {
+  #[serde(rename_all = "camelCase")]
+  Rsa {
+    raw_data: RustRawKeyData,
+    modulus_length: usize,
+    public_exponent: ToJsBuffer,
+  },
+  #[serde(rename_all = "camelCase")]
+  Ec { raw_data: RustRawKeyData },
+  #[serde(rename_all = "camelCase")]
+  #[allow(dead_code)]
+  Aes { raw_data: RustRawKeyData },
+  #[serde(rename_all = "camelCase")]
+  Hmac { raw_data: RustRawKeyData },
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_import_key(
+  #[serde] opts: ImportKeyOptions,
+  #[serde] key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match opts {
+    ImportKeyOptions::RsassaPkcs1v15 {} => import_key_rsassa(key_data),
+    ImportKeyOptions::RsaPss {} => import_key_rsapss(key_data),
+    ImportKeyOptions::RsaOaep {} => import_key_rsaoaep(key_data),
+    ImportKeyOptions::Ecdsa { named_curve }
+    | ImportKeyOptions::Ecdh { named_curve } => {
+      import_key_ec(key_data, named_curve)
+    }
+    ImportKeyOptions::Aes {} => import_key_aes(key_data),
+    ImportKeyOptions::Hmac {} => import_key_hmac(key_data),
+  }
+}
+
+const BASE64_URL_SAFE_FORGIVING:
+  base64::engine::general_purpose::GeneralPurpose =
+  base64::engine::general_purpose::GeneralPurpose::new(
+    &base64::alphabet::URL_SAFE,
+    base64::engine::general_purpose::GeneralPurposeConfig::new()
+      .with_decode_allow_trailing_bits(true)
+      .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
+  );
+
+macro_rules! jwt_b64_int_or_err {
+  ($name:ident, $b64:expr, $err:tt) => {
+    let bytes = BASE64_URL_SAFE_FORGIVING
+      .decode($b64)
+      .map_err(|_| ImportKeyError::$err)?;
+    let $name = UintRef::new(&bytes).map_err(|_| ImportKeyError::$err)?;
+  };
+}
+
+fn import_key_rsa_jwk(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::JwkPublicRsa { n, e } => {
+      jwt_b64_int_or_err!(modulus, &n, InvalidModulus);
+      jwt_b64_int_or_err!(public_exponent, &e, InvalidPublicExponent);
+
+      let public_key = rsa::pkcs1::RsaPublicKey {
+        modulus,
+        public_exponent,
+      };
+
+      let mut data = Vec::new();
+      public_key
+        .encode_to_vec(&mut data)
+        .map_err(|_| ImportKeyError::InvalidRSAPublicKey)?;
+
+      let public_exponent =
+        public_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = public_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Public(data.into()),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::JwkPrivateRsa {
+      n,
+      e,
+      d,
+      p,
+      q,
+      dp,
+      dq,
+      qi,
+    } => {
+      jwt_b64_int_or_err!(modulus, &n, InvalidModulus);
+      jwt_b64_int_or_err!(public_exponent, &e, InvalidPublicExponent);
+      jwt_b64_int_or_err!(private_exponent, &d, InvalidPrivateExponent);
+      jwt_b64_int_or_err!(prime1, &p, InvalidFirstPrimeFactor);
+      jwt_b64_int_or_err!(prime2, &q, InvalidSecondPrimeFactor);
+      jwt_b64_int_or_err!(exponent1, &dp, InvalidFirstCRTExponent);
+      jwt_b64_int_or_err!(exponent2, &dq, InvalidSecondCRTExponent);
+      jwt_b64_int_or_err!(coefficient, &qi, InvalidCRTCoefficient);
+
+      let private_key = rsa::pkcs1::RsaPrivateKey {
+        modulus,
+        public_exponent,
+        private_exponent,
+        prime1,
+        prime2,
+        exponent1,
+        exponent2,
+        coefficient,
+        other_prime_infos: None,
+      };
+
+      let mut data = Vec::new();
+      private_key
+        .encode_to_vec(&mut data)
+        .map_err(|_| ImportKeyError::InvalidRSAPrivateKey)?;
+
+      let public_exponent =
+        private_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = private_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Private(data.into()),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    _ => unreachable!(),
+  }
+}
+
+fn import_key_rsassa(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::Spki(data) => {
+      // 2-3.
+      let pk_info = spki::SubjectPublicKeyInfoRef::try_from(&*data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let public_key = rsa::pkcs1::RsaPublicKey::from_der(
+        pk_info.subject_public_key.raw_bytes(),
+      )?;
+
+      let bytes_consumed = public_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(
+          pk_info.subject_public_key.raw_bytes().len() as u16,
+        )
+      {
+        return Err(ImportKeyError::PublicKeyTooLong);
+      }
+
+      let data = pk_info.subject_public_key.raw_bytes().to_vec().into();
+      let public_exponent =
+        public_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = public_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Public(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::Pkcs8(data) => {
+      // 2-3.
+      let pk_info = PrivateKeyInfo::from_der(&data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let private_key =
+        rsa::pkcs1::RsaPrivateKey::from_der(pk_info.private_key)?;
+
+      let bytes_consumed = private_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(pk_info.private_key.len() as u16)
+      {
+        return Err(ImportKeyError::PrivateKeyTooLong);
+      }
+
+      let data = pk_info.private_key.to_vec().into();
+      let public_exponent =
+        private_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = private_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Private(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::JwkPublicRsa { .. } | KeyData::JwkPrivateRsa { .. } => {
+      import_key_rsa_jwk(key_data)
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn import_key_rsapss(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::Spki(data) => {
+      // 2-3.
+      let pk_info = spki::SubjectPublicKeyInfoRef::try_from(&*data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let public_key = rsa::pkcs1::RsaPublicKey::from_der(
+        pk_info.subject_public_key.raw_bytes(),
+      )?;
+
+      let bytes_consumed = public_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(
+          pk_info.subject_public_key.raw_bytes().len() as u16,
+        )
+      {
+        return Err(ImportKeyError::PublicKeyTooLong);
+      }
+
+      let data = pk_info.subject_public_key.raw_bytes().to_vec().into();
+      let public_exponent =
+        public_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = public_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Public(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::Pkcs8(data) => {
+      // 2-3.
+      let pk_info = PrivateKeyInfo::from_der(&data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let private_key =
+        rsa::pkcs1::RsaPrivateKey::from_der(pk_info.private_key)?;
+
+      let bytes_consumed = private_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(pk_info.private_key.len() as u16)
+      {
+        return Err(ImportKeyError::PrivateKeyTooLong);
+      }
+
+      let data = pk_info.private_key.to_vec().into();
+      let public_exponent =
+        private_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = private_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Private(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::JwkPublicRsa { .. } | KeyData::JwkPrivateRsa { .. } => {
+      import_key_rsa_jwk(key_data)
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn import_key_rsaoaep(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::Spki(data) => {
+      // 2-3.
+      let pk_info = spki::SubjectPublicKeyInfoRef::try_from(&*data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let public_key = rsa::pkcs1::RsaPublicKey::from_der(
+        pk_info.subject_public_key.raw_bytes(),
+      )?;
+
+      let bytes_consumed = public_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(
+          pk_info.subject_public_key.raw_bytes().len() as u16,
+        )
+      {
+        return Err(ImportKeyError::PublicKeyTooLong);
+      }
+
+      let data = pk_info.subject_public_key.raw_bytes().to_vec().into();
+      let public_exponent =
+        public_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = public_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Public(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::Pkcs8(data) => {
+      // 2-3.
+      let pk_info = PrivateKeyInfo::from_der(&data)?;
+
+      // 4-5.
+      let alg = pk_info.algorithm.oid;
+
+      // 6-7. (skipped, only support rsaEncryption for interoperability)
+      if alg != RSA_ENCRYPTION_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 8-9.
+      let private_key =
+        rsa::pkcs1::RsaPrivateKey::from_der(pk_info.private_key)?;
+
+      let bytes_consumed = private_key.encoded_len()?;
+
+      if bytes_consumed
+        != rsa::pkcs1::der::Length::new(pk_info.private_key.len() as u16)
+      {
+        return Err(ImportKeyError::PrivateKeyTooLong);
+      }
+
+      let data = pk_info.private_key.to_vec().into();
+      let public_exponent =
+        private_key.public_exponent.as_bytes().to_vec().into();
+      let modulus_length = private_key.modulus.as_bytes().len() * 8;
+
+      Ok(ImportKeyResult::Rsa {
+        raw_data: RustRawKeyData::Private(data),
+        modulus_length,
+        public_exponent,
+      })
+    }
+    KeyData::JwkPublicRsa { .. } | KeyData::JwkPrivateRsa { .. } => {
+      import_key_rsa_jwk(key_data)
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn decode_b64url_to_field_bytes<C: elliptic_curve::Curve>(
+  b64: &str,
+) -> Result<elliptic_curve::FieldBytes<C>, ImportKeyError> {
+  jwt_b64_int_or_err!(val, b64, InvalidB64Coordinate);
+
+  let mut bytes = elliptic_curve::FieldBytes::<C>::default();
+  let original_bytes = val.as_bytes();
+  let mut new_bytes: Vec<u8> = vec![];
+  if original_bytes.len() < bytes.len() {
+    new_bytes = vec![0; bytes.len() - original_bytes.len()];
+  }
+  new_bytes.extend_from_slice(original_bytes);
+
+  let val = new_bytes.as_slice();
+
+  if val.len() != bytes.len() {
+    return Err(ImportKeyError::InvalidB64Coordinate);
+  }
+  bytes.copy_from_slice(val);
+
+  Ok(bytes)
+}
+
+fn import_key_ec_jwk_to_point(
+  x: String,
+  y: String,
+  named_curve: EcNamedCurve,
+) -> Result<Vec<u8>, ImportKeyError> {
+  let point_bytes = match named_curve {
+    EcNamedCurve::P256 => {
+      let x = decode_b64url_to_field_bytes::<p256::NistP256>(&x)?;
+      let y = decode_b64url_to_field_bytes::<p256::NistP256>(&y)?;
+
+      p256::EncodedPoint::from_affine_coordinates(&x, &y, false).to_bytes()
+    }
+    EcNamedCurve::P384 => {
+      let x = decode_b64url_to_field_bytes::<p384::NistP384>(&x)?;
+      let y = decode_b64url_to_field_bytes::<p384::NistP384>(&y)?;
+
+      p384::EncodedPoint::from_affine_coordinates(&x, &y, false).to_bytes()
+    }
+    EcNamedCurve::P521 => {
+      let x = decode_b64url_to_field_bytes::<p521::NistP521>(&x)?;
+      let y = decode_b64url_to_field_bytes::<p521::NistP521>(&y)?;
+
+      p521::EncodedPoint::from_affine_coordinates(&x, &y, false).to_bytes()
+    }
+  };
+
+  Ok(point_bytes.to_vec())
+}
+
+fn import_key_ec_jwk(
+  key_data: KeyData,
+  named_curve: EcNamedCurve,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::JwkPublicEc { x, y } => {
+      let point_bytes = import_key_ec_jwk_to_point(x, y, named_curve)?;
+
+      Ok(ImportKeyResult::Ec {
+        raw_data: RustRawKeyData::Public(point_bytes.into()),
+      })
+    }
+    KeyData::JwkPrivateEc { d, .. } => {
+      let pkcs8_der = match named_curve {
+        EcNamedCurve::P256 => {
+          let d = decode_b64url_to_field_bytes::<p256::NistP256>(&d)?;
+          let pk = p256::SecretKey::from_bytes(&d)?;
+
+          pk.to_pkcs8_der()
+            .map_err(|_| ImportKeyError::InvalidJWKPrivateKey)?
+        }
+        EcNamedCurve::P384 => {
+          let d = decode_b64url_to_field_bytes::<p384::NistP384>(&d)?;
+          let pk = p384::SecretKey::from_bytes(&d)?;
+
+          pk.to_pkcs8_der()
+            .map_err(|_| ImportKeyError::InvalidJWKPrivateKey)?
+        }
+        EcNamedCurve::P521 => {
+          let d = decode_b64url_to_field_bytes::<p521::NistP521>(&d)?;
+          let pk = p521::SecretKey::from_bytes(&d)?;
+
+          pk.to_pkcs8_der()
+            .map_err(|_| ImportKeyError::InvalidJWKPrivateKey)?
+        }
+      };
+
+      Ok(ImportKeyResult::Ec {
+        raw_data: RustRawKeyData::Private(pkcs8_der.as_bytes().to_vec().into()),
+      })
+    }
+    _ => unreachable!(),
+  }
+}
+
+pub struct ECParametersSpki {
+  pub named_curve_alg: spki::der::asn1::ObjectIdentifier,
+}
+
+impl<'a> TryFrom<spki::der::asn1::AnyRef<'a>> for ECParametersSpki {
+  type Error = spki::der::Error;
+
+  fn try_from(
+    any: spki::der::asn1::AnyRef<'a>,
+  ) -> spki::der::Result<ECParametersSpki> {
+    let x = any.try_into()?;
+
+    Ok(Self { named_curve_alg: x })
+  }
+}
+
+fn import_key_ec(
+  key_data: KeyData,
+  named_curve: EcNamedCurve,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  match key_data {
+    KeyData::Raw(data) => {
+      // The point is parsed and validated, ultimately the original data is
+      // returned though.
+      match named_curve {
+        EcNamedCurve::P256 => {
+          // 1-2.
+          let point = p256::EncodedPoint::from_bytes(&data)
+            .map_err(|_| ImportKeyError::InvalidP256ECPoint)?;
+          // 3.
+          if point.is_identity() {
+            return Err(ImportKeyError::InvalidP256ECPoint);
+          }
+        }
+        EcNamedCurve::P384 => {
+          // 1-2.
+          let point = p384::EncodedPoint::from_bytes(&data)
+            .map_err(|_| ImportKeyError::InvalidP384ECPoint)?;
+          // 3.
+          if point.is_identity() {
+            return Err(ImportKeyError::InvalidP384ECPoint);
+          }
+        }
+        EcNamedCurve::P521 => {
+          // 1-2.
+          let point = p521::EncodedPoint::from_bytes(&data)
+            .map_err(|_| ImportKeyError::InvalidP521ECPoint)?;
+          // 3.
+          if point.is_identity() {
+            return Err(ImportKeyError::InvalidP521ECPoint);
+          }
+        }
+      };
+      Ok(ImportKeyResult::Ec {
+        raw_data: RustRawKeyData::Public(data.to_vec().into()),
+      })
+    }
+    KeyData::Pkcs8(data) => {
+      let pk = PrivateKeyInfo::from_der(data.as_ref())
+        .map_err(|_| ImportKeyError::ExpectedValidPkcs8Data)?;
+      let named_curve_alg = pk
+        .algorithm
+        .parameters
+        .ok_or(ImportKeyError::MalformedParameters)?
+        .try_into()
+        .map_err(|_| ImportKeyError::MalformedParameters)?;
+
+      let pk_named_curve = match named_curve_alg {
+        // id-secp256r1
+        ID_SECP256R1_OID => Some(EcNamedCurve::P256),
+        // id-secp384r1
+        ID_SECP384R1_OID => Some(EcNamedCurve::P384),
+        // id-secp521r1
+        ID_SECP521R1_OID => Some(EcNamedCurve::P521),
+        _ => None,
+      };
+
+      if pk_named_curve != Some(named_curve) {
+        return Err(ImportKeyError::CurveMismatch);
+      }
+
+      Ok(ImportKeyResult::Ec {
+        raw_data: RustRawKeyData::Private(data.to_vec().into()),
+      })
+    }
+    KeyData::Spki(data) => {
+      // 2-3.
+      let pk_info = spki::SubjectPublicKeyInfoRef::try_from(&*data)?;
+
+      // 4.
+      let alg = pk_info.algorithm.oid;
+      // id-ecPublicKey
+      if alg != elliptic_curve::ALGORITHM_OID {
+        return Err(ImportKeyError::UnsupportedAlgorithm);
+      }
+
+      // 5-7.
+      let params = ECParametersSpki::try_from(
+        pk_info
+          .algorithm
+          .parameters
+          .ok_or(ImportKeyError::MalformedParameters)?,
+      )
+      .map_err(|_| ImportKeyError::MalformedParameters)?;
+
+      // 8-9.
+      let named_curve_alg = params.named_curve_alg;
+      let pk_named_curve = match named_curve_alg {
+        // id-secp256r1
+        ID_SECP256R1_OID => Some(EcNamedCurve::P256),
+        // id-secp384r1
+        ID_SECP384R1_OID => Some(EcNamedCurve::P384),
+        // id-secp521r1
+        ID_SECP521R1_OID => Some(EcNamedCurve::P521),
+        _ => None,
+      };
+
+      // 10.
+      let encoded_key;
+
+      if let Some(pk_named_curve) = pk_named_curve {
+        let pk = pk_info.subject_public_key;
+
+        encoded_key = pk.raw_bytes().to_vec();
+
+        let bytes_consumed = match named_curve {
+          EcNamedCurve::P256 => {
+            let point = p256::EncodedPoint::from_bytes(&*encoded_key)
+              .map_err(|_| ImportKeyError::InvalidP256ECSPKIData)?;
+            if point.is_identity() {
+              return Err(ImportKeyError::InvalidP256ECPoint);
+            }
+
+            point.as_bytes().len()
+          }
+          EcNamedCurve::P384 => {
+            let point = p384::EncodedPoint::from_bytes(&*encoded_key)
+              .map_err(|_| ImportKeyError::InvalidP384ECSPKIData)?;
+
+            if point.is_identity() {
+              return Err(ImportKeyError::InvalidP384ECPoint);
+            }
+
+            point.as_bytes().len()
+          }
+          EcNamedCurve::P521 => {
+            let point = p521::EncodedPoint::from_bytes(&*encoded_key)
+              .map_err(|_| ImportKeyError::InvalidP521ECSPKIData)?;
+
+            if point.is_identity() {
+              return Err(ImportKeyError::InvalidP521ECPoint);
+            }
+
+            point.as_bytes().len()
+          }
+        };
+
+        if bytes_consumed != pk_info.subject_public_key.raw_bytes().len() {
+          return Err(ImportKeyError::PublicKeyTooLong);
+        }
+
+        // 11.
+        if named_curve != pk_named_curve {
+          return Err(ImportKeyError::CurveMismatch);
+        }
+      } else {
+        return Err(ImportKeyError::UnsupportedNamedCurve);
+      }
+
+      Ok(ImportKeyResult::Ec {
+        raw_data: RustRawKeyData::Public(encoded_key.into()),
+      })
+    }
+    KeyData::JwkPublicEc { .. } | KeyData::JwkPrivateEc { .. } => {
+      import_key_ec_jwk(key_data, named_curve)
+    }
+    _ => Err(SharedError::UnsupportedFormat.into()),
+  }
+}
+
+fn import_key_aes(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  Ok(match key_data {
+    KeyData::JwkSecret { k } => {
+      let data = BASE64_URL_SAFE_FORGIVING
+        .decode(k)
+        .map_err(|_| ImportKeyError::InvalidKeyData)?;
+      ImportKeyResult::Hmac {
+        raw_data: RustRawKeyData::Secret(data.into()),
+      }
+    }
+    _ => return Err(SharedError::UnsupportedFormat.into()),
+  })
+}
+
+fn import_key_hmac(
+  key_data: KeyData,
+) -> Result<ImportKeyResult, ImportKeyError> {
+  Ok(match key_data {
+    KeyData::JwkSecret { k } => {
+      let data = BASE64_URL_SAFE_FORGIVING
+        .decode(k)
+        .map_err(|_| ImportKeyError::InvalidKeyData)?;
+      ImportKeyResult::Hmac {
+        raw_data: RustRawKeyData::Secret(data.into()),
+      }
+    }
+    _ => return Err(SharedError::UnsupportedFormat.into()),
+  })
+}

--- a/vendor/deno_crypto/key.rs
+++ b/vendor/deno_crypto/key.rs
@@ -1,0 +1,140 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use ring::agreement::Algorithm as RingAlgorithm;
+use ring::digest;
+use ring::hkdf;
+use ring::hmac::Algorithm as HmacAlgorithm;
+use ring::signature::EcdsaSigningAlgorithm;
+use ring::signature::EcdsaVerificationAlgorithm;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Copy, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum KeyType {
+  Public,
+  Private,
+  Secret,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+pub enum CryptoHash {
+  #[serde(rename = "SHA-1")]
+  Sha1,
+  #[serde(rename = "SHA-256")]
+  Sha256,
+  #[serde(rename = "SHA-384")]
+  Sha384,
+  #[serde(rename = "SHA-512")]
+  Sha512,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone)]
+pub enum CryptoNamedCurve {
+  #[serde(rename = "P-256")]
+  P256,
+  #[serde(rename = "P-384")]
+  P384,
+}
+
+impl From<CryptoNamedCurve> for &RingAlgorithm {
+  fn from(curve: CryptoNamedCurve) -> &'static RingAlgorithm {
+    match curve {
+      CryptoNamedCurve::P256 => &ring::agreement::ECDH_P256,
+      CryptoNamedCurve::P384 => &ring::agreement::ECDH_P384,
+    }
+  }
+}
+
+impl From<CryptoNamedCurve> for &EcdsaSigningAlgorithm {
+  fn from(curve: CryptoNamedCurve) -> &'static EcdsaSigningAlgorithm {
+    match curve {
+      CryptoNamedCurve::P256 => {
+        &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING
+      }
+      CryptoNamedCurve::P384 => {
+        &ring::signature::ECDSA_P384_SHA384_FIXED_SIGNING
+      }
+    }
+  }
+}
+
+impl From<CryptoNamedCurve> for &EcdsaVerificationAlgorithm {
+  fn from(curve: CryptoNamedCurve) -> &'static EcdsaVerificationAlgorithm {
+    match curve {
+      CryptoNamedCurve::P256 => &ring::signature::ECDSA_P256_SHA256_FIXED,
+      CryptoNamedCurve::P384 => &ring::signature::ECDSA_P384_SHA384_FIXED,
+    }
+  }
+}
+
+impl From<CryptoHash> for HmacAlgorithm {
+  fn from(hash: CryptoHash) -> HmacAlgorithm {
+    match hash {
+      CryptoHash::Sha1 => ring::hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+      CryptoHash::Sha256 => ring::hmac::HMAC_SHA256,
+      CryptoHash::Sha384 => ring::hmac::HMAC_SHA384,
+      CryptoHash::Sha512 => ring::hmac::HMAC_SHA512,
+    }
+  }
+}
+
+impl From<CryptoHash> for &'static digest::Algorithm {
+  fn from(hash: CryptoHash) -> &'static digest::Algorithm {
+    match hash {
+      CryptoHash::Sha1 => &digest::SHA1_FOR_LEGACY_USE_ONLY,
+      CryptoHash::Sha256 => &digest::SHA256,
+      CryptoHash::Sha384 => &digest::SHA384,
+      CryptoHash::Sha512 => &digest::SHA512,
+    }
+  }
+}
+
+pub struct HkdfOutput<T>(pub T);
+
+impl hkdf::KeyType for HkdfOutput<usize> {
+  fn len(&self) -> usize {
+    self.0
+  }
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum KeyUsage {
+  Encrypt,
+  Decrypt,
+  Sign,
+  Verify,
+  DeriveKey,
+  DeriveBits,
+  WrapKey,
+  UnwrapKey,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub enum Algorithm {
+  #[serde(rename = "RSASSA-PKCS1-v1_5")]
+  RsassaPkcs1v15,
+  #[serde(rename = "RSA-PSS")]
+  RsaPss,
+  #[serde(rename = "RSA-OAEP")]
+  RsaOaep,
+  #[serde(rename = "ECDSA")]
+  Ecdsa,
+  #[serde(rename = "ECDH")]
+  Ecdh,
+  #[serde(rename = "AES-CTR")]
+  AesCtr,
+  #[serde(rename = "AES-CBC")]
+  AesCbc,
+  #[serde(rename = "AES-GCM")]
+  AesGcm,
+  #[serde(rename = "AES-KW")]
+  AesKw,
+  #[serde(rename = "HMAC")]
+  Hmac,
+  #[serde(rename = "PBKDF2")]
+  Pbkdf2,
+  #[serde(rename = "HKDF")]
+  Hkdf,
+}

--- a/vendor/deno_crypto/lib.deno_crypto.d.ts
+++ b/vendor/deno_crypto/lib.deno_crypto.d.ts
@@ -1,0 +1,401 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-var
+
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+
+/** @category Crypto */
+declare var crypto: Crypto;
+
+/** @category Crypto */
+interface Algorithm {
+  name: string;
+}
+
+/** @category Crypto */
+interface KeyAlgorithm {
+  name: string;
+}
+
+/** @category Crypto */
+type AlgorithmIdentifier = string | Algorithm;
+/** @category Crypto */
+type HashAlgorithmIdentifier = AlgorithmIdentifier;
+/** @category Crypto */
+type KeyType = "private" | "public" | "secret";
+/** @category Crypto */
+type KeyUsage =
+  | "decrypt"
+  | "deriveBits"
+  | "deriveKey"
+  | "encrypt"
+  | "sign"
+  | "unwrapKey"
+  | "verify"
+  | "wrapKey";
+/** @category Crypto */
+type KeyFormat = "jwk" | "pkcs8" | "raw" | "spki";
+/** @category Crypto */
+type NamedCurve = string;
+
+/** @category Crypto */
+interface RsaOtherPrimesInfo {
+  d?: string;
+  r?: string;
+  t?: string;
+}
+
+/** @category Crypto */
+interface JsonWebKey {
+  alg?: string;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  ext?: boolean;
+  k?: string;
+  // deno-lint-ignore camelcase
+  key_ops?: string[];
+  kty?: string;
+  n?: string;
+  oth?: RsaOtherPrimesInfo[];
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  y?: string;
+}
+
+/** @category Crypto */
+interface AesCbcParams extends Algorithm {
+  iv: BufferSource;
+}
+
+/** @category Crypto */
+interface AesGcmParams extends Algorithm {
+  iv: BufferSource;
+  additionalData?: BufferSource;
+  tagLength?: number;
+}
+
+/** @category Crypto */
+interface AesCtrParams extends Algorithm {
+  counter: BufferSource;
+  length: number;
+}
+
+/** @category Crypto */
+interface HmacKeyGenParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+/** @category Crypto */
+interface EcKeyGenParams extends Algorithm {
+  namedCurve: NamedCurve;
+}
+
+/** @category Crypto */
+interface EcKeyImportParams extends Algorithm {
+  namedCurve: NamedCurve;
+}
+
+/** @category Crypto */
+interface EcdsaParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+/** @category Crypto */
+interface RsaHashedImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+/** @category Crypto */
+interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+  hash: HashAlgorithmIdentifier;
+}
+
+/** @category Crypto */
+interface RsaKeyGenParams extends Algorithm {
+  modulusLength: number;
+  publicExponent: Uint8Array;
+}
+
+/** @category Crypto */
+interface RsaPssParams extends Algorithm {
+  saltLength: number;
+}
+
+/** @category Crypto */
+interface RsaOaepParams extends Algorithm {
+  label?: Uint8Array;
+}
+
+/** @category Crypto */
+interface HmacImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+/** @category Crypto */
+interface EcKeyAlgorithm extends KeyAlgorithm {
+  namedCurve: NamedCurve;
+}
+
+/** @category Crypto */
+interface HmacKeyAlgorithm extends KeyAlgorithm {
+  hash: KeyAlgorithm;
+  length: number;
+}
+
+/** @category Crypto */
+interface RsaHashedKeyAlgorithm extends RsaKeyAlgorithm {
+  hash: KeyAlgorithm;
+}
+
+/** @category Crypto */
+interface RsaKeyAlgorithm extends KeyAlgorithm {
+  modulusLength: number;
+  publicExponent: Uint8Array;
+}
+
+/** @category Crypto */
+interface HkdfParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  info: BufferSource;
+  salt: BufferSource;
+}
+
+/** @category Crypto */
+interface Pbkdf2Params extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  iterations: number;
+  salt: BufferSource;
+}
+
+/** @category Crypto */
+interface AesDerivedKeyParams extends Algorithm {
+  length: number;
+}
+
+/** @category Crypto */
+interface EcdhKeyDeriveParams extends Algorithm {
+  public: CryptoKey;
+}
+
+/** @category Crypto */
+interface AesKeyGenParams extends Algorithm {
+  length: number;
+}
+
+/** @category Crypto */
+interface AesKeyAlgorithm extends KeyAlgorithm {
+  length: number;
+}
+
+/** The CryptoKey dictionary of the Web Crypto API represents a cryptographic
+ * key.
+ *
+ * @category Crypto
+ */
+interface CryptoKey {
+  readonly algorithm: KeyAlgorithm;
+  readonly extractable: boolean;
+  readonly type: KeyType;
+  readonly usages: KeyUsage[];
+}
+
+/** @category Crypto */
+declare var CryptoKey: {
+  readonly prototype: CryptoKey;
+  new (): never;
+};
+
+/** The CryptoKeyPair dictionary of the Web Crypto API represents a key pair for
+ * an asymmetric cryptography algorithm, also known as a public-key algorithm.
+ *
+ * @category Crypto
+ */
+interface CryptoKeyPair {
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+}
+
+/** @category Crypto */
+declare var CryptoKeyPair: {
+  readonly prototype: CryptoKeyPair;
+  new (): never;
+};
+
+/** This Web Crypto API interface provides a number of low-level cryptographic
+ * functions. It is accessed via the Crypto.subtle properties available in a
+ * window context (via globalThis.crypto).
+ *
+ * @category Crypto
+ */
+interface SubtleCrypto {
+  generateKey(
+    algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKeyPair>;
+  generateKey(
+    algorithm: AesKeyGenParams | HmacKeyGenParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  generateKey(
+    algorithm: AlgorithmIdentifier,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKeyPair | CryptoKey>;
+  importKey(
+    format: "jwk",
+    keyData: JsonWebKey,
+    algorithm:
+      | AlgorithmIdentifier
+      | HmacImportParams
+      | RsaHashedImportParams
+      | EcKeyImportParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  importKey(
+    format: Exclude<KeyFormat, "jwk">,
+    keyData: BufferSource,
+    algorithm:
+      | AlgorithmIdentifier
+      | HmacImportParams
+      | RsaHashedImportParams
+      | EcKeyImportParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
+  exportKey(
+    format: Exclude<KeyFormat, "jwk">,
+    key: CryptoKey,
+  ): Promise<ArrayBuffer>;
+  sign(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+    key: CryptoKey,
+    data: BufferSource,
+  ): Promise<ArrayBuffer>;
+  verify(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+    key: CryptoKey,
+    signature: BufferSource,
+    data: BufferSource,
+  ): Promise<boolean>;
+  digest(
+    algorithm: AlgorithmIdentifier,
+    data: BufferSource,
+  ): Promise<ArrayBuffer>;
+  encrypt(
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCbcParams
+      | AesGcmParams
+      | AesCtrParams,
+    key: CryptoKey,
+    data: BufferSource,
+  ): Promise<ArrayBuffer>;
+  decrypt(
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCbcParams
+      | AesGcmParams
+      | AesCtrParams,
+    key: CryptoKey,
+    data: BufferSource,
+  ): Promise<ArrayBuffer>;
+  deriveBits(
+    algorithm:
+      | AlgorithmIdentifier
+      | HkdfParams
+      | Pbkdf2Params
+      | EcdhKeyDeriveParams,
+    baseKey: CryptoKey,
+    length: number,
+  ): Promise<ArrayBuffer>;
+  deriveKey(
+    algorithm:
+      | AlgorithmIdentifier
+      | HkdfParams
+      | Pbkdf2Params
+      | EcdhKeyDeriveParams,
+    baseKey: CryptoKey,
+    derivedKeyType:
+      | AlgorithmIdentifier
+      | AesDerivedKeyParams
+      | HmacImportParams
+      | HkdfParams
+      | Pbkdf2Params,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+  wrapKey(
+    format: KeyFormat,
+    key: CryptoKey,
+    wrappingKey: CryptoKey,
+    wrapAlgorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCbcParams
+      | AesCtrParams,
+  ): Promise<ArrayBuffer>;
+  unwrapKey(
+    format: KeyFormat,
+    wrappedKey: BufferSource,
+    unwrappingKey: CryptoKey,
+    unwrapAlgorithm:
+      | AlgorithmIdentifier
+      | RsaOaepParams
+      | AesCbcParams
+      | AesCtrParams,
+    unwrappedKeyAlgorithm:
+      | AlgorithmIdentifier
+      | HmacImportParams
+      | RsaHashedImportParams
+      | EcKeyImportParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[],
+  ): Promise<CryptoKey>;
+}
+
+/** @category Crypto */
+declare var SubtleCrypto: {
+  readonly prototype: SubtleCrypto;
+  new (): never;
+};
+
+/** @category Crypto */
+interface Crypto {
+  readonly subtle: SubtleCrypto;
+  getRandomValues<
+    T extends
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Uint8ClampedArray
+      | BigInt64Array
+      | BigUint64Array,
+  >(
+    array: T,
+  ): T;
+  randomUUID(): `${string}-${string}-${string}-${string}-${string}`;
+}
+
+/** @category Crypto */
+declare var Crypto: {
+  readonly prototype: Crypto;
+  new (): never;
+};

--- a/vendor/deno_crypto/lib.rs
+++ b/vendor/deno_crypto/lib.rs
@@ -1,0 +1,828 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use aes_kw::KekAes128;
+use aes_kw::KekAes192;
+use aes_kw::KekAes256;
+
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::Engine;
+use deno_core::error::not_supported;
+use deno_core::op2;
+use deno_core::ToJsBuffer;
+
+use deno_core::unsync::spawn_blocking;
+use deno_core::JsBuffer;
+use deno_core::OpState;
+use serde::Deserialize;
+
+use p256::elliptic_curve::sec1::FromEncodedPoint;
+use p256::pkcs8::DecodePrivateKey;
+use rand::rngs::OsRng;
+use rand::rngs::StdRng;
+use rand::thread_rng;
+use rand::Rng;
+use rand::SeedableRng;
+use ring::digest;
+use ring::hkdf;
+use ring::hmac::Algorithm as HmacAlgorithm;
+use ring::hmac::Key as HmacKey;
+use ring::pbkdf2;
+use ring::rand as RingRand;
+use ring::signature::EcdsaKeyPair;
+use ring::signature::EcdsaSigningAlgorithm;
+use ring::signature::EcdsaVerificationAlgorithm;
+use ring::signature::KeyPair;
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::pkcs1::DecodeRsaPublicKey;
+use rsa::signature::SignatureEncoding;
+use rsa::signature::Signer;
+use rsa::signature::Verifier;
+use rsa::traits::SignatureScheme;
+use rsa::Pss;
+use rsa::RsaPrivateKey;
+use rsa::RsaPublicKey;
+use sha1::Sha1;
+use sha2::Digest;
+use sha2::Sha256;
+use sha2::Sha384;
+use sha2::Sha512;
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+
+pub use rand; // Re-export rand
+
+mod decrypt;
+mod ed25519;
+mod encrypt;
+mod export_key;
+mod generate_key;
+mod import_key;
+mod key;
+mod shared;
+mod x25519;
+mod x448;
+
+pub use crate::decrypt::op_crypto_decrypt;
+pub use crate::decrypt::DecryptError;
+pub use crate::ed25519::Ed25519Error;
+pub use crate::encrypt::op_crypto_encrypt;
+pub use crate::encrypt::EncryptError;
+pub use crate::export_key::op_crypto_export_key;
+pub use crate::export_key::ExportKeyError;
+pub use crate::generate_key::op_crypto_generate_key;
+pub use crate::generate_key::GenerateKeyError;
+pub use crate::import_key::op_crypto_import_key;
+pub use crate::import_key::ImportKeyError;
+use crate::key::Algorithm;
+use crate::key::CryptoHash;
+use crate::key::CryptoNamedCurve;
+use crate::key::HkdfOutput;
+pub use crate::shared::SharedError;
+use crate::shared::V8RawKeyData;
+pub use crate::x25519::X25519Error;
+pub use crate::x448::X448Error;
+
+deno_core::extension!(deno_crypto,
+  deps = [ deno_webidl, deno_web ],
+  ops = [
+    op_crypto_get_random_values,
+    op_crypto_generate_key,
+    op_crypto_sign_key,
+    op_crypto_verify_key,
+    op_crypto_derive_bits,
+    op_crypto_import_key,
+    op_crypto_export_key,
+    op_crypto_encrypt,
+    op_crypto_decrypt,
+    op_crypto_subtle_digest,
+    op_crypto_random_uuid,
+    op_crypto_wrap_key,
+    op_crypto_unwrap_key,
+    op_crypto_base64url_decode,
+    op_crypto_base64url_encode,
+    x25519::op_crypto_generate_x25519_keypair,
+    x25519::op_crypto_derive_bits_x25519,
+    x25519::op_crypto_import_spki_x25519,
+    x25519::op_crypto_import_pkcs8_x25519,
+    x25519::op_crypto_export_spki_x25519,
+    x25519::op_crypto_export_pkcs8_x25519,
+    x448::op_crypto_generate_x448_keypair,
+    x448::op_crypto_derive_bits_x448,
+    x448::op_crypto_import_spki_x448,
+    x448::op_crypto_import_pkcs8_x448,
+    x448::op_crypto_export_spki_x448,
+    x448::op_crypto_export_pkcs8_x448,
+    ed25519::op_crypto_generate_ed25519_keypair,
+    ed25519::op_crypto_import_spki_ed25519,
+    ed25519::op_crypto_import_pkcs8_ed25519,
+    ed25519::op_crypto_sign_ed25519,
+    ed25519::op_crypto_verify_ed25519,
+    ed25519::op_crypto_export_spki_ed25519,
+    ed25519::op_crypto_export_pkcs8_ed25519,
+    ed25519::op_crypto_jwk_x_ed25519,
+  ],
+  esm = [ "00_crypto.js" ],
+  options = {
+    maybe_seed: Option<u64>,
+  },
+  state = |state, options| {
+    if let Some(seed) = options.maybe_seed {
+      state.put(StdRng::seed_from_u64(seed));
+    }
+  },
+);
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+  #[error(transparent)]
+  General(#[from] SharedError),
+  #[error(transparent)]
+  JoinError(#[from] tokio::task::JoinError),
+  #[error(transparent)]
+  Der(#[from] rsa::pkcs1::der::Error),
+  #[error("Missing argument hash")]
+  MissingArgumentHash,
+  #[error("Missing argument saltLength")]
+  MissingArgumentSaltLength,
+  #[error("unsupported algorithm")]
+  UnsupportedAlgorithm,
+  #[error(transparent)]
+  KeyRejected(#[from] ring::error::KeyRejected),
+  #[error(transparent)]
+  RSA(#[from] rsa::Error),
+  #[error(transparent)]
+  Pkcs1(#[from] rsa::pkcs1::Error),
+  #[error(transparent)]
+  Unspecified(#[from] ring::error::Unspecified),
+  #[error("Invalid key format")]
+  InvalidKeyFormat,
+  #[error(transparent)]
+  P256Ecdsa(#[from] p256::ecdsa::Error),
+  #[error("Unexpected error decoding private key")]
+  DecodePrivateKey,
+  #[error("Missing argument publicKey")]
+  MissingArgumentPublicKey,
+  #[error("Missing argument namedCurve")]
+  MissingArgumentNamedCurve,
+  #[error("Missing argument info")]
+  MissingArgumentInfo,
+  #[error("The length provided for HKDF is too large")]
+  HKDFLengthTooLarge,
+  #[error(transparent)]
+  Base64Decode(#[from] base64::DecodeError),
+  #[error("Data must be multiple of 8 bytes")]
+  DataInvalidSize,
+  #[error("Invalid key length")]
+  InvalidKeyLength,
+  #[error("encryption error")]
+  EncryptionError,
+  #[error("decryption error - integrity check failed")]
+  DecryptionError,
+  #[error("The ArrayBufferView's byte length ({0}) exceeds the number of bytes of entropy available via this API (65536)")]
+  ArrayBufferViewLengthExceeded(usize),
+  #[error(transparent)]
+  Other(deno_core::error::AnyError),
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_base64url_decode(
+  #[string] data: String,
+) -> Result<ToJsBuffer, Error> {
+  let data: Vec<u8> = BASE64_URL_SAFE_NO_PAD.decode(data)?;
+  Ok(data.into())
+}
+
+#[op2]
+#[string]
+pub fn op_crypto_base64url_encode(#[buffer] data: JsBuffer) -> String {
+  let data: String = BASE64_URL_SAFE_NO_PAD.encode(data);
+  data
+}
+
+#[op2(fast)]
+pub fn op_crypto_get_random_values(
+  state: &mut OpState,
+  #[buffer] out: &mut [u8],
+) -> Result<(), Error> {
+  if out.len() > 65536 {
+    return Err(Error::ArrayBufferViewLengthExceeded(out.len()));
+  }
+
+  let maybe_seeded_rng = state.try_borrow_mut::<StdRng>();
+  if let Some(seeded_rng) = maybe_seeded_rng {
+    seeded_rng.fill(out);
+  } else {
+    let mut rng = thread_rng();
+    rng.fill(out);
+  }
+
+  Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyFormat {
+  Raw,
+  Pkcs8,
+  Spki,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyType {
+  Secret,
+  Private,
+  Public,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct KeyData {
+  r#type: KeyType,
+  data: JsBuffer,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignArg {
+  key: KeyData,
+  algorithm: Algorithm,
+  salt_length: Option<u32>,
+  hash: Option<CryptoHash>,
+  named_curve: Option<CryptoNamedCurve>,
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_sign_key(
+  #[serde] args: SignArg,
+  #[buffer] zero_copy: JsBuffer,
+) -> Result<ToJsBuffer, Error> {
+  deno_core::unsync::spawn_blocking(move || {
+    let data = &*zero_copy;
+    let algorithm = args.algorithm;
+
+    let signature = match algorithm {
+      Algorithm::RsassaPkcs1v15 => {
+        use rsa::pkcs1v15::SigningKey;
+        let private_key = RsaPrivateKey::from_pkcs1_der(&args.key.data)?;
+        match args.hash.ok_or_else(|| Error::MissingArgumentHash)? {
+          CryptoHash::Sha1 => {
+            let signing_key = SigningKey::<Sha1>::new(private_key);
+            signing_key.sign(data)
+          }
+          CryptoHash::Sha256 => {
+            let signing_key = SigningKey::<Sha256>::new(private_key);
+            signing_key.sign(data)
+          }
+          CryptoHash::Sha384 => {
+            let signing_key = SigningKey::<Sha384>::new(private_key);
+            signing_key.sign(data)
+          }
+          CryptoHash::Sha512 => {
+            let signing_key = SigningKey::<Sha512>::new(private_key);
+            signing_key.sign(data)
+          }
+        }
+        .to_vec()
+      }
+      Algorithm::RsaPss => {
+        let private_key = RsaPrivateKey::from_pkcs1_der(&args.key.data)?;
+
+        let salt_len = args
+          .salt_length
+          .ok_or_else(|| Error::MissingArgumentSaltLength)?
+          as usize;
+
+        let mut rng = OsRng;
+        match args.hash.ok_or_else(|| Error::MissingArgumentHash)? {
+          CryptoHash::Sha1 => {
+            let signing_key = Pss::new_with_salt::<Sha1>(salt_len);
+            let hashed = Sha1::digest(data);
+            signing_key.sign(Some(&mut rng), &private_key, &hashed)?
+          }
+          CryptoHash::Sha256 => {
+            let signing_key = Pss::new_with_salt::<Sha256>(salt_len);
+            let hashed = Sha256::digest(data);
+            signing_key.sign(Some(&mut rng), &private_key, &hashed)?
+          }
+          CryptoHash::Sha384 => {
+            let signing_key = Pss::new_with_salt::<Sha384>(salt_len);
+            let hashed = Sha384::digest(data);
+            signing_key.sign(Some(&mut rng), &private_key, &hashed)?
+          }
+          CryptoHash::Sha512 => {
+            let signing_key = Pss::new_with_salt::<Sha512>(salt_len);
+            let hashed = Sha512::digest(data);
+            signing_key.sign(Some(&mut rng), &private_key, &hashed)?
+          }
+        }
+        .to_vec()
+      }
+      Algorithm::Ecdsa => {
+        let curve: &EcdsaSigningAlgorithm = args
+          .named_curve
+          .ok_or_else(|| Error::Other(not_supported()))?
+          .into();
+
+        let rng = RingRand::SystemRandom::new();
+        let key_pair = EcdsaKeyPair::from_pkcs8(curve, &args.key.data, &rng)?;
+        // We only support P256-SHA256 & P384-SHA384. These are recommended signature pairs.
+        // https://briansmith.org/rustdoc/ring/signature/index.html#statics
+        if let Some(hash) = args.hash {
+          match hash {
+            CryptoHash::Sha256 | CryptoHash::Sha384 => (),
+            _ => return Err(Error::UnsupportedAlgorithm),
+          }
+        };
+
+        let signature = key_pair.sign(&rng, data)?;
+
+        // Signature data as buffer.
+        signature.as_ref().to_vec()
+      }
+      Algorithm::Hmac => {
+        let hash: HmacAlgorithm = args
+          .hash
+          .ok_or_else(|| Error::Other(not_supported()))?
+          .into();
+
+        let key = HmacKey::new(hash, &args.key.data);
+
+        let signature = ring::hmac::sign(&key, data);
+        signature.as_ref().to_vec()
+      }
+      _ => return Err(Error::UnsupportedAlgorithm),
+    };
+
+    Ok(signature.into())
+  })
+  .await?
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyArg {
+  key: KeyData,
+  algorithm: Algorithm,
+  salt_length: Option<u32>,
+  hash: Option<CryptoHash>,
+  signature: JsBuffer,
+  named_curve: Option<CryptoNamedCurve>,
+}
+
+#[op2(async)]
+pub async fn op_crypto_verify_key(
+  #[serde] args: VerifyArg,
+  #[buffer] zero_copy: JsBuffer,
+) -> Result<bool, Error> {
+  deno_core::unsync::spawn_blocking(move || {
+    let data = &*zero_copy;
+    let algorithm = args.algorithm;
+
+    let verification = match algorithm {
+      Algorithm::RsassaPkcs1v15 => {
+        use rsa::pkcs1v15::Signature;
+        use rsa::pkcs1v15::VerifyingKey;
+        let public_key = read_rsa_public_key(args.key)?;
+        let signature: Signature = args.signature.as_ref().try_into()?;
+        match args.hash.ok_or_else(|| Error::MissingArgumentHash)? {
+          CryptoHash::Sha1 => {
+            let verifying_key = VerifyingKey::<Sha1>::new(public_key);
+            verifying_key.verify(data, &signature).is_ok()
+          }
+          CryptoHash::Sha256 => {
+            let verifying_key = VerifyingKey::<Sha256>::new(public_key);
+            verifying_key.verify(data, &signature).is_ok()
+          }
+          CryptoHash::Sha384 => {
+            let verifying_key = VerifyingKey::<Sha384>::new(public_key);
+            verifying_key.verify(data, &signature).is_ok()
+          }
+          CryptoHash::Sha512 => {
+            let verifying_key = VerifyingKey::<Sha512>::new(public_key);
+            verifying_key.verify(data, &signature).is_ok()
+          }
+        }
+      }
+      Algorithm::RsaPss => {
+        let public_key = read_rsa_public_key(args.key)?;
+        let signature = args.signature.as_ref();
+
+        let salt_len = args
+          .salt_length
+          .ok_or_else(|| Error::MissingArgumentSaltLength)?
+          as usize;
+
+        match args.hash.ok_or_else(|| Error::MissingArgumentHash)? {
+          CryptoHash::Sha1 => {
+            let pss = Pss::new_with_salt::<Sha1>(salt_len);
+            let hashed = Sha1::digest(data);
+            pss.verify(&public_key, &hashed, signature).is_ok()
+          }
+          CryptoHash::Sha256 => {
+            let pss = Pss::new_with_salt::<Sha256>(salt_len);
+            let hashed = Sha256::digest(data);
+            pss.verify(&public_key, &hashed, signature).is_ok()
+          }
+          CryptoHash::Sha384 => {
+            let pss = Pss::new_with_salt::<Sha384>(salt_len);
+            let hashed = Sha384::digest(data);
+            pss.verify(&public_key, &hashed, signature).is_ok()
+          }
+          CryptoHash::Sha512 => {
+            let pss = Pss::new_with_salt::<Sha512>(salt_len);
+            let hashed = Sha512::digest(data);
+            pss.verify(&public_key, &hashed, signature).is_ok()
+          }
+        }
+      }
+      Algorithm::Hmac => {
+        let hash: HmacAlgorithm = args
+          .hash
+          .ok_or_else(|| Error::Other(not_supported()))?
+          .into();
+        let key = HmacKey::new(hash, &args.key.data);
+        ring::hmac::verify(&key, data, &args.signature).is_ok()
+      }
+      Algorithm::Ecdsa => {
+        let signing_alg: &EcdsaSigningAlgorithm = args
+          .named_curve
+          .ok_or_else(|| Error::Other(not_supported()))?
+          .into();
+        let verify_alg: &EcdsaVerificationAlgorithm = args
+          .named_curve
+          .ok_or_else(|| Error::Other(not_supported()))?
+          .into();
+
+        let private_key;
+
+        let public_key_bytes = match args.key.r#type {
+          KeyType::Private => {
+            let rng = RingRand::SystemRandom::new();
+            private_key =
+              EcdsaKeyPair::from_pkcs8(signing_alg, &args.key.data, &rng)?;
+
+            private_key.public_key().as_ref()
+          }
+          KeyType::Public => &*args.key.data,
+          _ => return Err(Error::InvalidKeyFormat),
+        };
+
+        let public_key =
+          ring::signature::UnparsedPublicKey::new(verify_alg, public_key_bytes);
+
+        public_key.verify(data, &args.signature).is_ok()
+      }
+      _ => return Err(Error::UnsupportedAlgorithm),
+    };
+
+    Ok(verification)
+  })
+  .await?
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeriveKeyArg {
+  key: KeyData,
+  algorithm: Algorithm,
+  hash: Option<CryptoHash>,
+  length: usize,
+  iterations: Option<u32>,
+  // ECDH
+  public_key: Option<KeyData>,
+  named_curve: Option<CryptoNamedCurve>,
+  // HKDF
+  info: Option<JsBuffer>,
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_derive_bits(
+  #[serde] args: DeriveKeyArg,
+  #[buffer] zero_copy: Option<JsBuffer>,
+) -> Result<ToJsBuffer, Error> {
+  deno_core::unsync::spawn_blocking(move || {
+    let algorithm = args.algorithm;
+    match algorithm {
+      Algorithm::Pbkdf2 => {
+        let zero_copy =
+          zero_copy.ok_or_else(|| Error::Other(not_supported()))?;
+        let salt = &*zero_copy;
+        // The caller must validate these cases.
+        assert!(args.length > 0);
+        assert!(args.length % 8 == 0);
+
+        let algorithm =
+          match args.hash.ok_or_else(|| Error::Other(not_supported()))? {
+            CryptoHash::Sha1 => pbkdf2::PBKDF2_HMAC_SHA1,
+            CryptoHash::Sha256 => pbkdf2::PBKDF2_HMAC_SHA256,
+            CryptoHash::Sha384 => pbkdf2::PBKDF2_HMAC_SHA384,
+            CryptoHash::Sha512 => pbkdf2::PBKDF2_HMAC_SHA512,
+          };
+
+        // This will never panic. We have already checked length earlier.
+        let iterations = NonZeroU32::new(
+          args
+            .iterations
+            .ok_or_else(|| Error::Other(not_supported()))?,
+        )
+        .unwrap();
+        let secret = args.key.data;
+        let mut out = vec![0; args.length / 8];
+        pbkdf2::derive(algorithm, iterations, salt, &secret, &mut out);
+        Ok(out.into())
+      }
+      Algorithm::Ecdh => {
+        let named_curve = args
+          .named_curve
+          .ok_or_else(|| Error::MissingArgumentNamedCurve)?;
+
+        let public_key = args
+          .public_key
+          .ok_or_else(|| Error::MissingArgumentPublicKey)?;
+
+        match named_curve {
+          CryptoNamedCurve::P256 => {
+            let secret_key = p256::SecretKey::from_pkcs8_der(&args.key.data)
+              .map_err(|_| Error::DecodePrivateKey)?;
+
+            let public_key = match public_key.r#type {
+              KeyType::Private => {
+                p256::SecretKey::from_pkcs8_der(&public_key.data)
+                  .map_err(|_| Error::DecodePrivateKey)?
+                  .public_key()
+              }
+              KeyType::Public => {
+                let point = p256::EncodedPoint::from_bytes(public_key.data)
+                  .map_err(|_| Error::DecodePrivateKey)?;
+
+                let pk = p256::PublicKey::from_encoded_point(&point);
+                // pk is a constant time Option.
+                if pk.is_some().into() {
+                  pk.unwrap()
+                } else {
+                  return Err(Error::DecodePrivateKey);
+                }
+              }
+              _ => unreachable!(),
+            };
+
+            let shared_secret = p256::elliptic_curve::ecdh::diffie_hellman(
+              secret_key.to_nonzero_scalar(),
+              public_key.as_affine(),
+            );
+
+            // raw serialized x-coordinate of the computed point
+            Ok(shared_secret.raw_secret_bytes().to_vec().into())
+          }
+          CryptoNamedCurve::P384 => {
+            let secret_key = p384::SecretKey::from_pkcs8_der(&args.key.data)
+              .map_err(|_| Error::DecodePrivateKey)?;
+
+            let public_key = match public_key.r#type {
+              KeyType::Private => {
+                p384::SecretKey::from_pkcs8_der(&public_key.data)
+                  .map_err(|_| Error::DecodePrivateKey)?
+                  .public_key()
+              }
+              KeyType::Public => {
+                let point = p384::EncodedPoint::from_bytes(public_key.data)
+                  .map_err(|_| Error::DecodePrivateKey)?;
+
+                let pk = p384::PublicKey::from_encoded_point(&point);
+                // pk is a constant time Option.
+                if pk.is_some().into() {
+                  pk.unwrap()
+                } else {
+                  return Err(Error::DecodePrivateKey);
+                }
+              }
+              _ => unreachable!(),
+            };
+
+            let shared_secret = p384::elliptic_curve::ecdh::diffie_hellman(
+              secret_key.to_nonzero_scalar(),
+              public_key.as_affine(),
+            );
+
+            // raw serialized x-coordinate of the computed point
+            Ok(shared_secret.raw_secret_bytes().to_vec().into())
+          }
+        }
+      }
+      Algorithm::Hkdf => {
+        let zero_copy =
+          zero_copy.ok_or_else(|| Error::Other(not_supported()))?;
+        let salt = &*zero_copy;
+        let algorithm =
+          match args.hash.ok_or_else(|| Error::Other(not_supported()))? {
+            CryptoHash::Sha1 => hkdf::HKDF_SHA1_FOR_LEGACY_USE_ONLY,
+            CryptoHash::Sha256 => hkdf::HKDF_SHA256,
+            CryptoHash::Sha384 => hkdf::HKDF_SHA384,
+            CryptoHash::Sha512 => hkdf::HKDF_SHA512,
+          };
+
+        let info = args.info.ok_or_else(|| Error::MissingArgumentInfo)?;
+        // IKM
+        let secret = args.key.data;
+        // L
+        let length = args.length / 8;
+
+        let salt = hkdf::Salt::new(algorithm, salt);
+        let prk = salt.extract(&secret);
+        let info = &[&*info];
+        let okm = prk
+          .expand(info, HkdfOutput(length))
+          .map_err(|_e| Error::HKDFLengthTooLarge)?;
+        let mut r = vec![0u8; length];
+        okm.fill(&mut r)?;
+        Ok(r.into())
+      }
+      _ => Err(Error::UnsupportedAlgorithm),
+    }
+  })
+  .await?
+}
+
+fn read_rsa_public_key(key_data: KeyData) -> Result<RsaPublicKey, Error> {
+  let public_key = match key_data.r#type {
+    KeyType::Private => {
+      RsaPrivateKey::from_pkcs1_der(&key_data.data)?.to_public_key()
+    }
+    KeyType::Public => RsaPublicKey::from_pkcs1_der(&key_data.data)?,
+    KeyType::Secret => unreachable!("unexpected KeyType::Secret"),
+  };
+  Ok(public_key)
+}
+
+#[op2]
+#[string]
+pub fn op_crypto_random_uuid(state: &mut OpState) -> Result<String, Error> {
+  let maybe_seeded_rng = state.try_borrow_mut::<StdRng>();
+  let uuid = if let Some(seeded_rng) = maybe_seeded_rng {
+    let mut bytes = [0u8; 16];
+    seeded_rng.fill(&mut bytes);
+    fast_uuid_v4(&mut bytes)
+  } else {
+    let mut rng = thread_rng();
+    let mut bytes = [0u8; 16];
+    rng.fill(&mut bytes);
+    fast_uuid_v4(&mut bytes)
+  };
+
+  Ok(uuid)
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_crypto_subtle_digest(
+  #[serde] algorithm: CryptoHash,
+  #[buffer] data: JsBuffer,
+) -> Result<ToJsBuffer, Error> {
+  let output = spawn_blocking(move || {
+    digest::digest(algorithm.into(), &data)
+      .as_ref()
+      .to_vec()
+      .into()
+  })
+  .await?;
+
+  Ok(output)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapUnwrapKeyArg {
+  key: V8RawKeyData,
+  algorithm: Algorithm,
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_wrap_key(
+  #[serde] args: WrapUnwrapKeyArg,
+  #[buffer] data: JsBuffer,
+) -> Result<ToJsBuffer, Error> {
+  let algorithm = args.algorithm;
+
+  match algorithm {
+    Algorithm::AesKw => {
+      let key = args.key.as_secret_key()?;
+
+      if data.len() % 8 != 0 {
+        return Err(Error::DataInvalidSize);
+      }
+
+      let wrapped_key = match key.len() {
+        16 => KekAes128::new(key.into()).wrap_vec(&data),
+        24 => KekAes192::new(key.into()).wrap_vec(&data),
+        32 => KekAes256::new(key.into()).wrap_vec(&data),
+        _ => return Err(Error::InvalidKeyLength),
+      }
+      .map_err(|_| Error::EncryptionError)?;
+
+      Ok(wrapped_key.into())
+    }
+    _ => Err(Error::UnsupportedAlgorithm),
+  }
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_unwrap_key(
+  #[serde] args: WrapUnwrapKeyArg,
+  #[buffer] data: JsBuffer,
+) -> Result<ToJsBuffer, Error> {
+  let algorithm = args.algorithm;
+  match algorithm {
+    Algorithm::AesKw => {
+      let key = args.key.as_secret_key()?;
+
+      if data.len() % 8 != 0 {
+        return Err(Error::DataInvalidSize);
+      }
+
+      let unwrapped_key = match key.len() {
+        16 => KekAes128::new(key.into()).unwrap_vec(&data),
+        24 => KekAes192::new(key.into()).unwrap_vec(&data),
+        32 => KekAes256::new(key.into()).unwrap_vec(&data),
+        _ => return Err(Error::InvalidKeyLength),
+      }
+      .map_err(|_| Error::DecryptionError)?;
+
+      Ok(unwrapped_key.into())
+    }
+    _ => Err(Error::UnsupportedAlgorithm),
+  }
+}
+
+pub fn get_declaration() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_crypto.d.ts")
+}
+
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+fn fast_uuid_v4(bytes: &mut [u8; 16]) -> String {
+  // Set UUID version to 4 and variant to 1.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  let buf = [
+    HEX_CHARS[(bytes[0] >> 4) as usize],
+    HEX_CHARS[(bytes[0] & 0x0f) as usize],
+    HEX_CHARS[(bytes[1] >> 4) as usize],
+    HEX_CHARS[(bytes[1] & 0x0f) as usize],
+    HEX_CHARS[(bytes[2] >> 4) as usize],
+    HEX_CHARS[(bytes[2] & 0x0f) as usize],
+    HEX_CHARS[(bytes[3] >> 4) as usize],
+    HEX_CHARS[(bytes[3] & 0x0f) as usize],
+    b'-',
+    HEX_CHARS[(bytes[4] >> 4) as usize],
+    HEX_CHARS[(bytes[4] & 0x0f) as usize],
+    HEX_CHARS[(bytes[5] >> 4) as usize],
+    HEX_CHARS[(bytes[5] & 0x0f) as usize],
+    b'-',
+    HEX_CHARS[(bytes[6] >> 4) as usize],
+    HEX_CHARS[(bytes[6] & 0x0f) as usize],
+    HEX_CHARS[(bytes[7] >> 4) as usize],
+    HEX_CHARS[(bytes[7] & 0x0f) as usize],
+    b'-',
+    HEX_CHARS[(bytes[8] >> 4) as usize],
+    HEX_CHARS[(bytes[8] & 0x0f) as usize],
+    HEX_CHARS[(bytes[9] >> 4) as usize],
+    HEX_CHARS[(bytes[9] & 0x0f) as usize],
+    b'-',
+    HEX_CHARS[(bytes[10] >> 4) as usize],
+    HEX_CHARS[(bytes[10] & 0x0f) as usize],
+    HEX_CHARS[(bytes[11] >> 4) as usize],
+    HEX_CHARS[(bytes[11] & 0x0f) as usize],
+    HEX_CHARS[(bytes[12] >> 4) as usize],
+    HEX_CHARS[(bytes[12] & 0x0f) as usize],
+    HEX_CHARS[(bytes[13] >> 4) as usize],
+    HEX_CHARS[(bytes[13] & 0x0f) as usize],
+    HEX_CHARS[(bytes[14] >> 4) as usize],
+    HEX_CHARS[(bytes[14] & 0x0f) as usize],
+    HEX_CHARS[(bytes[15] >> 4) as usize],
+    HEX_CHARS[(bytes[15] & 0x0f) as usize],
+  ];
+
+  // Safety: the buffer is all valid UTF-8.
+  unsafe { String::from_utf8_unchecked(buf.to_vec()) }
+}
+
+#[test]
+fn test_fast_uuid_v4_correctness() {
+  let mut rng = thread_rng();
+  let mut bytes = [0u8; 16];
+  rng.fill(&mut bytes);
+  let uuid = fast_uuid_v4(&mut bytes.clone());
+  let uuid_lib = uuid::Builder::from_bytes(bytes)
+    .set_variant(uuid::Variant::RFC4122)
+    .set_version(uuid::Version::Random)
+    .as_uuid()
+    .to_string();
+  assert_eq!(uuid, uuid_lib);
+}

--- a/vendor/deno_crypto/shared.rs
+++ b/vendor/deno_crypto/shared.rs
@@ -1,0 +1,179 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use std::borrow::Cow;
+
+use deno_core::JsBuffer;
+use deno_core::ToJsBuffer;
+use elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::DecodePrivateKey;
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::pkcs1::EncodeRsaPublicKey;
+use rsa::RsaPrivateKey;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const RSA_ENCRYPTION_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+
+pub const ID_SECP256R1_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+pub const ID_SECP384R1_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.3.132.0.34");
+pub const ID_SECP521R1_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.3.132.0.35");
+
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+pub enum ShaHash {
+  #[serde(rename = "SHA-1")]
+  Sha1,
+  #[serde(rename = "SHA-256")]
+  Sha256,
+  #[serde(rename = "SHA-384")]
+  Sha384,
+  #[serde(rename = "SHA-512")]
+  Sha512,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+pub enum EcNamedCurve {
+  #[serde(rename = "P-256")]
+  P256,
+  #[serde(rename = "P-384")]
+  P384,
+  #[serde(rename = "P-521")]
+  P521,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type", content = "data")]
+pub enum V8RawKeyData {
+  Secret(JsBuffer),
+  Private(JsBuffer),
+  Public(JsBuffer),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase", tag = "type", content = "data")]
+pub enum RustRawKeyData {
+  Secret(ToJsBuffer),
+  Private(ToJsBuffer),
+  Public(ToJsBuffer),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SharedError {
+  #[error("expected valid private key")]
+  ExpectedValidPrivateKey,
+  #[error("expected valid public key")]
+  ExpectedValidPublicKey,
+  #[error("expected valid private EC key")]
+  ExpectedValidPrivateECKey,
+  #[error("expected valid public EC key")]
+  ExpectedValidPublicECKey,
+  #[error("expected private key")]
+  ExpectedPrivateKey,
+  #[error("expected public key")]
+  ExpectedPublicKey,
+  #[error("expected secret key")]
+  ExpectedSecretKey,
+  #[error("failed to decode private key")]
+  FailedDecodePrivateKey,
+  #[error("failed to decode public key")]
+  FailedDecodePublicKey,
+  #[error("unsupported format")]
+  UnsupportedFormat,
+}
+
+impl V8RawKeyData {
+  pub fn as_rsa_public_key(&self) -> Result<Cow<'_, [u8]>, SharedError> {
+    match self {
+      V8RawKeyData::Public(data) => Ok(Cow::Borrowed(data)),
+      V8RawKeyData::Private(data) => {
+        let private_key = RsaPrivateKey::from_pkcs1_der(data)
+          .map_err(|_| SharedError::ExpectedValidPrivateKey)?;
+
+        let public_key_doc = private_key
+          .to_public_key()
+          .to_pkcs1_der()
+          .map_err(|_| SharedError::ExpectedValidPublicKey)?;
+
+        Ok(Cow::Owned(public_key_doc.as_bytes().into()))
+      }
+      _ => Err(SharedError::ExpectedPublicKey),
+    }
+  }
+
+  pub fn as_rsa_private_key(&self) -> Result<&[u8], SharedError> {
+    match self {
+      V8RawKeyData::Private(data) => Ok(data),
+      _ => Err(SharedError::ExpectedPrivateKey),
+    }
+  }
+
+  pub fn as_secret_key(&self) -> Result<&[u8], SharedError> {
+    match self {
+      V8RawKeyData::Secret(data) => Ok(data),
+      _ => Err(SharedError::ExpectedSecretKey),
+    }
+  }
+
+  pub fn as_ec_public_key_p256(
+    &self,
+  ) -> Result<p256::EncodedPoint, SharedError> {
+    match self {
+      V8RawKeyData::Public(data) => p256::PublicKey::from_sec1_bytes(data)
+        .map(|p| p.to_encoded_point(false))
+        .map_err(|_| SharedError::ExpectedValidPublicECKey),
+      V8RawKeyData::Private(data) => {
+        let signing_key = p256::SecretKey::from_pkcs8_der(data)
+          .map_err(|_| SharedError::ExpectedValidPrivateECKey)?;
+        Ok(signing_key.public_key().to_encoded_point(false))
+      }
+      // Should never reach here.
+      V8RawKeyData::Secret(_) => unreachable!(),
+    }
+  }
+
+  pub fn as_ec_public_key_p384(
+    &self,
+  ) -> Result<p384::EncodedPoint, SharedError> {
+    match self {
+      V8RawKeyData::Public(data) => p384::PublicKey::from_sec1_bytes(data)
+        .map(|p| p.to_encoded_point(false))
+        .map_err(|_| SharedError::ExpectedValidPublicECKey),
+      V8RawKeyData::Private(data) => {
+        let signing_key = p384::SecretKey::from_pkcs8_der(data)
+          .map_err(|_| SharedError::ExpectedValidPrivateECKey)?;
+        Ok(signing_key.public_key().to_encoded_point(false))
+      }
+      // Should never reach here.
+      V8RawKeyData::Secret(_) => unreachable!(),
+    }
+  }
+
+  pub fn as_ec_public_key_p521(
+    &self,
+  ) -> Result<p521::EncodedPoint, SharedError> {
+    match self {
+      V8RawKeyData::Public(data) => {
+        // public_key is a serialized EncodedPoint
+        p521::EncodedPoint::from_bytes(data)
+          .map_err(|_| SharedError::ExpectedValidPublicECKey)
+      }
+      V8RawKeyData::Private(data) => {
+        let signing_key = p521::SecretKey::from_pkcs8_der(data)
+          .map_err(|_| SharedError::ExpectedValidPrivateECKey)?;
+        Ok(signing_key.public_key().to_encoded_point(false))
+      }
+      // Should never reach here.
+      V8RawKeyData::Secret(_) => unreachable!(),
+    }
+  }
+
+  pub fn as_ec_private_key(&self) -> Result<&[u8], SharedError> {
+    match self {
+      V8RawKeyData::Private(data) => Ok(data),
+      _ => Err(SharedError::ExpectedPrivateKey),
+    }
+  }
+}

--- a/vendor/deno_crypto/x25519.rs
+++ b/vendor/deno_crypto/x25519.rs
@@ -1,0 +1,162 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use curve25519_dalek::montgomery::MontgomeryPoint;
+use deno_core::op2;
+use deno_core::ToJsBuffer;
+use elliptic_curve::pkcs8::PrivateKeyInfo;
+use elliptic_curve::subtle::ConstantTimeEq;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use spki::der::asn1::BitString;
+use spki::der::Decode;
+use spki::der::Encode;
+
+#[derive(Debug, thiserror::Error)]
+pub enum X25519Error {
+  #[error("Failed to export key")]
+  FailedExport,
+  #[error("Invalid key data")]
+  InvalidKeyLength,
+  #[error(transparent)]
+  Der(#[from] spki::der::Error),
+}
+
+#[op2(fast)]
+pub fn op_crypto_generate_x25519_keypair(
+  #[buffer] pkey: &mut [u8],
+  #[buffer] pubkey: &mut [u8],
+) {
+  // u-coordinate of the base point.
+  const X25519_BASEPOINT_BYTES: [u8; 32] = [
+    9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+  ];
+  let mut rng = OsRng;
+  rng.fill_bytes(pkey);
+  // https://www.rfc-editor.org/rfc/rfc7748#section-6.1
+  // pubkey = x25519(a, 9) which is constant-time Montgomery ladder.
+  //   https://eprint.iacr.org/2014/140.pdf page 4
+  //   https://eprint.iacr.org/2017/212.pdf algorithm 8
+  // pubkey is in LE order.
+  let pkey: [u8; 32] = pkey.try_into().expect("Expected byteLength 32");
+  pubkey.copy_from_slice(&x25519_dalek::x25519(pkey, X25519_BASEPOINT_BYTES));
+}
+
+const MONTGOMERY_IDENTITY: MontgomeryPoint = MontgomeryPoint([0; 32]);
+
+#[op2(fast)]
+pub fn op_crypto_derive_bits_x25519(
+  #[buffer] k: &[u8],
+  #[buffer] u: &[u8],
+  #[buffer] secret: &mut [u8],
+) -> Result<bool, X25519Error> {
+  let k: [u8; 32] = k.try_into().map_err(|_| X25519Error::InvalidKeyLength)?;
+  let u: [u8; 32] = u.try_into().map_err(|_| X25519Error::InvalidKeyLength)?;
+  let sh_sec = x25519_dalek::x25519(k, u);
+  let point = MontgomeryPoint(sh_sec);
+  if point.ct_eq(&MONTGOMERY_IDENTITY).unwrap_u8() == 1 {
+    return Ok(true);
+  }
+  secret.copy_from_slice(&sh_sec);
+  Ok(false)
+}
+
+// id-X25519 OBJECT IDENTIFIER ::= { 1 3 101 110 }
+pub const X25519_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.3.101.110");
+
+#[op2(fast)]
+pub fn op_crypto_import_spki_x25519(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  let pk_info = match spki::SubjectPublicKeyInfoRef::try_from(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != X25519_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  out.copy_from_slice(pk_info.subject_public_key.raw_bytes());
+  true
+}
+
+#[op2(fast)]
+pub fn op_crypto_import_pkcs8_x25519(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  // This should probably use OneAsymmetricKey instead
+  let pk_info = match PrivateKeyInfo::from_der(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != X25519_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  // 6.
+  // CurvePrivateKey ::= OCTET STRING
+  if pk_info.private_key.len() != 34 {
+    return false;
+  }
+  out.copy_from_slice(&pk_info.private_key[2..]);
+  true
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_spki_x25519(
+  #[buffer] pubkey: &[u8],
+) -> Result<ToJsBuffer, X25519Error> {
+  let key_info = spki::SubjectPublicKeyInfo {
+    algorithm: spki::AlgorithmIdentifierRef {
+      // id-X25519
+      oid: X25519_OID,
+      parameters: None,
+    },
+    subject_public_key: BitString::from_bytes(pubkey)?,
+  };
+  Ok(
+    key_info
+      .to_der()
+      .map_err(|_| X25519Error::FailedExport)?
+      .into(),
+  )
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_pkcs8_x25519(
+  #[buffer] pkey: &[u8],
+) -> Result<ToJsBuffer, X25519Error> {
+  use rsa::pkcs1::der::Encode;
+
+  // This should probably use OneAsymmetricKey instead
+  let pk_info = rsa::pkcs8::PrivateKeyInfo {
+    public_key: None,
+    algorithm: rsa::pkcs8::AlgorithmIdentifierRef {
+      // id-X25519
+      oid: X25519_OID,
+      parameters: None,
+    },
+    private_key: pkey, // OCTET STRING
+  };
+
+  let mut buf = Vec::new();
+  pk_info.encode_to_vec(&mut buf)?;
+  Ok(buf.into())
+}

--- a/vendor/deno_crypto/x448.rs
+++ b/vendor/deno_crypto/x448.rs
@@ -1,0 +1,154 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::op2;
+use deno_core::ToJsBuffer;
+use ed448_goldilocks::curve::MontgomeryPoint;
+use ed448_goldilocks::Scalar;
+use elliptic_curve::pkcs8::PrivateKeyInfo;
+use elliptic_curve::subtle::ConstantTimeEq;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use spki::der::asn1::BitString;
+use spki::der::Decode;
+use spki::der::Encode;
+
+#[derive(Debug, thiserror::Error)]
+pub enum X448Error {
+  #[error("Failed to export key")]
+  FailedExport,
+  #[error("Invalid key data")]
+  InvalidKeyLength,
+  #[error(transparent)]
+  Der(#[from] spki::der::Error),
+}
+
+#[op2(fast)]
+pub fn op_crypto_generate_x448_keypair(
+  #[buffer] pkey: &mut [u8],
+  #[buffer] pubkey: &mut [u8],
+) {
+  let mut rng = OsRng;
+  rng.fill_bytes(pkey);
+
+  // x448(pkey, 5)
+  let point = &MontgomeryPoint::generator()
+    * &Scalar::from_bytes(pkey.try_into().unwrap());
+  pubkey.copy_from_slice(&point.0);
+}
+
+const MONTGOMERY_IDENTITY: MontgomeryPoint = MontgomeryPoint([0; 56]);
+
+#[op2(fast)]
+pub fn op_crypto_derive_bits_x448(
+  #[buffer] k: &[u8],
+  #[buffer] u: &[u8],
+  #[buffer] secret: &mut [u8],
+) -> Result<bool, X448Error> {
+  let k: [u8; 56] = k.try_into().map_err(|_| X448Error::InvalidKeyLength)?;
+  let u: [u8; 56] = u.try_into().map_err(|_| X448Error::InvalidKeyLength)?;
+
+  // x448(k, u)
+  let point = &MontgomeryPoint(u) * &Scalar::from_bytes(k);
+  if point.ct_eq(&MONTGOMERY_IDENTITY).unwrap_u8() == 1 {
+    return Ok(true);
+  }
+
+  secret.copy_from_slice(&point.0);
+  Ok(false)
+}
+
+// id-X448 OBJECT IDENTIFIER ::= { 1 3 101 111 }
+const X448_OID: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.3.101.111");
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_spki_x448(
+  #[buffer] pubkey: &[u8],
+) -> Result<ToJsBuffer, X448Error> {
+  let key_info = spki::SubjectPublicKeyInfo {
+    algorithm: spki::AlgorithmIdentifierRef {
+      oid: X448_OID,
+      parameters: None,
+    },
+    subject_public_key: BitString::from_bytes(pubkey)?,
+  };
+  Ok(
+    key_info
+      .to_der()
+      .map_err(|_| X448Error::FailedExport)?
+      .into(),
+  )
+}
+
+#[op2]
+#[serde]
+pub fn op_crypto_export_pkcs8_x448(
+  #[buffer] pkey: &[u8],
+) -> Result<ToJsBuffer, X448Error> {
+  use rsa::pkcs1::der::Encode;
+
+  let pk_info = rsa::pkcs8::PrivateKeyInfo {
+    public_key: None,
+    algorithm: rsa::pkcs8::AlgorithmIdentifierRef {
+      oid: X448_OID,
+      parameters: None,
+    },
+    private_key: pkey, // OCTET STRING
+  };
+
+  let mut buf = Vec::new();
+  pk_info.encode_to_vec(&mut buf)?;
+  Ok(buf.into())
+}
+
+#[op2(fast)]
+pub fn op_crypto_import_spki_x448(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  let pk_info = match spki::SubjectPublicKeyInfoRef::try_from(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != X448_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  out.copy_from_slice(pk_info.subject_public_key.raw_bytes());
+  true
+}
+
+#[op2(fast)]
+pub fn op_crypto_import_pkcs8_x448(
+  #[buffer] key_data: &[u8],
+  #[buffer] out: &mut [u8],
+) -> bool {
+  // 2-3.
+  let pk_info = match PrivateKeyInfo::from_der(key_data) {
+    Ok(pk_info) => pk_info,
+    Err(_) => return false,
+  };
+  // 4.
+  let alg = pk_info.algorithm.oid;
+  if alg != X448_OID {
+    return false;
+  }
+  // 5.
+  if pk_info.algorithm.parameters.is_some() {
+    return false;
+  }
+  // 6.
+  // CurvePrivateKey ::= OCTET STRING
+  if pk_info.private_key.len() != 56 {
+    return false;
+  }
+  out.copy_from_slice(&pk_info.private_key[2..]);
+  true
+}


### PR DESCRIPTION
## What

Two `crypto.subtle` paths in `deno_crypto` 0.196.0 panic on user-supplied key material. The panics happen inside op functions that cannot unwind, so they **abort the whole process** instead of surfacing a JS exception — a single edge function can take the runtime down.

**1. EC `importKey("pkcs8", ...)`** — `import_key.rs:683` unwraps the conversion of the PKCS#8 `AlgorithmIdentifier` parameters into a named-curve OID. A key that encodes *explicit* EC parameters (a `SEQUENCE`) instead of a curve OID aborts:

```
thread 'tokio-runtime-worker' panicked at deno_crypto-0.196.0/import_key.rs:683:10:
called `Result::unwrap()` on an `Err` value: Error { kind: TagUnexpected {
  expected: Some(Tag(0x06: OBJECT IDENTIFIER)), actual: Tag(0x30: SEQUENCE) }, position: None }
...
panic in a function that cannot unwind
```

**2. `importKey("raw", ...)` for X25519/X448/Ed25519** — the key length is never validated, so a shorter key (e.g. an empty `Uint8Array`) is stored as-is and the subsequent `deriveBits` aborts in `op_crypto_derive_bits_{x25519,x448}` when converting the slice to a fixed-size array. Same shape, found while auditing for the pattern above.

## How

Both are fixed upstream — [denoland/deno#32410](https://github.com/denoland/deno/pull/32410) and [denoland/deno#33944](https://github.com/denoland/deno/pull/33944) — but the releases carrying them (deno v2.7.10+) require a `deno_core` bump we can't take here. So this vendors `deno_crypto` 0.196.0 under `vendor/` (same pattern as `deno_fetch`/`deno_http`/`deno_telemetry`) and cherry-picks just those two fixes.

The vendored tree is otherwise byte-identical to the published crate. The Rust diff against pristine 0.196.0 is:

- `import_key.rs` — one line, `.unwrap()` → `.map_err(|_| ImportKeyError::MalformedParameters)?`
- `x25519.rs` / `x448.rs` — `derive_bits` returns `Result` instead of `expect`-ing, plus a new `InvalidKeyLength` variant
- `00_crypto.js` — length validation on the raw/jwk import paths (X448's jwk path was also missing the `op_crypto_base64url_decode` try/catch that X25519/Ed25519 already had)

`deno/runtime/errors.rs` maps the new variants to `DOMExceptionDataError`.

The remaining 26 panic sites in the crate were checked and are unreachable: the ECDH `pk.unwrap()`s in `lib.rs` sit behind `is_some()` guards, and PBKDF2's `NonZeroU32::new().unwrap()` / `assert!(length % 8 == 0)` are guarded in JS, which throws `OperationError` first.

## Verification

Built locally and driven through a function that hits each path.

**Before** (fix reverted, everything else identical) — one request kills the process:

```
19: deno_crypto::import_key::op_crypto_import_key::op_crypto_import_key::v8_fn_ptr
      at vendor/deno_crypto/import_key.rs:154:1
thread caused non-unwinding panic. aborting.
```

**After** — DOMExceptions, process survives repeated hits, valid keys unaffected:

```
ec-pkcs8-seq-params:  DOMExceptionDataError - malformed parameters
x25519-raw-short:     DOMException DataError - Invalid key data
x448-raw-short:       DOMException DataError - Invalid key data
ed25519-raw-short:    DOMException DataError - Invalid key data
ec-pkcs8-valid:       OK (round-trip import succeeded)
x25519-valid:         OK (32 bytes)
```

`cargo check --workspace` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)