### PR TITLE
fix(fs): tolerate concurrent creation of tests/.env in build script

### DIFF
--- a/crates/fs/build.rs
+++ b/crates/fs/build.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io::ErrorKind;
 use std::path::Path;
 
 fn main() {
@@ -9,8 +10,13 @@ fn main() {
 
   if env_path.exists() {
     println!("cargo:rustc-cfg=dotenv")
-  } else {
-    File::create_new(env_path).unwrap();
+  } else if let Err(err) = File::create_new(env_path) {
+    // A concurrent build (e.g. rust-analyzer checking the crate while cargo
+    // builds it from its own target dir) may have created the file between
+    // the `exists` check and here — that's fine, it exists either way.
+    if err.kind() != ErrorKind::AlreadyExists {
+      panic!("failed to create {env_file}: {err}");
+    }
   }
 
   println!("cargo::rerun-if-changed={}", env_file);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Closes #728.

## Description

`crates/fs/build.rs` has a TOCTOU window between `env_path.exists()` and `File::create_new(env_path).unwrap()`: when two builds run the build script concurrently (e.g. rust-analyzer checking the crate from its own target dir while `cargo check` runs in a terminal), both can see `tests/.env` as missing and the loser of the race panics with `AlreadyExists`, failing the whole build. Details and a deterministic reproduction are in #728.

This change treats `AlreadyExists` from `File::create_new` as success — the file exists either way, which is all the build script needs — and keeps failing (now with the path in the message) for any other error.

Verified locally:

- the losing-race code path (`exists()` → `false`, create → `EEXIST`, simulated with a dangling symlink) panics before this change and builds cleanly after it;
- a fresh state (no `tests/.env`) still creates the file, and an existing file still sets `cfg(dotenv)`.
