### PR TITLE
fix(fs): eliminate check-then-create race on tests/.env in build script

### DIFF
--- a/crates/fs/build.rs
+++ b/crates/fs/build.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io::ErrorKind;
 use std::path::Path;
 
 fn main() {
@@ -7,10 +8,13 @@ fn main() {
 
   println!("cargo::rustc-check-cfg=cfg(dotenv)");
 
-  if env_path.exists() {
-    println!("cargo:rustc-cfg=dotenv")
-  } else {
-    File::create_new(env_path).unwrap();
+  // Create-or-detect in one syscall so concurrent builds can't race.
+  match File::create_new(env_path) {
+    Ok(_) => {}
+    Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+      println!("cargo:rustc-cfg=dotenv")
+    }
+    Err(err) => panic!("failed to create {env_file}: {err}"),
   }
 
   println!("cargo::rerun-if-changed={}", env_file);


### PR DESCRIPTION
## Summary

Closes #728. `crates/fs/build.rs` had a check-then-create race on `tests/.env`: two builds running the build script concurrently — typically rust-analyzer (own target dir) alongside a terminal `cargo check` — could both observe the file as missing, and the loser panicked with `AlreadyExists`, failing the build. Details and a deterministic reproduction are in #728.

As proposed there, this removes the race rather than tolerating it: a single `File::create_new` replaces the `exists()`/`create_new` pair, branching on the result — created → no dotenv; `AlreadyExists` → the file is there, so set `cfg(dotenv)`; anything else still fails the build, now with the path in the message. Creation is atomic, so there is no window left to race through.

## Validation

- Existing `tests/.env`: `cfg(dotenv)` is still set.
- Fresh state (no `tests/.env`): the file is still created, `cfg(dotenv)` unset.
- The formerly-panicking path (`exists()` → `false` while creation hits `EEXIST`, exercised with the dangling-symlink repro from #728): builds cleanly, sets `cfg(dotenv)`.
