### PR TITLE
feat(base): stamp project ref into the outbound user agent

### DIFF
--- a/crates/base/src/runtime/mod.rs
+++ b/crates/base/src/runtime/mod.rs
@@ -111,6 +111,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::instrument;
 use tracing::trace;
+use tracing::warn;
 use tracing::Instrument;
 use tracing::Span;
 
@@ -743,7 +744,16 @@ where
         let project_ref = context
           .get("projectRef")
           .and_then(serde_json::Value::as_str)
-          .and_then(deno::versions::sanitize_project_ref);
+          .and_then(|it| {
+            let sanitized = deno::versions::sanitize_project_ref(it);
+            if sanitized.is_none() {
+              warn!(
+                project_ref = it,
+                "invalid project ref is not stamped into the user agent"
+              );
+            }
+            sanitized
+          });
 
         let extensions = vec![
           deno_telemetry::deno_telemetry::init_ops(),

--- a/crates/base/src/runtime/mod.rs
+++ b/crates/base/src/runtime/mod.rs
@@ -758,8 +758,7 @@ where
           deno_canvas::deno_canvas::init_ops(),
           deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(
             deno_fetch::Options {
-              user_agent: deno::versions::user_agent_for_project(project_ref)
-                .into_owned(),
+              user_agent: deno::versions::user_agent(project_ref),
               request_builder_hook: project_ref
                 .map(|it| deno::versions::user_agent_comment(Some(it)))
                 .and_then(|it| user_agent::stamping_hook(&it)),
@@ -772,7 +771,7 @@ where
             // A handshake carries this as its `User-Agent`; one the caller adds
             // through `WebSocketStream` is appended after it, never in place of
             // it, so the project stays on the wire either way.
-            deno::versions::user_agent_for_project(project_ref).into_owned(),
+            deno::versions::user_agent(project_ref),
             Some(root_cert_store_provider.clone()),
             None,
           ),

--- a/crates/base/src/runtime/mod.rs
+++ b/crates/base/src/runtime/mod.rs
@@ -130,6 +130,7 @@ mod unsync;
 
 pub mod otel;
 pub mod permissions;
+pub mod user_agent;
 
 const DEFAULT_ALLOC_CHECK_INT_MSEC: u64 = 1000;
 
@@ -737,6 +738,13 @@ where
           Arc::new(DenoCompileFileSystem::from_rc(vfs))
         })?;
 
+        // Outbound requests carry the project they were made from, so traffic
+        // reported as abusive can be traced back to it.
+        let project_ref = context
+          .get("projectRef")
+          .and_then(serde_json::Value::as_str)
+          .and_then(deno::versions::sanitize_project_ref);
+
         let extensions = vec![
           deno_telemetry::deno_telemetry::init_ops(),
           deno_webidl::deno_webidl::init_ops(),
@@ -750,14 +758,21 @@ where
           deno_canvas::deno_canvas::init_ops(),
           deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(
             deno_fetch::Options {
-              user_agent: deno::versions::user_agent().to_string(),
+              user_agent: deno::versions::user_agent_for_project(project_ref)
+                .into_owned(),
+              request_builder_hook: project_ref
+                .map(|it| deno::versions::user_agent_comment(Some(it)))
+                .and_then(|it| user_agent::stamping_hook(&it)),
               root_cert_store_provider: Some(root_cert_store_provider.clone()),
               file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
               ..Default::default()
             },
           ),
           deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
-            deno::versions::user_agent().to_string(),
+            // A handshake carries this as its `User-Agent`; one the caller adds
+            // through `WebSocketStream` is appended after it, never in place of
+            // it, so the project stays on the wire either way.
+            deno::versions::user_agent_for_project(project_ref).into_owned(),
             Some(root_cert_store_provider.clone()),
             None,
           ),

--- a/crates/base/src/runtime/user_agent.rs
+++ b/crates/base/src/runtime/user_agent.rs
@@ -27,7 +27,6 @@ pub fn stamping_hook(comment: &str) -> Option<RequestBuilderHook> {
   let comment = HeaderValue::from_str(comment)
     .ok()
     .filter(|it| !it.is_empty())?;
-
   Some(Arc::new(move |headers: &mut HeaderMap| {
     append_user_agent_comment(headers, &comment);
     Ok(())
@@ -41,9 +40,8 @@ fn append_user_agent_comment(headers: &mut HeaderMap, comment: &HeaderValue) {
     return;
   };
 
-  let current = entry.get().as_bytes();
-
   // Nothing to append to, and nothing to append twice to.
+  let current = entry.get().as_bytes();
   if current.is_empty() {
     entry.insert(comment.clone());
     return;
@@ -55,7 +53,6 @@ fn append_user_agent_comment(headers: &mut HeaderMap, comment: &HeaderValue) {
   }
 
   let mut value = Vec::with_capacity(current.len() + 1 + comment.len());
-
   value.extend_from_slice(current);
   value.push(b' ');
   value.extend_from_slice(comment.as_bytes());
@@ -73,7 +70,6 @@ mod tests {
   fn append(user_agent: Option<&str>) -> Option<String> {
     let comment = HeaderValue::from_static("(variant; ref=meow)");
     let mut headers = HeaderMap::new();
-
     if let Some(user_agent) = user_agent {
       headers.insert(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
     }

--- a/crates/base/src/runtime/user_agent.rs
+++ b/crates/base/src/runtime/user_agent.rs
@@ -5,6 +5,12 @@ use http::header::HeaderValue;
 use http::header::USER_AGENT;
 use http::HeaderMap;
 
+/// Hook run for every outbound request a worker makes.
+///
+/// It takes the header map rather than the request: `fetch()` and `node:http`
+/// build `Request<ReqBody>` while `node:http2` builds `Request<()>`, and a
+/// `dyn Fn` cannot be generic over the body type. Headers are the surface all
+/// paths share — and the only thing stamping touches anyway.
 pub type RequestBuilderHook =
   Arc<dyn Fn(&mut HeaderMap) -> Result<(), AnyError> + Send + Sync>;
 

--- a/crates/base/src/runtime/user_agent.rs
+++ b/crates/base/src/runtime/user_agent.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use deno::deno_fetch::ReqBody;
+use deno_core::error::AnyError;
+use http::header::HeaderValue;
+use http::header::USER_AGENT;
+use http::HeaderMap;
+use http::Request;
+
+pub type RequestBuilderHook =
+  Arc<dyn Fn(&mut Request<ReqBody>) -> Result<(), AnyError> + Send + Sync>;
+
+/// Builds the `deno_fetch` request hook that keeps `comment` on the
+/// `User-Agent` of every request a worker sends.
+///
+/// `deno_fetch` already falls back to the runtime's own `User-Agent` when a
+/// request carries none, so the hook only has to handle requests that set the
+/// header themselves: those keep what they set, with `comment` appended, and
+/// so cannot shed the project they were sent from.
+///
+/// Returns `None` if `comment` cannot be represented as a header value.
+pub fn stamping_hook(comment: &str) -> Option<RequestBuilderHook> {
+  let comment = HeaderValue::from_str(comment)
+    .ok()
+    .filter(|it| !it.is_empty())?;
+
+  Some(Arc::new(move |req: &mut Request<ReqBody>| {
+    append_user_agent_comment(req.headers_mut(), &comment);
+    Ok(())
+  }))
+}
+
+/// Appends `comment` to the `User-Agent`, if the request set one at all.
+fn append_user_agent_comment(headers: &mut HeaderMap, comment: &HeaderValue) {
+  let http::header::Entry::Occupied(mut entry) = headers.entry(USER_AGENT)
+  else {
+    return;
+  };
+
+  let current = entry.get().as_bytes();
+
+  // Nothing to append to, and nothing to append twice to.
+  if current.is_empty() {
+    entry.insert(comment.clone());
+    return;
+  } else if current
+    .windows(comment.len())
+    .any(|it| it == comment.as_bytes())
+  {
+    return;
+  }
+
+  let mut value = Vec::with_capacity(current.len() + 1 + comment.len());
+
+  value.extend_from_slice(current);
+  value.push(b' ');
+  value.extend_from_slice(comment.as_bytes());
+
+  // The parts are header values already, so the join is one too.
+  if let Ok(value) = HeaderValue::from_bytes(&value) {
+    entry.insert(value);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn append(user_agent: Option<&str>) -> Option<String> {
+    let comment = HeaderValue::from_static("(variant; ref=meow)");
+    let mut headers = HeaderMap::new();
+
+    if let Some(user_agent) = user_agent {
+      headers.insert(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
+    }
+
+    append_user_agent_comment(&mut headers, &comment);
+    headers
+      .get(USER_AGENT)
+      .map(|it| it.to_str().unwrap().to_string())
+  }
+
+  #[test]
+  fn test_append_user_agent_comment() {
+    // A request that sets no `User-Agent` is left to `deno_fetch`, which fills
+    // in the runtime's own.
+    assert_eq!(append(None), None);
+
+    // One the request set itself is kept, but cannot shed the comment.
+    assert_eq!(
+      append(Some("curl/8.7.1")).as_deref(),
+      Some("curl/8.7.1 (variant; ref=meow)")
+    );
+
+    // Already stamped (a forwarded `User-Agent`, say): left alone.
+    assert_eq!(
+      append(Some("curl/8.7.1 (variant; ref=meow)")).as_deref(),
+      Some("curl/8.7.1 (variant; ref=meow)")
+    );
+
+    // An empty one has nothing to append to.
+    assert_eq!(append(Some("")).as_deref(), Some("(variant; ref=meow)"));
+  }
+
+  #[test]
+  fn test_stamping_hook_rejects_invalid_comments() {
+    assert!(stamping_hook("(variant; ref=meow)").is_some());
+    assert!(stamping_hook("").is_none());
+    assert!(stamping_hook("new\nline").is_none());
+  }
+}

--- a/crates/base/src/runtime/user_agent.rs
+++ b/crates/base/src/runtime/user_agent.rs
@@ -1,14 +1,12 @@
 use std::sync::Arc;
 
-use deno::deno_fetch::ReqBody;
 use deno_core::error::AnyError;
 use http::header::HeaderValue;
 use http::header::USER_AGENT;
 use http::HeaderMap;
-use http::Request;
 
 pub type RequestBuilderHook =
-  Arc<dyn Fn(&mut Request<ReqBody>) -> Result<(), AnyError> + Send + Sync>;
+  Arc<dyn Fn(&mut HeaderMap) -> Result<(), AnyError> + Send + Sync>;
 
 /// Builds the `deno_fetch` request hook that keeps `comment` on the
 /// `User-Agent` of every request a worker sends.
@@ -24,8 +22,8 @@ pub fn stamping_hook(comment: &str) -> Option<RequestBuilderHook> {
     .ok()
     .filter(|it| !it.is_empty())?;
 
-  Some(Arc::new(move |req: &mut Request<ReqBody>| {
-    append_user_agent_comment(req.headers_mut(), &comment);
+  Some(Arc::new(move |headers: &mut HeaderMap| {
+    append_user_agent_comment(headers, &comment);
     Ok(())
   }))
 }

--- a/crates/base/test_cases/main_with_project_ref/index.ts
+++ b/crates/base/test_cases/main_with_project_ref/index.ts
@@ -1,0 +1,39 @@
+console.log("main function started");
+
+Deno.serve({
+  handler: async (req: Request) => {
+    const { pathname } = new URL(req.url);
+    const servicePath = `./test_cases${pathname}`;
+    const projectRef = req.headers.get("x-project-ref");
+
+    console.error(`serving the request with ${servicePath}`);
+
+    const envVarsObj = Deno.env.toObject();
+    const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]]);
+
+    try {
+      const worker = await EdgeRuntime.userWorkers.create({
+        servicePath,
+        memoryLimitMb: 150,
+        workerTimeoutMs: 10 * 60 * 1000,
+        cpuTimeSoftLimitMs: 10 * 60 * 1000,
+        cpuTimeHardLimitMs: 10 * 60 * 1000,
+        noModuleCache: false,
+        envVars,
+        context: projectRef ? { projectRef } : {},
+      });
+
+      return await worker.fetch(req);
+    } catch (e) {
+      console.error(e);
+
+      const error = { msg: e.toString() };
+      return new Response(
+        JSON.stringify(error),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+  },
+
+  onError: (e) => new Response(e.toString(), { status: 500 }),
+});

--- a/crates/base/test_cases/user-agent-http2/index.ts
+++ b/crates/base/test_cases/user-agent-http2/index.ts
@@ -1,0 +1,23 @@
+import http2 from "node:http2";
+
+Deno.serve((req: Request) => {
+  const echoUrl = req.headers.get("x-echo-url")!;
+  const userAgent = req.headers.get("x-set-user-agent");
+
+  return new Promise((resolve) => {
+    const client = http2.connect(echoUrl);
+    const stream = client.request(
+      userAgent === null ? {} : { "user-agent": userAgent },
+    );
+
+    let body = "";
+
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => body += chunk);
+    stream.on("end", () => {
+      client.close();
+      resolve(new Response(body));
+    });
+    stream.end();
+  });
+});

--- a/crates/base/test_cases/user-agent-node/index.ts
+++ b/crates/base/test_cases/user-agent-node/index.ts
@@ -1,0 +1,22 @@
+import http from "node:http";
+
+Deno.serve((req: Request) => {
+  const echoUrl = new URL(req.headers.get("x-echo-url")!);
+  const userAgent = req.headers.get("x-set-user-agent");
+
+  return new Promise((resolve) => {
+    const outbound = http.request({
+      hostname: echoUrl.hostname,
+      port: echoUrl.port,
+      path: "/",
+      headers: userAgent === null ? {} : { "user-agent": userAgent },
+    }, (res) => {
+      let body = "";
+
+      res.on("data", (chunk) => body += chunk);
+      res.on("end", () => resolve(new Response(body)));
+    });
+
+    outbound.end();
+  });
+});

--- a/crates/base/test_cases/user-agent-websocket/index.ts
+++ b/crates/base/test_cases/user-agent-websocket/index.ts
@@ -1,0 +1,21 @@
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.headers.get("x-echo-url")!);
+
+  url.protocol = "ws:";
+
+  // The echo server answers the handshake with a plain response, so the socket
+  // never opens. All this has to do is get the handshake sent, and the server
+  // records the `User-Agent` it arrived with.
+  await new Promise((resolve) => {
+    const socket = new WebSocket(url);
+
+    socket.onopen = () => {
+      socket.close();
+      resolve(null);
+    };
+    socket.onerror = () => resolve(null);
+    socket.onclose = () => resolve(null);
+  });
+
+  return new Response("ok");
+});

--- a/crates/base/test_cases/user-agent/index.ts
+++ b/crates/base/test_cases/user-agent/index.ts
@@ -1,0 +1,34 @@
+Deno.serve(async (req: Request) => {
+  const echoUrl = req.headers.get("x-echo-url")!;
+  const userAgent = req.headers.get("x-set-user-agent");
+
+  // How the outbound `User-Agent` is handed to `fetch`. Each of these reaches
+  // the header a different way, so each has to end up stamped.
+  const style = req.headers.get("x-header-style");
+
+  let resp: Response;
+
+  if (userAgent === null) {
+    resp = await fetch(echoUrl);
+  } else if (style === "array") {
+    resp = await fetch(echoUrl, { headers: [["user-agent", userAgent]] });
+  } else if (style === "headers") {
+    resp = await fetch(echoUrl, {
+      headers: new Headers({ "user-agent": userAgent }),
+    });
+  } else if (style === "request") {
+    resp = await fetch(
+      new Request(echoUrl, { headers: { "user-agent": userAgent } }),
+    );
+  } else if (style === "request-overridden") {
+    // `init.headers` wins over the ones the `Request` carries.
+    resp = await fetch(
+      new Request(echoUrl, { headers: { "user-agent": "discarded/1.0" } }),
+      { headers: { "user-agent": userAgent } },
+    );
+  } else {
+    resp = await fetch(echoUrl, { headers: { "user-agent": userAgent } });
+  }
+
+  return new Response(await resp.text());
+});

--- a/crates/base/test_cases/user-agent/index.ts
+++ b/crates/base/test_cases/user-agent/index.ts
@@ -2,33 +2,10 @@ Deno.serve(async (req: Request) => {
   const echoUrl = req.headers.get("x-echo-url")!;
   const userAgent = req.headers.get("x-set-user-agent");
 
-  // How the outbound `User-Agent` is handed to `fetch`. Each of these reaches
-  // the header a different way, so each has to end up stamped.
-  const style = req.headers.get("x-header-style");
-
-  let resp: Response;
-
-  if (userAgent === null) {
-    resp = await fetch(echoUrl);
-  } else if (style === "array") {
-    resp = await fetch(echoUrl, { headers: [["user-agent", userAgent]] });
-  } else if (style === "headers") {
-    resp = await fetch(echoUrl, {
-      headers: new Headers({ "user-agent": userAgent }),
-    });
-  } else if (style === "request") {
-    resp = await fetch(
-      new Request(echoUrl, { headers: { "user-agent": userAgent } }),
-    );
-  } else if (style === "request-overridden") {
-    // `init.headers` wins over the ones the `Request` carries.
-    resp = await fetch(
-      new Request(echoUrl, { headers: { "user-agent": "discarded/1.0" } }),
-      { headers: { "user-agent": userAgent } },
-    );
-  } else {
-    resp = await fetch(echoUrl, { headers: { "user-agent": userAgent } });
-  }
+  const resp = await fetch(
+    echoUrl,
+    userAgent === null ? {} : { headers: { "user-agent": userAgent } },
+  );
 
   return new Response(await resp.text());
 });

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4774,7 +4774,7 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
   // A function that sends no `User-Agent` of its own gets the runtime's, and
   // the project ref is part of it.
   {
-    let expected = deno::versions::user_agent_for_project(Some(PROJECT_REF));
+    let expected = deno::versions::user_agent(Some(PROJECT_REF));
 
     integration_test!(
       "./test_cases/main_with_project_ref",
@@ -4867,7 +4867,7 @@ async fn test_outbound_node_http_user_agent_is_stamped_with_project_ref() {
 
   // `node:http` sends no `User-Agent` of its own, so it gets the runtime's.
   {
-    let expected = deno::versions::user_agent_for_project(Some(PROJECT_REF));
+    let expected = deno::versions::user_agent(Some(PROJECT_REF));
 
     integration_test!(
       "./test_cases/main_with_project_ref",
@@ -4951,6 +4951,6 @@ async fn test_websocket_handshake_user_agent_is_stamped_with_project_ref() {
 
   assert_eq!(
     seen.as_slice(),
-    [deno::versions::user_agent_for_project(Some(PROJECT_REF)).to_string()]
+    [deno::versions::user_agent(Some(PROJECT_REF))]
   );
 }

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4681,54 +4681,8 @@ fn new_localhost_tls(secure: bool) -> Option<Tls> {
 /// observable this way.
 type SeenUserAgents = Arc<std::sync::Mutex<Vec<String>>>;
 
-/// Answers every request with the `User-Agent` it arrived with.
-async fn echo_user_agent_server(
-  listener: TcpListener,
-  token: CancellationToken,
-  seen: SeenUserAgents,
-) {
-  loop {
-    tokio::select! {
-      Ok((stream, _)) = listener.accept() => {
-        let seen = seen.clone();
-
-        tokio::spawn(async move {
-          hyper::server::conn::Http::new()
-            .serve_connection(
-              stream,
-              hyper::service::service_fn(move |req: Request<Body>| {
-                let seen = seen.clone();
-
-                async move {
-                  let user_agent = req
-                    .headers()
-                    .get(header::USER_AGENT)
-                    .and_then(|it| it.to_str().ok())
-                    .unwrap_or_default()
-                    .to_string();
-
-                  seen.lock().unwrap().push(user_agent.clone());
-
-                  Ok::<_, hyper::Error>(
-                    HttpResponse::new(Body::from(user_agent)),
-                  )
-                }
-              }),
-            )
-            .await
-            .ok();
-        });
-      }
-
-      _ = token.cancelled() => {
-        break;
-      }
-    }
-  }
-}
-
-/// Starts an echo server on a port of its own. The returned future runs it
-/// until the token is cancelled.
+/// Starts a server that answers every request with the `User-Agent` it arrived
+/// with, until the token is cancelled.
 async fn start_echo_user_agent_server(
   token: CancellationToken,
 ) -> (String, SeenUserAgents, tokio::task::JoinHandle<()>) {
@@ -4738,11 +4692,81 @@ async fn start_echo_user_agent_server(
   let server = tokio::spawn({
     let seen = seen.clone();
     async move {
-      echo_user_agent_server(listener, token, seen).await;
+      loop {
+        tokio::select! {
+          Ok((stream, _)) = listener.accept() => {
+            let seen = seen.clone();
+            tokio::spawn(async move {
+              hyper::server::conn::Http::new()
+                .serve_connection(
+                  stream,
+                  hyper::service::service_fn(move |req: Request<Body>| {
+                    let seen = seen.clone();
+                    async move {
+                      let user_agent = req
+                        .headers()
+                        .get(header::USER_AGENT)
+                        .and_then(|it| it.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string();
+
+                      seen.lock().unwrap().push(user_agent.clone());
+                      Ok::<_, hyper::Error>(
+                        HttpResponse::new(Body::from(user_agent)),
+                      )
+                    }
+                  }),
+                )
+                .await
+                .ok();
+            });
+          }
+          _ = token.cancelled() => break,
+        }
+      }
     }
   });
 
   (url, seen, server)
+}
+
+/// Serves `path` from `main_with_project_ref` and asserts the function's
+/// outbound request reached the echo server with `expected` as `User-Agent`.
+async fn assert_echoed_user_agent(
+  path: &str,
+  echo_url: &str,
+  project_ref: Option<&str>,
+  user_agent: Option<&str>,
+  expected: String,
+) {
+  let mut builder = Client::new()
+    .request(
+      Method::POST,
+      format!("http://localhost:{}/{}", NON_SECURE_PORT, path),
+    )
+    .header("x-echo-url", echo_url);
+
+  if let Some(project_ref) = project_ref {
+    builder = builder.header("x-project-ref", project_ref);
+  }
+  if let Some(user_agent) = user_agent {
+    builder = builder.header("x-set-user-agent", user_agent);
+  }
+
+  integration_test!(
+    "./test_cases/main_with_project_ref",
+    NON_SECURE_PORT,
+    "",
+    None,
+    Some(builder),
+    None,
+    (|resp| async move {
+      let resp = resp.unwrap();
+      assert_eq!(resp.status().as_u16(), StatusCode::OK);
+      assert_eq!(resp.text().await.unwrap(), expected);
+    }),
+    TerminationToken::new()
+  );
 }
 
 #[tokio::test]
@@ -4752,90 +4776,39 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
 
   let token = CancellationToken::new();
   let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
-
-  let request = |project_ref: Option<&str>, user_agent: Option<&str>| {
-    let mut builder = Client::new()
-      .request(
-        Method::POST,
-        format!("http://localhost:{}/user-agent", NON_SECURE_PORT),
-      )
-      .header("x-echo-url", &echo_url);
-
-    if let Some(project_ref) = project_ref {
-      builder = builder.header("x-project-ref", project_ref);
-    }
-    if let Some(user_agent) = user_agent {
-      builder = builder.header("x-set-user-agent", user_agent);
-    }
-
-    builder
-  };
+  let ref_comment = deno::versions::user_agent_comment(Some(PROJECT_REF));
 
   // A function that sends no `User-Agent` of its own gets the runtime's, and
   // the project ref is part of it.
-  {
-    let expected = deno::versions::user_agent(Some(PROJECT_REF));
-
-    integration_test!(
-      "./test_cases/main_with_project_ref",
-      NON_SECURE_PORT,
-      "",
-      None,
-      Some(request(Some(PROJECT_REF), None)),
-      None,
-      (|resp| async move {
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), expected);
-      }),
-      TerminationToken::new()
-    );
-  }
+  assert_echoed_user_agent(
+    "user-agent",
+    &echo_url,
+    Some(PROJECT_REF),
+    None,
+    deno::versions::user_agent(Some(PROJECT_REF)),
+  )
+  .await;
 
   // A function that sets its own `User-Agent` keeps it, but cannot drop the
   // project ref.
-  {
-    let expected = format!(
-      "curl/8.7.1 {}",
-      deno::versions::user_agent_comment(Some(PROJECT_REF))
-    );
-
-    integration_test!(
-      "./test_cases/main_with_project_ref",
-      NON_SECURE_PORT,
-      "",
-      None,
-      Some(request(Some(PROJECT_REF), Some("curl/8.7.1"))),
-      None,
-      (|resp| async move {
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), expected);
-      }),
-      TerminationToken::new()
-    );
-  }
+  assert_echoed_user_agent(
+    "user-agent",
+    &echo_url,
+    Some(PROJECT_REF),
+    Some("curl/8.7.1"),
+    format!("curl/8.7.1 {ref_comment}"),
+  )
+  .await;
 
   // Without a project ref, nothing is stamped.
-  {
-    integration_test!(
-      "./test_cases/main_with_project_ref",
-      NON_SECURE_PORT,
-      "",
-      None,
-      Some(request(None, Some("curl/8.7.1"))),
-      None,
-      (|resp| async move {
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), "curl/8.7.1");
-      }),
-      TerminationToken::new()
-    );
-  }
+  assert_echoed_user_agent(
+    "user-agent",
+    &echo_url,
+    None,
+    Some("curl/8.7.1"),
+    "curl/8.7.1".into(),
+  )
+  .await;
 
   token.cancel();
   server.await.unwrap();
@@ -4848,67 +4821,27 @@ async fn test_outbound_node_http_user_agent_is_stamped_with_project_ref() {
 
   let token = CancellationToken::new();
   let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
-
-  let request = |user_agent: Option<&str>| {
-    let mut builder = Client::new()
-      .request(
-        Method::POST,
-        format!("http://localhost:{}/user-agent-node", NON_SECURE_PORT),
-      )
-      .header("x-project-ref", PROJECT_REF)
-      .header("x-echo-url", &echo_url);
-
-    if let Some(user_agent) = user_agent {
-      builder = builder.header("x-set-user-agent", user_agent);
-    }
-
-    builder
-  };
+  let ref_comment = deno::versions::user_agent_comment(Some(PROJECT_REF));
 
   // `node:http` sends no `User-Agent` of its own, so it gets the runtime's.
-  {
-    let expected = deno::versions::user_agent(Some(PROJECT_REF));
-
-    integration_test!(
-      "./test_cases/main_with_project_ref",
-      NON_SECURE_PORT,
-      "",
-      None,
-      Some(request(None)),
-      None,
-      (|resp| async move {
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), expected);
-      }),
-      TerminationToken::new()
-    );
-  }
+  assert_echoed_user_agent(
+    "user-agent-node",
+    &echo_url,
+    Some(PROJECT_REF),
+    None,
+    deno::versions::user_agent(Some(PROJECT_REF)),
+  )
+  .await;
 
   // One the caller set is kept, with the project appended to it.
-  {
-    let expected = format!(
-      "curl/8.7.1 {}",
-      deno::versions::user_agent_comment(Some(PROJECT_REF))
-    );
-
-    integration_test!(
-      "./test_cases/main_with_project_ref",
-      NON_SECURE_PORT,
-      "",
-      None,
-      Some(request(Some("curl/8.7.1"))),
-      None,
-      (|resp| async move {
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), expected);
-      }),
-      TerminationToken::new()
-    );
-  }
+  assert_echoed_user_agent(
+    "user-agent-node",
+    &echo_url,
+    Some(PROJECT_REF),
+    Some("curl/8.7.1"),
+    format!("curl/8.7.1 {ref_comment}"),
+  )
+  .await;
 
   token.cancel();
   server.await.unwrap();
@@ -4947,10 +4880,8 @@ async fn test_websocket_handshake_user_agent_is_stamped_with_project_ref() {
   token.cancel();
   server.await.unwrap();
 
-  let seen = seen.lock().unwrap();
-
   assert_eq!(
-    seen.as_slice(),
+    seen.lock().unwrap().as_slice(),
     [deno::versions::user_agent(Some(PROJECT_REF))]
   );
 }

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4849,6 +4849,39 @@ async fn test_outbound_node_http_user_agent_is_stamped_with_project_ref() {
 
 #[tokio::test]
 #[serial]
+async fn test_outbound_node_http2_user_agent_is_stamped_with_project_ref() {
+  const PROJECT_REF: &str = "abcdefghijklmnopqrst";
+
+  let token = CancellationToken::new();
+  let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
+  let ref_comment = deno::versions::user_agent_comment(Some(PROJECT_REF));
+
+  // `node:http2` sends no `User-Agent` of its own, so it gets the runtime's.
+  assert_echoed_user_agent(
+    "user-agent-http2",
+    &echo_url,
+    Some(PROJECT_REF),
+    None,
+    deno::versions::user_agent(Some(PROJECT_REF)),
+  )
+  .await;
+
+  // One the caller set is kept, with the project appended to it.
+  assert_echoed_user_agent(
+    "user-agent-http2",
+    &echo_url,
+    Some(PROJECT_REF),
+    Some("curl/8.7.1"),
+    format!("curl/8.7.1 {ref_comment}"),
+  )
+  .await;
+
+  token.cancel();
+  server.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
 async fn test_websocket_handshake_user_agent_is_stamped_with_project_ref() {
   const PROJECT_REF: &str = "abcdefghijklmnopqrst";
 

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4753,9 +4753,7 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
   let token = CancellationToken::new();
   let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
 
-  let request = |project_ref: Option<&str>,
-                 user_agent: Option<&str>,
-                 header_style: Option<&str>| {
+  let request = |project_ref: Option<&str>, user_agent: Option<&str>| {
     let mut builder = Client::new()
       .request(
         Method::POST,
@@ -4768,9 +4766,6 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
     }
     if let Some(user_agent) = user_agent {
       builder = builder.header("x-set-user-agent", user_agent);
-    }
-    if let Some(header_style) = header_style {
-      builder = builder.header("x-header-style", header_style);
     }
 
     builder
@@ -4786,7 +4781,7 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
       NON_SECURE_PORT,
       "",
       None,
-      Some(request(Some(PROJECT_REF), None, None)),
+      Some(request(Some(PROJECT_REF), None)),
       None,
       (|resp| async move {
         let resp = resp.unwrap();
@@ -4799,14 +4794,8 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
   }
 
   // A function that sets its own `User-Agent` keeps it, but cannot drop the
-  // project ref, no matter how it hands the header to `fetch`.
-  for header_style in [
-    "object",
-    "array",
-    "headers",
-    "request",
-    "request-overridden",
-  ] {
+  // project ref.
+  {
     let expected = format!(
       "curl/8.7.1 {}",
       deno::versions::user_agent_comment(Some(PROJECT_REF))
@@ -4817,17 +4806,13 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
       NON_SECURE_PORT,
       "",
       None,
-      Some(request(
-        Some(PROJECT_REF),
-        Some("curl/8.7.1"),
-        Some(header_style)
-      )),
+      Some(request(Some(PROJECT_REF), Some("curl/8.7.1"))),
       None,
       (|resp| async move {
         let resp = resp.unwrap();
 
         assert_eq!(resp.status().as_u16(), StatusCode::OK);
-        assert_eq!(resp.text().await.unwrap(), expected, "{header_style}");
+        assert_eq!(resp.text().await.unwrap(), expected);
       }),
       TerminationToken::new()
     );
@@ -4840,7 +4825,7 @@ async fn test_outbound_user_agent_is_stamped_with_project_ref() {
       NON_SECURE_PORT,
       "",
       None,
-      Some(request(None, Some("curl/8.7.1"), None)),
+      Some(request(None, Some("curl/8.7.1"))),
       None,
       (|resp| async move {
         let resp = resp.unwrap();

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4675,3 +4675,297 @@ fn new_localhost_tls(secure: bool) -> Option<Tls> {
     Tls::new(SECURE_PORT, TLS_LOCALHOST_KEY, TLS_LOCALHOST_CERT).unwrap()
   })
 }
+
+/// Every `User-Agent` the echo server has been sent, in arrival order. Requests
+/// that never get a response of their own (a websocket handshake, say) are only
+/// observable this way.
+type SeenUserAgents = Arc<std::sync::Mutex<Vec<String>>>;
+
+/// Answers every request with the `User-Agent` it arrived with.
+async fn echo_user_agent_server(
+  listener: TcpListener,
+  token: CancellationToken,
+  seen: SeenUserAgents,
+) {
+  loop {
+    tokio::select! {
+      Ok((stream, _)) = listener.accept() => {
+        let seen = seen.clone();
+
+        tokio::spawn(async move {
+          hyper::server::conn::Http::new()
+            .serve_connection(
+              stream,
+              hyper::service::service_fn(move |req: Request<Body>| {
+                let seen = seen.clone();
+
+                async move {
+                  let user_agent = req
+                    .headers()
+                    .get(header::USER_AGENT)
+                    .and_then(|it| it.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+
+                  seen.lock().unwrap().push(user_agent.clone());
+
+                  Ok::<_, hyper::Error>(
+                    HttpResponse::new(Body::from(user_agent)),
+                  )
+                }
+              }),
+            )
+            .await
+            .ok();
+        });
+      }
+
+      _ = token.cancelled() => {
+        break;
+      }
+    }
+  }
+}
+
+/// Starts an echo server on a port of its own. The returned future runs it
+/// until the token is cancelled.
+async fn start_echo_user_agent_server(
+  token: CancellationToken,
+) -> (String, SeenUserAgents, tokio::task::JoinHandle<()>) {
+  let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+  let url = format!("http://{}", listener.local_addr().unwrap());
+  let seen = SeenUserAgents::default();
+  let server = tokio::spawn({
+    let seen = seen.clone();
+    async move {
+      echo_user_agent_server(listener, token, seen).await;
+    }
+  });
+
+  (url, seen, server)
+}
+
+#[tokio::test]
+#[serial]
+async fn test_outbound_user_agent_is_stamped_with_project_ref() {
+  const PROJECT_REF: &str = "abcdefghijklmnopqrst";
+
+  let token = CancellationToken::new();
+  let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
+
+  let request = |project_ref: Option<&str>,
+                 user_agent: Option<&str>,
+                 header_style: Option<&str>| {
+    let mut builder = Client::new()
+      .request(
+        Method::POST,
+        format!("http://localhost:{}/user-agent", NON_SECURE_PORT),
+      )
+      .header("x-echo-url", &echo_url);
+
+    if let Some(project_ref) = project_ref {
+      builder = builder.header("x-project-ref", project_ref);
+    }
+    if let Some(user_agent) = user_agent {
+      builder = builder.header("x-set-user-agent", user_agent);
+    }
+    if let Some(header_style) = header_style {
+      builder = builder.header("x-header-style", header_style);
+    }
+
+    builder
+  };
+
+  // A function that sends no `User-Agent` of its own gets the runtime's, and
+  // the project ref is part of it.
+  {
+    let expected = deno::versions::user_agent_for_project(Some(PROJECT_REF));
+
+    integration_test!(
+      "./test_cases/main_with_project_ref",
+      NON_SECURE_PORT,
+      "",
+      None,
+      Some(request(Some(PROJECT_REF), None, None)),
+      None,
+      (|resp| async move {
+        let resp = resp.unwrap();
+
+        assert_eq!(resp.status().as_u16(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), expected);
+      }),
+      TerminationToken::new()
+    );
+  }
+
+  // A function that sets its own `User-Agent` keeps it, but cannot drop the
+  // project ref, no matter how it hands the header to `fetch`.
+  for header_style in [
+    "object",
+    "array",
+    "headers",
+    "request",
+    "request-overridden",
+  ] {
+    let expected = format!(
+      "curl/8.7.1 {}",
+      deno::versions::user_agent_comment(Some(PROJECT_REF))
+    );
+
+    integration_test!(
+      "./test_cases/main_with_project_ref",
+      NON_SECURE_PORT,
+      "",
+      None,
+      Some(request(
+        Some(PROJECT_REF),
+        Some("curl/8.7.1"),
+        Some(header_style)
+      )),
+      None,
+      (|resp| async move {
+        let resp = resp.unwrap();
+
+        assert_eq!(resp.status().as_u16(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), expected, "{header_style}");
+      }),
+      TerminationToken::new()
+    );
+  }
+
+  // Without a project ref, nothing is stamped.
+  {
+    integration_test!(
+      "./test_cases/main_with_project_ref",
+      NON_SECURE_PORT,
+      "",
+      None,
+      Some(request(None, Some("curl/8.7.1"), None)),
+      None,
+      (|resp| async move {
+        let resp = resp.unwrap();
+
+        assert_eq!(resp.status().as_u16(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), "curl/8.7.1");
+      }),
+      TerminationToken::new()
+    );
+  }
+
+  token.cancel();
+  server.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_outbound_node_http_user_agent_is_stamped_with_project_ref() {
+  const PROJECT_REF: &str = "abcdefghijklmnopqrst";
+
+  let token = CancellationToken::new();
+  let (echo_url, _, server) = start_echo_user_agent_server(token.clone()).await;
+
+  let request = |user_agent: Option<&str>| {
+    let mut builder = Client::new()
+      .request(
+        Method::POST,
+        format!("http://localhost:{}/user-agent-node", NON_SECURE_PORT),
+      )
+      .header("x-project-ref", PROJECT_REF)
+      .header("x-echo-url", &echo_url);
+
+    if let Some(user_agent) = user_agent {
+      builder = builder.header("x-set-user-agent", user_agent);
+    }
+
+    builder
+  };
+
+  // `node:http` sends no `User-Agent` of its own, so it gets the runtime's.
+  {
+    let expected = deno::versions::user_agent_for_project(Some(PROJECT_REF));
+
+    integration_test!(
+      "./test_cases/main_with_project_ref",
+      NON_SECURE_PORT,
+      "",
+      None,
+      Some(request(None)),
+      None,
+      (|resp| async move {
+        let resp = resp.unwrap();
+
+        assert_eq!(resp.status().as_u16(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), expected);
+      }),
+      TerminationToken::new()
+    );
+  }
+
+  // One the caller set is kept, with the project appended to it.
+  {
+    let expected = format!(
+      "curl/8.7.1 {}",
+      deno::versions::user_agent_comment(Some(PROJECT_REF))
+    );
+
+    integration_test!(
+      "./test_cases/main_with_project_ref",
+      NON_SECURE_PORT,
+      "",
+      None,
+      Some(request(Some("curl/8.7.1"))),
+      None,
+      (|resp| async move {
+        let resp = resp.unwrap();
+
+        assert_eq!(resp.status().as_u16(), StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), expected);
+      }),
+      TerminationToken::new()
+    );
+  }
+
+  token.cancel();
+  server.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_websocket_handshake_user_agent_is_stamped_with_project_ref() {
+  const PROJECT_REF: &str = "abcdefghijklmnopqrst";
+
+  let token = CancellationToken::new();
+  let (echo_url, seen, server) =
+    start_echo_user_agent_server(token.clone()).await;
+
+  let builder = Client::new()
+    .request(
+      Method::POST,
+      format!("http://localhost:{}/user-agent-websocket", NON_SECURE_PORT),
+    )
+    .header("x-project-ref", PROJECT_REF)
+    .header("x-echo-url", &echo_url);
+
+  integration_test!(
+    "./test_cases/main_with_project_ref",
+    NON_SECURE_PORT,
+    "",
+    None,
+    Some(builder),
+    None,
+    (|resp| async move {
+      assert_eq!(resp.unwrap().status().as_u16(), StatusCode::OK);
+    }),
+    TerminationToken::new()
+  );
+
+  token.cancel();
+  server.await.unwrap();
+
+  let seen = seen.lock().unwrap();
+
+  assert_eq!(
+    seen.as_slice(),
+    [deno::versions::user_agent_for_project(Some(PROJECT_REF)).to_string()]
+  );
+}

--- a/deno/http_util.rs
+++ b/deno/http_util.rs
@@ -257,7 +257,7 @@ impl HttpClientProvider {
       Entry::Occupied(entry) => Ok(HttpClient::new(entry.get().clone())),
       Entry::Vacant(entry) => {
         let client = create_http_client(
-          user_agent(),
+          &user_agent(None),
           CreateHttpClientOptions {
             root_cert_store: match &self.root_cert_store_provider {
               Some(provider) => Some(provider.get_or_try_init()?.clone()),

--- a/deno/versions.rs
+++ b/deno/versions.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use deno_telemetry::OtelRuntimeConfig;
-use once_cell::sync::Lazy;
 
 use crate::version;
 
@@ -9,44 +8,27 @@ pub fn edge_runtime_version() -> &'static str {
   option_env!("GIT_V_TAG").unwrap_or("0.1.0")
 }
 
-/// Comment identifying this runtime, and the project the worker belongs to
-/// when it is known.
-///
-/// The value is a single [RFC 9110 comment][1], so it can either close a
-/// `User-Agent` built by us or be appended to one supplied by the function.
+/// `User-Agent` sent by every worker, tagged with the project the worker
+/// belongs to when it is known.
+pub fn user_agent(project_ref: Option<&str>) -> String {
+  // TODO: It should be changed to a well-known name for the ecosystem.
+  format!("Deno/{} {}", version(), user_agent_comment(project_ref))
+}
+
+/// The comment part of [`user_agent`]: a single [RFC 9110 comment][1], so it
+/// can also be appended to a `User-Agent` supplied by the function itself (see
+/// `base`'s `user_agent` module).
 ///
 /// [1]: https://www.rfc-editor.org/rfc/rfc9110#name-user-agent
 pub fn user_agent_comment(project_ref: Option<&str>) -> String {
-  let edge_runtime_version = edge_runtime_version();
+  let ref_part = project_ref
+    .map(|it| format!("; ref={it}"))
+    .unwrap_or_default();
 
-  match project_ref {
-    Some(project_ref) => format!(
-      "(variant; SupabaseEdgeRuntime/{}; ref={})",
-      edge_runtime_version, project_ref
-    ),
-    None => format!("(variant; SupabaseEdgeRuntime/{})", edge_runtime_version),
-  }
-}
-
-pub fn user_agent() -> &'static str {
-  static VALUE: Lazy<String> = Lazy::new(|| {
-    // TODO: It should be changed to a well-known name for the ecosystem.
-    format!("Deno/{} {}", version(), user_agent_comment(None))
-  });
-
-  VALUE.as_str()
-}
-
-/// Same as [`user_agent`], but tagged with the project the worker belongs to.
-pub fn user_agent_for_project(project_ref: Option<&str>) -> Cow<'static, str> {
-  match project_ref {
-    Some(project_ref) => Cow::Owned(format!(
-      "Deno/{} {}",
-      version(),
-      user_agent_comment(Some(project_ref))
-    )),
-    None => Cow::Borrowed(user_agent()),
-  }
+  format!(
+    "(variant; SupabaseEdgeRuntime/{}{ref_part})",
+    edge_runtime_version()
+  )
 }
 
 /// Accepts a project ref only if it is safe to put in a header comment.
@@ -80,18 +62,24 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_user_agent_for_project() {
-    let expected = format!(
-      "Deno/{} (variant; SupabaseEdgeRuntime/{}; ref=abcdefghijklmnopqrst)",
-      version(),
-      edge_runtime_version()
+  fn test_user_agent() {
+    assert_eq!(
+      user_agent(Some("abcdefghijklmnopqrst")),
+      format!(
+        "Deno/{} (variant; SupabaseEdgeRuntime/{}; ref=abcdefghijklmnopqrst)",
+        version(),
+        edge_runtime_version()
+      )
     );
 
     assert_eq!(
-      user_agent_for_project(Some("abcdefghijklmnopqrst")),
-      expected
+      user_agent(None),
+      format!(
+        "Deno/{} (variant; SupabaseEdgeRuntime/{})",
+        version(),
+        edge_runtime_version()
+      )
     );
-    assert_eq!(user_agent_for_project(None), user_agent());
   }
 
   #[test]

--- a/deno/versions.rs
+++ b/deno/versions.rs
@@ -95,17 +95,6 @@ mod tests {
   }
 
   #[test]
-  fn test_user_agent_comment() {
-    assert_eq!(
-      user_agent_comment(Some("abcdefghijklmnopqrst")),
-      format!(
-        "(variant; SupabaseEdgeRuntime/{}; ref=abcdefghijklmnopqrst)",
-        edge_runtime_version()
-      )
-    );
-  }
-
-  #[test]
   fn test_sanitize_project_ref() {
     assert_eq!(
       sanitize_project_ref("abcdefghijklmnopqrst"),

--- a/deno/versions.rs
+++ b/deno/versions.rs
@@ -24,7 +24,6 @@ pub fn user_agent_comment(project_ref: Option<&str>) -> String {
   let ref_part = project_ref
     .map(|it| format!("; ref={it}"))
     .unwrap_or_default();
-
   format!(
     "(variant; SupabaseEdgeRuntime/{}{ref_part})",
     edge_runtime_version()
@@ -42,7 +41,6 @@ pub fn sanitize_project_ref(project_ref: &str) -> Option<&str> {
     && project_ref
       .bytes()
       .all(|it| it.is_ascii_alphanumeric() || it == b'-' || it == b'_');
-
   is_valid.then_some(project_ref)
 }
 

--- a/deno/versions.rs
+++ b/deno/versions.rs
@@ -9,18 +9,59 @@ pub fn edge_runtime_version() -> &'static str {
   option_env!("GIT_V_TAG").unwrap_or("0.1.0")
 }
 
+/// Comment identifying this runtime, and the project the worker belongs to
+/// when it is known.
+///
+/// The value is a single [RFC 9110 comment][1], so it can either close a
+/// `User-Agent` built by us or be appended to one supplied by the function.
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc9110#name-user-agent
+pub fn user_agent_comment(project_ref: Option<&str>) -> String {
+  let edge_runtime_version = edge_runtime_version();
+
+  match project_ref {
+    Some(project_ref) => format!(
+      "(variant; SupabaseEdgeRuntime/{}; ref={})",
+      edge_runtime_version, project_ref
+    ),
+    None => format!("(variant; SupabaseEdgeRuntime/{})", edge_runtime_version),
+  }
+}
+
 pub fn user_agent() -> &'static str {
   static VALUE: Lazy<String> = Lazy::new(|| {
-    let deno_version = version();
-    let edge_runtime_version = edge_runtime_version();
-    format!(
-      // TODO: It should be changed to a well-known name for the ecosystem.
-      "Deno/{} (variant; SupabaseEdgeRuntime/{})",
-      deno_version, edge_runtime_version
-    )
+    // TODO: It should be changed to a well-known name for the ecosystem.
+    format!("Deno/{} {}", version(), user_agent_comment(None))
   });
 
   VALUE.as_str()
+}
+
+/// Same as [`user_agent`], but tagged with the project the worker belongs to.
+pub fn user_agent_for_project(project_ref: Option<&str>) -> Cow<'static, str> {
+  match project_ref {
+    Some(project_ref) => Cow::Owned(format!(
+      "Deno/{} {}",
+      version(),
+      user_agent_comment(Some(project_ref))
+    )),
+    None => Cow::Borrowed(user_agent()),
+  }
+}
+
+/// Accepts a project ref only if it is safe to put in a header comment.
+///
+/// Refs are alphanumeric in practice; anything else is dropped rather than
+/// escaped, since a ref we don't recognize is not worth attributing traffic
+/// to.
+pub fn sanitize_project_ref(project_ref: &str) -> Option<&str> {
+  let is_valid = !project_ref.is_empty()
+    && project_ref.len() <= 64
+    && project_ref
+      .bytes()
+      .all(|it| it.is_ascii_alphanumeric() || it == b'-' || it == b'_');
+
+  is_valid.then_some(project_ref)
 }
 
 pub fn is_canary() -> bool {
@@ -31,5 +72,54 @@ pub fn otel_runtime_config() -> OtelRuntimeConfig {
   OtelRuntimeConfig {
     runtime_name: Cow::Borrowed("deno"),
     runtime_version: Cow::Borrowed(version()),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_user_agent_for_project() {
+    let expected = format!(
+      "Deno/{} (variant; SupabaseEdgeRuntime/{}; ref=abcdefghijklmnopqrst)",
+      version(),
+      edge_runtime_version()
+    );
+
+    assert_eq!(
+      user_agent_for_project(Some("abcdefghijklmnopqrst")),
+      expected
+    );
+    assert_eq!(user_agent_for_project(None), user_agent());
+  }
+
+  #[test]
+  fn test_user_agent_comment() {
+    assert_eq!(
+      user_agent_comment(Some("abcdefghijklmnopqrst")),
+      format!(
+        "(variant; SupabaseEdgeRuntime/{}; ref=abcdefghijklmnopqrst)",
+        edge_runtime_version()
+      )
+    );
+  }
+
+  #[test]
+  fn test_sanitize_project_ref() {
+    assert_eq!(
+      sanitize_project_ref("abcdefghijklmnopqrst"),
+      Some("abcdefghijklmnopqrst")
+    );
+    assert_eq!(
+      sanitize_project_ref("with-dash_and_1"),
+      Some("with-dash_and_1")
+    );
+
+    assert_eq!(sanitize_project_ref(""), None);
+    assert_eq!(sanitize_project_ref("has space"), None);
+    assert_eq!(sanitize_project_ref("closes)comment"), None);
+    assert_eq!(sanitize_project_ref("new\nline"), None);
+    assert_eq!(sanitize_project_ref(&"a".repeat(65)), None);
   }
 }

--- a/ext/node/ops/http.rs
+++ b/ext/node/ops/http.rs
@@ -35,6 +35,7 @@ use deno_fetch::FetchError;
 use deno_fetch::FetchRequestResource;
 use deno_fetch::FetchReturn;
 use deno_fetch::HttpClientResource;
+use deno_fetch::Options as FetchOptions;
 use deno_fetch::ResBody;
 use http::header::HeaderMap;
 use http::header::HeaderName;
@@ -131,6 +132,16 @@ where
   }
   if let Some(len) = con_len {
     request.headers_mut().insert(CONTENT_LENGTH, len.into());
+  }
+
+  // `fetch()` runs this in `op_fetch`; node's client has its own op, so it has
+  // to run the hook itself to keep requests from here stamped the same way.
+  {
+    let options = state.borrow::<FetchOptions>();
+    if let Some(request_builder_hook) = options.request_builder_hook.as_ref() {
+      request_builder_hook(&mut request)
+        .map_err(FetchError::RequestBuilderHook)?;
+    }
   }
 
   let cancel_handle = CancelHandle::new_rc();

--- a/ext/node/ops/http.rs
+++ b/ext/node/ops/http.rs
@@ -139,7 +139,7 @@ where
   {
     let options = state.borrow::<FetchOptions>();
     if let Some(request_builder_hook) = options.request_builder_hook.as_ref() {
-      request_builder_hook(&mut request)
+      request_builder_hook(request.headers_mut())
         .map_err(FetchError::RequestBuilderHook)?;
     }
   }

--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -340,6 +340,22 @@ pub async fn op_http2_client_request(
     );
   }
 
+  // Requests from here never pass through `deno_fetch`'s client, so both its
+  // default `User-Agent` and the stamping hook have to be applied by hand to
+  // keep `node:http2` traffic attributed like every other outbound path.
+  {
+    let state = state.borrow();
+    let options = state.borrow::<deno_fetch::Options>();
+    let headers = req.headers_mut().unwrap();
+
+    if let Some(request_builder_hook) = options.request_builder_hook.as_ref() {
+      request_builder_hook(headers).map_err(Http2Error::Resource)?;
+    }
+    if let Ok(user_agent) = HeaderValue::from_str(&options.user_agent) {
+      headers.entry(http::header::USER_AGENT).or_insert(user_agent);
+    }
+  }
+
   let request = req.body(()).unwrap();
 
   let resource = {

--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -352,7 +352,9 @@ pub async fn op_http2_client_request(
       request_builder_hook(headers).map_err(Http2Error::Resource)?;
     }
     if let Ok(user_agent) = HeaderValue::from_str(&options.user_agent) {
-      headers.entry(http::header::USER_AGENT).or_insert(user_agent);
+      headers
+        .entry(http::header::USER_AGENT)
+        .or_insert(user_agent);
     }
   }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -55,6 +55,12 @@ interface PermissionsOptions {
 interface UserWorkerCreateContext {
   sourceMap?: boolean | null;
   importMapPath?: string | null;
+  /**
+   * Ref of the project the worker belongs to. Stamped into the `User-Agent` of
+   * every request the worker makes, so outbound traffic can be attributed back
+   * to the project.
+   */
+  projectRef?: string | null;
   shouldBootstrapMockFnThrowError?: boolean | null;
   suppressEszipMigrationWarning?: boolean | null;
   useReadSyncFileAPI?: boolean | null;

--- a/vendor/deno_fetch/lib.rs
+++ b/vendor/deno_fetch/lib.rs
@@ -116,9 +116,11 @@ pub struct Options {
   /// is sent.
   ///
   /// Unlike upstream, it is a closure rather than a plain `fn`, so a hook can
-  /// carry state of its own (the worker it belongs to, say), and it takes the
-  /// header map rather than the whole request, so paths that build requests
-  /// with other body types (`node:http2`, say) can run it too.
+  /// carry state of its own (the worker it belongs to, say). It also takes the
+  /// header map rather than the whole request: callers build requests with
+  /// different body types (`ReqBody` here, `()` in `node:http2`) and a
+  /// `dyn Fn` cannot be generic over them, while the headers are the surface
+  /// every path shares.
   #[allow(clippy::type_complexity)]
   pub request_builder_hook: Option<
     Arc<

--- a/vendor/deno_fetch/lib.rs
+++ b/vendor/deno_fetch/lib.rs
@@ -112,16 +112,17 @@ pub struct Options {
   ///
   /// For more info on what can be configured, see [`hyper_util::client::legacy::Builder`].
   pub client_builder_hook: Option<fn(HyperClientBuilder) -> HyperClientBuilder>,
-  /// A callback to customize every outbound request before it is sent.
+  /// A callback to customize the headers of every outbound request before it
+  /// is sent.
   ///
-  /// Unlike upstream, this is a closure rather than a plain `fn`, so a hook can
-  /// carry state of its own (the worker it belongs to, say).
+  /// Unlike upstream, it is a closure rather than a plain `fn`, so a hook can
+  /// carry state of its own (the worker it belongs to, say), and it takes the
+  /// header map rather than the whole request, so paths that build requests
+  /// with other body types (`node:http2`, say) can run it too.
   #[allow(clippy::type_complexity)]
   pub request_builder_hook: Option<
     Arc<
-      dyn Fn(
-          &mut http::Request<ReqBody>,
-        ) -> Result<(), deno_core::error::AnyError>
+      dyn Fn(&mut http::HeaderMap) -> Result<(), deno_core::error::AnyError>
         + Send
         + Sync,
     >,
@@ -566,7 +567,7 @@ where
       let options = state.borrow::<Options>();
       if let Some(request_builder_hook) = options.request_builder_hook.as_ref()
       {
-        request_builder_hook(&mut request)
+        request_builder_hook(request.headers_mut())
           .map_err(FetchError::RequestBuilderHook)?;
       }
 

--- a/vendor/deno_fetch/lib.rs
+++ b/vendor/deno_fetch/lib.rs
@@ -112,9 +112,19 @@ pub struct Options {
   ///
   /// For more info on what can be configured, see [`hyper_util::client::legacy::Builder`].
   pub client_builder_hook: Option<fn(HyperClientBuilder) -> HyperClientBuilder>,
+  /// A callback to customize every outbound request before it is sent.
+  ///
+  /// Unlike upstream, this is a closure rather than a plain `fn`, so a hook can
+  /// carry state of its own (the worker it belongs to, say).
   #[allow(clippy::type_complexity)]
   pub request_builder_hook: Option<
-    fn(&mut http::Request<ReqBody>) -> Result<(), deno_core::error::AnyError>,
+    Arc<
+      dyn Fn(
+          &mut http::Request<ReqBody>,
+        ) -> Result<(), deno_core::error::AnyError>
+        + Send
+        + Sync,
+    >,
   >,
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub client_cert_chain_and_key: TlsKeys,
@@ -554,7 +564,8 @@ where
       }
 
       let options = state.borrow::<Options>();
-      if let Some(request_builder_hook) = options.request_builder_hook {
+      if let Some(request_builder_hook) = options.request_builder_hook.as_ref()
+      {
         request_builder_hook(&mut request)
           .map_err(FetchError::RequestBuilderHook)?;
       }


### PR DESCRIPTION
## What

Outbound requests made by a user worker carry the ref of the project it belongs to, in the `User-Agent`:

```
Deno/2.1.4 (variant; SupabaseEdgeRuntime/1.74.0; ref=abcdefghijklmnopqrst)
```

The ref comes from a new `projectRef` value on the worker create context:

```ts
EdgeRuntime.userWorkers.create({ servicePath, context: { projectRef: "abcdefghijklmnopqrst" } })
```

Workers created without it behave exactly as before.

## Why

There is no way to tell which project a request leaving a function came from, so reported abusive traffic cannot be attributed.

## How

- Requests that send no `User-Agent` get the runtime's, ref included.
- Requests that set their own keep it, with the `(variant; …; ref=…)` comment (valid per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-user-agent)) appended — a function cannot shed the ref. A header that already carries the comment is left alone, so redirect hops don't accumulate copies.
- Refs that don't fit safely in a header comment (anything outside `[A-Za-z0-9_-]{1,64}`) are dropped with a warning rather than escaped.

Covered paths: `fetch` (including `Deno.createHttpClient` and redirects), `node:http(s)`, `node:http2`, and websocket handshakes. Raw `Deno.connect` sockets have no HTTP layer and are not covered.

Note for consumers: a function can pre-fake a `ref=` comment in its own `User-Agent`. The real comment is appended after it, so always parse the last one.

### The one vendored change

`deno_fetch::Options::request_builder_hook` becomes `Option<Arc<dyn Fn(&mut HeaderMap) -> …>>`. A closure, because the ref differs per worker and a plain `fn` has no way to receive it (the hook gets no `OpState`). A header map, because `node:http2` builds `Request<()>` while fetch builds `Request<ReqBody>`, and a `dyn Fn` cannot be generic over the body type. The stamping logic itself lives in `crates/base/src/runtime/user_agent.rs`, so a vendor upgrade only re-applies the type.

## Tests

Unit tests for the append rules and ref validation, plus integration tests against a server that echoes back the `User-Agent` it received, covering `fetch`, `node:http`, `node:http2`, and the websocket handshake.

```
cargo test -p base --lib user_agent
cargo test -p deno versions::
cargo test -p base --test integration_tests user_agent
```
