### PR TITLE
fix(fetch): preserve explicit trace context during propagation

### DIFF
--- a/crates/base/test_cases/trace-context-callee/index.ts
+++ b/crates/base/test_cases/trace-context-callee/index.ts
@@ -1,0 +1,8 @@
+Deno.serve((req: Request) =>
+  Response.json({
+    traceparent: req.headers.get("traceparent"),
+    tracestate: req.headers.get("tracestate"),
+    baggage: req.headers.get("baggage"),
+    custom: req.headers.get("x-app-traceparent"),
+  })
+);

--- a/crates/base/test_cases/trace-context-caller/index.ts
+++ b/crates/base/test_cases/trace-context-caller/index.ts
@@ -1,0 +1,23 @@
+const traceparent = "00-b1e669305668dc82c96cc31ce2e6cd99-1a5b74eca03f769f-01";
+
+Deno.serve(async (req: Request) => {
+  const origin = new URL(req.url).origin;
+
+  const headers = {
+    traceparent: traceparent,
+    tracestate: "foo=bar",
+    "x-app-traceparent": traceparent,
+  };
+
+  const response = await fetch(`${origin}/callee`, {
+    headers,
+    body: JSON.stringify({ hello: "world" }),
+    method: "POST",
+  });
+
+  const data = await response.json();
+  return Response.json({
+    sent: traceparent,
+    received: data,
+  });
+});

--- a/crates/base/test_cases/trace-context-main/index.ts
+++ b/crates/base/test_cases/trace-context-main/index.ts
@@ -1,0 +1,19 @@
+Deno.serve(async (req: Request) => {
+  const name = new URL(req.url).pathname.split("/").pop();
+  if (name !== "caller" && name !== "callee") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const worker = await EdgeRuntime.userWorkers.create({
+    servicePath: `./test_cases/trace-context-${name}`,
+    memoryLimitMb: 150,
+    workerTimeoutMs: 60_000,
+    cpuTimeSoftLimitMs: 60_000,
+    cpuTimeHardLimitMs: 60_000,
+    otelConfig: {
+      tracing_enabled: true,
+      propagators: ["TraceContext", "Baggage"],
+    },
+  });
+  return await worker.fetch(req);
+});

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4961,6 +4961,7 @@ async fn test_fetch_preserves_explicit_trace_context() {
                 !traceparent_str.contains(','),
                 "Traceparent contains illegal comma: {traceparent_str}"
             );
+            assert_eq!(received["tracestate"], "foo=bar");
         }),
         TerminationToken::new()
     );

--- a/crates/base/tests/integration_tests.rs
+++ b/crates/base/tests/integration_tests.rs
@@ -4917,3 +4917,51 @@ async fn test_websocket_handshake_user_agent_is_stamped_with_project_ref() {
     [deno::versions::user_agent(Some(PROJECT_REF))]
   );
 }
+
+#[tokio::test]
+#[serial]
+async fn test_fetch_preserves_explicit_trace_context() {
+    init_otel();
+
+    integration_test_with_server_flag!(
+        ServerFlags::default(),
+        "./test_cases/trace-context-main",
+        NON_SECURE_PORT,
+        "caller",
+        None,
+        Some(
+            reqwest::Client::new()
+                .get(format!("http://localhost:{NON_SECURE_PORT}/caller"))
+                .header(
+                    "traceparent",
+                    "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+                )
+        ),
+        None::<Tls>,
+        (|resp| async {
+            let resp = resp.unwrap();
+            let status = resp.status();
+            let body = resp.text().await.unwrap();
+            assert_eq!(status.as_u16(), 200, "{body}");
+
+            let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+            let received = &data["received"];
+
+            // 1. Must equal caller's exact explicit traceparent
+            assert_eq!(
+                received["traceparent"],
+                "00-b1e669305668dc82c96cc31ce2e6cd99-1a5b74eca03f769f-01",
+                "Traceparent was rewritten or appended with comma: {}",
+                received["traceparent"]
+            );
+
+            // 2. Must not contain comma-separated values
+            let traceparent_str = received["traceparent"].as_str().unwrap();
+            assert!(
+                !traceparent_str.contains(','),
+                "Traceparent contains illegal comma: {traceparent_str}"
+            );
+        }),
+        TerminationToken::new()
+    );
+}

--- a/vendor/deno_fetch/26_fetch.js
+++ b/vendor/deno_fetch/26_fetch.js
@@ -378,7 +378,10 @@ function fetch(input, init = { __proto__: null }) {
         for (const propagator of new SafeArrayIterator(PROPAGATORS)) {
           propagator.inject(context, requestObject.headers, {
             set(carrier, key, value) {
-              carrier.append(key, value);
+              
+              if(!carrier.has(key)) {
+                carrier.set(key, value);
+              }
             },
           });
         }

--- a/vendor/deno_fetch/26_fetch.js
+++ b/vendor/deno_fetch/26_fetch.js
@@ -376,12 +376,15 @@ function fetch(input, init = { __proto__: null }) {
       if (span) {
         const context = ContextManager.active();
         for (const propagator of new SafeArrayIterator(PROPAGATORS)) {
+          if (
+            requestObject.headers.has("traceparent") &&
+            ArrayPrototypeIncludes(propagator.fields(), "traceparent")
+          ) {
+            continue;
+          }
           propagator.inject(context, requestObject.headers, {
             set(carrier, key, value) {
-              
-              if(!carrier.has(key)) {
-                carrier.set(key, value);
-              }
+              carrier.append(key, value);
             },
           });
         }


### PR DESCRIPTION
## Tl;dr
Fixes https://github.com/supabase/edge-runtime/issues/739

Preserves caller-supplied `traceparent` and `tracestate` headers during function-to-function invocations.

## What changed
- In `vendor/deno_fetch/26_fetch.js`, skip injecting the trace context propagator if the request already contains an explicit `traceparent` header.
- Keeps `traceparent` and `tracestate` paired together from the caller, preventing the runtime from appending a second trace context or attaching mismatched runtime `tracestate`.
- Automatic trace propagation continues to work when no explicit header is provided.

## Validation
- `cargo test -p base --test integration_tests test_fetch_preserves_explicit_trace_context` (passed)
- Added 3 regression tests checking exact traceparent matching, comma prevention, and tracestate pairing.